### PR TITLE
Feature/skale 1516 improvements for snapshots

### DIFF
--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -575,7 +575,7 @@ void Client::onChainChanged( ImportRoute const& _ir ) {
     if ( chainParams().nodeInfo.snapshotInterval > 0 &&
          number() % chainParams().nodeInfo.snapshotInterval == 0 ) {
         m_snapshotManager->doSnapshot( number() );
-        // TODO Make this numbe configurable
+        // TODO Make this number configurable
         m_snapshotManager->leaveNLastSnapshots( 2 );
     }  // if snapshot
 }

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -575,6 +575,8 @@ void Client::onChainChanged( ImportRoute const& _ir ) {
     if ( chainParams().nodeInfo.snapshotInterval > 0 &&
          number() % chainParams().nodeInfo.snapshotInterval == 0 ) {
         m_snapshotManager->doSnapshot( number() );
+        // TODO Make this numbe configurable
+        m_snapshotManager->leaveNLastSnapshots( 2 );
     }  // if snapshot
 }
 

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -262,7 +262,7 @@ public:
         uint64_t _timestamp = ( uint64_t ) utcTime() );
 
     boost::filesystem::path createSnapshotFile( unsigned _blockNumber ) {
-        return m_snapshotManager->makeDiff( 0, _blockNumber );
+        return m_snapshotManager->makeOrGetDiff( 0, _blockNumber );
     }
 
 protected:

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -262,7 +262,10 @@ public:
         uint64_t _timestamp = ( uint64_t ) utcTime() );
 
     boost::filesystem::path createSnapshotFile( unsigned _blockNumber ) {
-        return m_snapshotManager->makeOrGetDiff( 0, _blockNumber );
+        boost::filesystem::path path = m_snapshotManager->makeOrGetDiff( 0, _blockNumber );
+        // TODO Make constant 2 configurable
+        m_snapshotManager->leaveNLastDiffs( 2 );
+        return path;
     }
 
 protected:

--- a/libskale/SnapshotManager.h
+++ b/libskale/SnapshotManager.h
@@ -113,13 +113,18 @@ public:
         const boost::filesystem::path& _dataDir, const std::vector< std::string >& _volumes );
     void doSnapshot( unsigned _blockNumber );
     void restoreSnapshot( unsigned _blockNumber );
-    boost::filesystem::path makeDiff( unsigned _fromBlock, unsigned _toBlock );
-    void importDiff( unsigned _blockNumber, const boost::filesystem::path& _diffPath );
+    boost::filesystem::path makeOrGetDiff( unsigned _fromBlock, unsigned _toBlock );
+    void importDiff( unsigned _fromBlock, unsigned _toBlock );
+    boost::filesystem::path getDiffPath( unsigned _fromBlock, unsigned _toBlock );
+
+    void leaveNLastSnapshots( unsigned n );
+    void leaveNLastDiffs( unsigned n );
 
 private:
     boost::filesystem::path data_dir;
     std::vector< std::string > volumes;
     boost::filesystem::path snapshots_dir;
+    boost::filesystem::path diffs_dir;
 };
 
 #endif  // SNAPSHOTAGENT_H

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -737,26 +737,10 @@ int main( int argc, char** argv ) try {
 
     if ( vm.count( "download-snapshot" ) ) {
         try {
-            fs::path saveTo;
-
-            if ( vm.count( "download-target" ) )
-                saveTo = fs::path( vm["download-target"].as< string >() );
-            else {
-                string filename_string = "/tmp/skaled_snapshot_download_XXXXXX";
-                char buf[filename_string.length() + 1];
-                strcpy( buf, filename_string.c_str() );
-                int fd = mkstemp( buf );
-                if ( fd < 0 ) {
-                    throw std::runtime_error( "Failed to open " + filename_string );
-                }
-                close( fd );
-                saveTo = buf;
-            }
-
             std::string strURLWeb3 = vm["download-snapshot"].as< string >();
 
             std::cout << cc::normal( "Will download snapshot from " ) << cc::u( strURLWeb3 )
-                      << cc::normal( " to " ) << cc::info( saveTo.native() ) << std::endl;
+                      << std::endl;
             bool isBinaryDownload = true;
 
             unsigned block_number;
@@ -783,6 +767,8 @@ int main( int argc, char** argv ) try {
                 block_number -= block_number % chainParams.nodeInfo.snapshotInterval;
             }
 
+            fs::path saveTo = snapshotManager->getDiffPath( 0, block_number );
+
             bool bOK = dev::rpc::snapshot::download( strURLWeb3, block_number, saveTo,
                 [&]( size_t idxChunck, size_t cntChunks ) -> bool {
                     std::cout << cc::normal( "... download progress ... " )
@@ -800,7 +786,7 @@ int main( int argc, char** argv ) try {
             std::cout << cc::success( "Snapshot download success for block " )
                       << cc::u( to_string( block_number ) ) << std::endl;
 
-            snapshotManager->importDiff( block_number, saveTo );
+            snapshotManager->importDiff( 0, block_number );
             fs::remove( saveTo );
 
             // HACK refactor this piece of code!

--- a/test/unittests/libskale/SnapshotManager.cpp
+++ b/test/unittests/libskale/SnapshotManager.cpp
@@ -186,13 +186,13 @@ BOOST_FIXTURE_TEST_CASE( SimplePositiveTest, BtrfsFixture ) {
     BOOST_REQUIRE( fs::exists( fs::path( BTRFS_DIR_PATH ) / "vol2" / "d21" ) );
     BOOST_REQUIRE( !fs::exists( fs::path( BTRFS_DIR_PATH ) / "vol1" / "d12" ) );
 
-    fs::path diff12 = mgr.makeDiff( 1, 2 );
+    fs::path diff12 = mgr.makeOrGetDiff( 1, 2 );
     btrfs.subvolume._delete( ( BTRFS_DIR_PATH + "/snapshots/2/vol1" ).c_str() );
     btrfs.subvolume._delete( ( BTRFS_DIR_PATH + "/snapshots/2/vol2" ).c_str() );
     fs::remove_all( BTRFS_DIR_PATH + "/snapshots/2" );
     BOOST_REQUIRE( !fs::exists( fs::path( BTRFS_DIR_PATH ) / "snapshots" / "2" ) );
 
-    mgr.importDiff( 2, diff12 );
+    mgr.importDiff( 1, 2 );
     BOOST_REQUIRE( fs::exists( fs::path( BTRFS_DIR_PATH ) / "snapshots" / "2" / "vol1" / "d11" ) );
     BOOST_REQUIRE( fs::exists( fs::path( BTRFS_DIR_PATH ) / "snapshots" / "2" / "vol1" / "d12" ) );
     BOOST_REQUIRE( !fs::exists( fs::path( BTRFS_DIR_PATH ) / "snapshots" / "2" / "vol2" / "d21" ) );
@@ -304,28 +304,29 @@ BOOST_FIXTURE_TEST_CASE( DiffTest, BtrfsFixture ) {
     fs::create_directory( fs::path( BTRFS_DIR_PATH ) / "vol1" / "dir" );
     mgr.doSnapshot( 4 );
 
-    BOOST_REQUIRE_THROW( mgr.makeDiff( 1, 3 ), SnapshotManager::SnapshotAbsent );
-    BOOST_REQUIRE_THROW( mgr.makeDiff( 2, 3 ), SnapshotManager::SnapshotAbsent );
-    BOOST_REQUIRE_THROW( mgr.makeDiff( 1, 2 ), SnapshotManager::SnapshotAbsent );
+    BOOST_REQUIRE_THROW( mgr.makeOrGetDiff( 1, 3 ), SnapshotManager::SnapshotAbsent );
+    BOOST_REQUIRE_THROW( mgr.makeOrGetDiff( 2, 3 ), SnapshotManager::SnapshotAbsent );
+    BOOST_REQUIRE_THROW( mgr.makeOrGetDiff( 1, 2 ), SnapshotManager::SnapshotAbsent );
 
     fs::path tmp;
-    BOOST_REQUIRE_NO_THROW( tmp = mgr.makeDiff( 2, 4 ) );
+    BOOST_REQUIRE_NO_THROW( tmp = mgr.makeOrGetDiff( 2, 4 ) );
     fs::remove( tmp );
 
-    BOOST_REQUIRE_NO_THROW( tmp = mgr.makeDiff( 2, 2 ) );
+    BOOST_REQUIRE_NO_THROW( tmp = mgr.makeOrGetDiff( 2, 2 ) );
     fs::remove( tmp );
 
-    BOOST_REQUIRE_NO_THROW( tmp = mgr.makeDiff( 4, 2 ) );
+    BOOST_REQUIRE_NO_THROW( tmp = mgr.makeOrGetDiff( 4, 2 ) );
     fs::remove( tmp );
 
     // strange - but ok...
-    BOOST_REQUIRE_NO_THROW( tmp = mgr.makeDiff( 2, 4 ) );
+    BOOST_REQUIRE_NO_THROW( tmp = mgr.makeOrGetDiff( 2, 4 ) );
     BOOST_REQUIRE_GT( fs::file_size( tmp ), 0 );
     fs::remove( tmp );
 
     btrfs.subvolume._delete( ( fs::path( BTRFS_DIR_PATH ) / "snapshots" / "4" / "vol1" ).c_str() );
 
-    BOOST_REQUIRE_THROW( tmp = mgr.makeDiff( 2, 4 ), SnapshotManager::CannotPerformBtrfsOperation );
+    BOOST_REQUIRE_THROW(
+        tmp = mgr.makeOrGetDiff( 2, 4 ), SnapshotManager::CannotPerformBtrfsOperation );
 }
 
 // TODO Tests to check no files left in /tmp?!
@@ -333,23 +334,22 @@ BOOST_FIXTURE_TEST_CASE( DiffTest, BtrfsFixture ) {
 BOOST_FIXTURE_TEST_CASE( ImportTest, BtrfsFixture ) {
     SnapshotManager mgr( fs::path( BTRFS_DIR_PATH ), {"vol1", "vol2"} );
 
-    BOOST_REQUIRE_THROW( mgr.importDiff( 1, fs::path( BTRFS_DIR_PATH ) / "_nonexistent" ),
-        SnapshotManager::InvalidPath );
+    BOOST_REQUIRE_THROW( mgr.importDiff( 8, 8 ), SnapshotManager::InvalidPath );
 
     BOOST_REQUIRE_NO_THROW( mgr.doSnapshot( 2 ) );
     BOOST_REQUIRE_NO_THROW( mgr.doSnapshot( 4 ) );
 
     fs::path diff24;
-    BOOST_REQUIRE_NO_THROW( diff24 = mgr.makeDiff( 2, 4 ) );
+    BOOST_REQUIRE_NO_THROW( diff24 = mgr.makeOrGetDiff( 2, 4 ) );
 
-    BOOST_REQUIRE_THROW( mgr.importDiff( 4, diff24 ), SnapshotManager::SnapshotPresent );
+    BOOST_REQUIRE_THROW( mgr.importDiff( 2, 4 ), SnapshotManager::SnapshotPresent );
 
     // delete dest
     btrfs.subvolume._delete( ( fs::path( BTRFS_DIR_PATH ) / "snapshots" / "4" / "vol1" ).c_str() );
     btrfs.subvolume._delete( ( fs::path( BTRFS_DIR_PATH ) / "snapshots" / "4" / "vol2" ).c_str() );
     fs::remove_all( fs::path( BTRFS_DIR_PATH ) / "snapshots" / "4" );
 
-    BOOST_REQUIRE_NO_THROW( mgr.importDiff( 4, diff24 ) );
+    BOOST_REQUIRE_NO_THROW( mgr.importDiff( 2, 4 ) );
 
     // delete dest
     btrfs.subvolume._delete( ( fs::path( BTRFS_DIR_PATH ) / "snapshots" / "4" / "vol1" ).c_str() );
@@ -359,13 +359,11 @@ BOOST_FIXTURE_TEST_CASE( ImportTest, BtrfsFixture ) {
     // no source
     btrfs.subvolume._delete( ( fs::path( BTRFS_DIR_PATH ) / "snapshots" / "2" / "vol1" ).c_str() );
 
-    BOOST_REQUIRE_THROW(
-        mgr.importDiff( 4, diff24 ), SnapshotManager::CannotPerformBtrfsOperation );
+    BOOST_REQUIRE_THROW( mgr.importDiff( 2, 4 ), SnapshotManager::CannotPerformBtrfsOperation );
 
     btrfs.subvolume._delete( ( fs::path( BTRFS_DIR_PATH ) / "snapshots" / "2" / "vol2" ).c_str() );
     fs::remove_all( fs::path( BTRFS_DIR_PATH ) / "snapshots" / "2" );
-    BOOST_REQUIRE_THROW(
-        mgr.importDiff( 4, diff24 ), SnapshotManager::CannotPerformBtrfsOperation );
+    BOOST_REQUIRE_THROW( mgr.importDiff( 2, 4 ), SnapshotManager::CannotPerformBtrfsOperation );
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
1. Client automatically maintains only 2 last snapshots (i.e. BTRFS volumes)
2. SnapshotManager now has `leaveNLastDiffs(unsigned n)` to delete extra diffs.
3. SnapshotManager now has `getDiffPath( unsigned _fromBlock, unsigned _toBlock )` that returns path where you can store diff (i.e. write there by yourself).

Example:
```
SnashotManager mgr;   // generally created in main()
fs::path p = mgr.getDiffPath(0, 10);
ofstream os(p.c_str());
os.write(...);
os.close();
mgr.importDiff(0, 10);   // import same diff as snapshot
```

See https://github.com/skalenetwork/skaled/blob/feature/SKALE-1516-improvements-for-snapshots/skaled/main.cpp#L770