### PR TITLE
SKALE-1534 Fixed Executive creation with depth=0 bug

### DIFF
--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -126,7 +126,7 @@ evmc_status_code transactionExceptionToEvmcStatusCode( TransactionException ex )
 
 
 CallResult ExtVM::call( CallParameters& _p ) {
-    Executive e{m_s, envInfo(), m_sealEngine, depth + 1};
+    Executive e{m_s, envInfo(), m_sealEngine, 0, depth + 1};
     if ( !e.call( _p, gasPrice, origin ) ) {
         go( depth, e, _p.onOp );
         e.accrueSubState( sub );
@@ -150,7 +150,7 @@ void ExtVM::setStore( u256 _n, u256 _v ) {
 
 CreateResult ExtVM::create( u256 _endowment, u256& io_gas, bytesConstRef _code, Instruction _op,
     u256 _salt, OnOpFunc const& _onOp ) {
-    Executive e{m_s, envInfo(), m_sealEngine, depth + 1};
+    Executive e{m_s, envInfo(), m_sealEngine, 0, depth + 1};
     bool result = false;
     if ( _op == Instruction::CREATE )
         result = e.createOpcode( myAddress, _endowment, gasPrice, io_gas, _code, origin );


### PR DESCRIPTION
Problem was here:
```
Executive e{m_s, envInfo(), m_sealEngine, depth + 1};
```
with ctor:
```
Executive( skale::State& _s, EnvInfo const& _envInfo, SealEngineFace const& _sealEngine,
        const u256& _gasPrice, unsigned _level = 0 )
```