### PR TITLE
SKALE-1613 IMA messages verification

### DIFF
--- a/libdevcore/BMPBN.h
+++ b/libdevcore/BMPBN.h
@@ -29,6 +29,8 @@
 #pragma once
 
 #include <stdint.h>
+#include <iostream>
+#include <sstream>
 #include <string>
 
 #include "Common.h"
@@ -84,6 +86,18 @@ inline T decode( const uint8_t* input, size_t length ) {
     if ( a >= 0x80 )
         result |= T( -1 ) << ( bits + 8 );
     return result;
+}
+
+template < class T >
+inline std::string toHexStringWithPadding(
+    const T& value, size_t nPadding = std::string::npos, bool bWith0x = true ) {
+    std::stringstream ss;
+    if ( bWith0x )
+        ss << "0x";
+    if ( nPadding != std::string::npos )
+        ss << std::setfill( '0' ) << std::setw( nPadding );
+    ss << std::hex << value;
+    return ss.str();
 }
 
 };  // namespace BMPBN

--- a/libdevcore/BMPBN.h
+++ b/libdevcore/BMPBN.h
@@ -33,6 +33,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "Common.h"
 
@@ -59,10 +60,10 @@ inline size_t lengthOf( T value ) {  // we need non-cost copied value here
 
 template < class T >
 inline void encode( T value, uint8_t* output, size_t length ) {  // we need non-cost copied value
+                                                                 // here
     if ( output == nullptr || length == 0 )
         return;
     memset( output, 0, length );
-    // here
     if ( value.is_zero() )
         ( *output ) = 0;
     else if ( value.sign() > 0 )
@@ -77,6 +78,35 @@ inline void encode( T value, uint8_t* output, size_t length ) {  // we need non-
             value >>= 8;
         }
     }
+}
+
+template < class T >
+inline std::vector< uint8_t > encode2vec(
+    T value, bool bIsInversive = false ) {  // we need non-cost copied value here
+    std::vector< uint8_t > vec;
+    if ( value.is_zero() )
+        vec.push_back( 0 );
+    else if ( value.sign() > 0 )
+        while ( !value.is_zero() ) {
+            uint8_t b = value.template convert_to< uint8_t >();
+            if ( bIsInversive )
+                vec.insert( vec.begin(), b );
+            else
+                vec.push_back( b );
+            value >>= 8;
+        }
+    else {
+        value = ~value;
+        while ( value.is_zero() ) {
+            uint8_t b = ~value.template convert_to< uint8_t >();
+            if ( bIsInversive )
+                vec.insert( vec.begin(), b );
+            else
+                vec.push_back( b );
+            value >>= 8;
+        }
+    }
+    return vec;
 }
 
 template < class T >

--- a/libdevcore/BMPBN.h
+++ b/libdevcore/BMPBN.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <string.h>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -58,6 +59,9 @@ inline size_t lengthOf( T value ) {  // we need non-cost copied value here
 
 template < class T >
 inline void encode( T value, uint8_t* output, size_t length ) {  // we need non-cost copied value
+    if ( output == nullptr || length == 0 )
+        return;
+    memset( output, 0, length );
     // here
     if ( value.is_zero() )
         ( *output ) = 0;
@@ -78,6 +82,8 @@ inline void encode( T value, uint8_t* output, size_t length ) {  // we need non-
 template < class T >
 inline T decode( const uint8_t* input, size_t length ) {
     T result( 0 );
+    if ( input == nullptr || length == 0 )
+        return result;
     int bits = -8;
     while ( length-- > 1 )
         result |= T( *( input++ ) ) << ( bits += 8 );

--- a/libdevcore/BMPBN.h
+++ b/libdevcore/BMPBN.h
@@ -1,0 +1,90 @@
+/*
+    Copyright (C) 2018-2019 SKALE Labs
+
+    This file is part of skaled.
+
+    ska;ed is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skaled is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file BMPBM.h
+ * @author Sergiy Lavrynenko <sergiy@skalelabs.com>
+ * @date 2014
+ *
+ * BMPBN - Boost Multi Precision Big Number tool and conversion helper APIs
+ * Type T everywhere should be kind of u256, boost::multiprecision::number,
+ * boost::multiprecision::cpp_int or similar; the APIs in this namesapce are based on:
+ * https://groups.google.com/forum/#!topic/boost-list/lsboSQ5lHgY
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <string>
+
+#include "Common.h"
+
+namespace dev {
+namespace BMPBN {
+
+template < class T >
+inline size_t lengthOf( T value ) {  // we need non-cost copied value here
+    if ( value.is_zero() )
+        return 1;
+    if ( value.sign() < 0 )
+        value = ~value;
+    size_t length = 0;
+    uint8_t lastByte = 0;
+    do {
+        lastByte = value.template convert_to< uint8_t >();
+        value >>= 8;
+        ++length;
+    } while ( !value.is_zero() );
+    if ( lastByte >= 0x80 )
+        ++length;
+    return length;
+}
+
+template < class T >
+inline void encode( T value, uint8_t* output, size_t length ) {  // we need non-cost copied value
+    // here
+    if ( value.is_zero() )
+        ( *output ) = 0;
+    else if ( value.sign() > 0 )
+        while ( length-- > 0 ) {
+            *( output++ ) = value.template convert_to< uint8_t >();
+            value >>= 8;
+        }
+    else {
+        value = ~value;
+        while ( length-- > 0 ) {
+            *( output++ ) = ~value.template convert_to< uint8_t >();
+            value >>= 8;
+        }
+    }
+}
+
+template < class T >
+inline T decode( const uint8_t* input, size_t length ) {
+    T result( 0 );
+    int bits = -8;
+    while ( length-- > 1 )
+        result |= T( *( input++ ) ) << ( bits += 8 );
+    uint8_t a = *( input++ );
+    result |= T( a ) << ( bits += 8 );
+    if ( a >= 0x80 )
+        result |= T( -1 ) << ( bits + 8 );
+    return result;
+}
+
+};  // namespace BMPBN
+};  // namespace dev

--- a/libdevcore/BMPBN_tests.h
+++ b/libdevcore/BMPBN_tests.h
@@ -1,0 +1,201 @@
+/*
+    Copyright (C) 2018-2019 SKALE Labs
+
+    This file is part of skaled.
+
+    ska;ed is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skaled is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file BMPBM.h
+ * @author Sergiy Lavrynenko <sergiy@skalelabs.com>
+ * @date 2014
+ *
+ * BMPBN - Boost Multi Precision Big Number tool and conversion helper APIs
+ * Type T everywhere should be kind of u256, boost::multiprecision::number,
+ * boost::multiprecision::cpp_int or similar; the APIs in this namesapce are based on:
+ * https://groups.google.com/forum/#!topic/boost-list/lsboSQ5lHgY
+ */
+
+#pragma once
+
+#include "BMPBN.h"
+
+#include <skutils/console_colors.h>
+
+#include <sstream>
+
+namespace dev {
+namespace BMPBN {
+
+template < class T >
+inline bool test1( const std::string& s, bool bIsVerbose ) {
+    std::stringstream ss;
+    T x( s );
+    uint8_t buffer[256];
+    size_t length = lengthOf( x );  // lengthOf< T >( x )
+    size_t index = 0;
+    encode< T >( x, buffer, length );
+    T y = decode< T >( buffer, length );
+    if ( bIsVerbose )
+        ss << std::hex << std::setw( 2 ) << std::setfill( '0' ) << int( buffer[0] );
+    if ( bIsVerbose ) {
+        while ( --length > 0 )
+            ss << cc::debug( ":" ) << std::setw( 2 ) << std::setfill( '0' )
+               << int( buffer[++index] );
+    }
+    if ( bIsVerbose )
+        ss << cc::debug( " = " ) << std::dec << std::setw( 1 ) << x << cc::debug( ", " );
+    if ( x != y ) {
+        if ( bIsVerbose )
+            std::cout << "    " << ss.str() << cc::fatal( "FAILED" ) << "\n";
+        return false;
+    }
+    // if ( bIsVerbose )
+    //    std::cout << "    " << cc::success( "OK for " ) << cc::info( s ) << "\n";
+    return true;
+}  // namespace rpc
+
+template < class T >
+inline bool test(
+    bool bIncludeNegative, bool bIncludeHuge, bool bIsVerbose, const char* strTypeDescription ) {
+    if ( bIsVerbose && strTypeDescription && strTypeDescription[0] )
+        std::cout << cc::debug( "Testing conversion of " ) << cc::info( strTypeDescription )
+                  << cc::debug( "..." ) << "\n";
+    bool bOKay = true;
+    //
+    if ( !test1< T >( std::string( "0" ), bIsVerbose ) )
+        bOKay = false;
+    if ( !test1< T >( std::string( "1" ), bIsVerbose ) )
+        bOKay = false;
+    if ( !test1< T >( std::string( "-1" ), bIsVerbose ) )
+        bOKay = false;
+    //
+    if ( !test1< T >( std::string( "32767" ), bIsVerbose ) )
+        bOKay = false;
+    if ( bIncludeNegative )
+        if ( !test1< T >( std::string( "-32767" ), bIsVerbose ) )
+            bOKay = false;
+    //
+    if ( !test1< T >( std::string( "32768" ), bIsVerbose ) )
+        bOKay = false;
+    if ( bIncludeNegative )
+        if ( !test1< T >( std::string( "-32768" ), bIsVerbose ) )
+            bOKay = false;
+    if ( !test1< T >( std::string( "32769" ), bIsVerbose ) )
+        bOKay = false;
+    if ( bIncludeNegative )
+        if ( !test1< T >( std::string( "-32769" ), bIsVerbose ) )
+            bOKay = false;
+    //
+    if ( !test1< T >( std::string( "65535" ), bIsVerbose ) )
+        bOKay = false;
+    if ( bIncludeNegative )
+        if ( !test1< T >( std::string( "-65535" ), bIsVerbose ) )
+            bOKay = false;
+    if ( !test1< T >( std::string( "65536" ), bIsVerbose ) )
+        bOKay = false;
+    if ( bIncludeNegative )
+        if ( !test1< T >( std::string( "-65536" ), bIsVerbose ) )
+            bOKay = false;
+    //
+    if ( !test1< T >( std::string( "2147483647" ), bIsVerbose ) )
+        bOKay = false;
+    if ( bIncludeNegative )
+        if ( !test1< T >( std::string( "-2147483647" ), bIsVerbose ) )
+            bOKay = false;
+    //
+    if ( !test1< T >( std::string( "2147483648" ), bIsVerbose ) )
+        bOKay = false;
+    if ( bIncludeNegative )
+        if ( !test1< T >( std::string( "-2147483648" ), bIsVerbose ) )
+            bOKay = false;
+    //
+    if ( !test1< T >( std::string( "9223372036854775807" ), bIsVerbose ) )
+        bOKay = false;
+    if ( bIncludeNegative )
+        if ( !test1< T >( std::string( "-9223372036854775807" ), bIsVerbose ) )
+            bOKay = false;
+    //
+    if ( bIncludeHuge ) {
+        if ( !test1< T >( std::string( "9223372036854775808" ), bIsVerbose ) )
+            bOKay = false;
+        if ( bIncludeNegative )
+            if ( !test1< T >( std::string( "-9223372036854775808" ), bIsVerbose ) )
+                bOKay = false;
+        //
+
+        if ( !test1< T >( std::string( "170141183460469231731687303715884105727" ), bIsVerbose ) )
+            bOKay = false;
+        if ( bIncludeNegative )
+            if ( !test1< T >(
+                     std::string( "-170141183460469231731687303715884105727" ), bIsVerbose ) )
+                bOKay = false;
+        if ( !test1< T >( std::string( "170141183460469231731687303715884105728" ), bIsVerbose ) )
+            bOKay = false;
+        if ( bIncludeNegative )
+            if ( !test1< T >(
+                     std::string( "-170141183460469231731687303715884105728" ), bIsVerbose ) )
+                bOKay = false;
+        //
+        if ( !test1< T >(
+                 std::string( "184467440737095516151844674407370955161518446744073709551615" ),
+                 bIsVerbose ) )
+            bOKay = false;
+        if ( bIncludeNegative )
+            if ( !test1< T >(
+                     std::string( "-184467440737095516151844674407370955161518446744073709551615" ),
+                     bIsVerbose ) )
+                bOKay = false;
+    }
+    if ( bIsVerbose && strTypeDescription && strTypeDescription[0] ) {
+        if ( bOKay )
+            std::cout << cc::success( "Successfull conversion test of " )
+                      << cc::info( strTypeDescription ) << cc::success( "." ) << "\n";
+        else
+            std::cout << cc::fatal( "FAILED" ) << cc::error( " conversion test of " )
+                      << cc::warn( strTypeDescription ) << cc::error( "." ) << "\n";
+    }
+    return bOKay;
+}  // namespace BMPBN
+
+template < class T >
+inline bool test_limit_limbs_and_halves(
+    const char* strStartValue, size_t nBits, bool bIsVerbose ) {
+    if ( bIsVerbose )
+        std::cout << cc::debug( "Testing limit margin of " ) << cc::num10( nBits )
+                  << cc::debug( " bit values..." ) << "\n";
+    bool bOKay = true;
+    if ( !test1< T >( std::string( strStartValue ), bIsVerbose ) )
+        bOKay = false;
+    T n( strStartValue );
+    for ( size_t i = 0; i < nBits; ++i ) {
+        n /= 2;
+        if ( i == 0 )
+            ++n;
+        if ( !test1< T >( std::string( n.str() ), bIsVerbose ) )
+            bOKay = false;
+    }
+    if ( bIsVerbose ) {
+        if ( bOKay )
+            std::cout << cc::success( "Successfull conversion test of " ) << cc::num10( nBits )
+                      << cc::success( " bit values." ) << "\n";
+        else
+            std::cout << cc::fatal( "FAILED" ) << cc::error( " conversion test of " )
+                      << cc::num10( nBits ) << cc::num10( nBits ) << cc::debug( " bit values" )
+                      << "\n";
+    }
+    return bOKay;
+}
+
+};  // namespace BMPBN
+};  // namespace dev

--- a/libweb3jsonrpc/CMakeLists.txt
+++ b/libweb3jsonrpc/CMakeLists.txt
@@ -108,14 +108,20 @@ jsonrpcstub_create(web3jsonrpc skaleStats.json
 	SkaleStatsClient ${CMAKE_CURRENT_BINARY_DIR} SkaleStatsClient
 )
 
-target_include_directories( skale PRIVATE
+link_directories(${BLS_WITH_FF_LIBRARY_DIR})
+
+target_include_directories( web3jsonrpc PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../libconsensus/libBLS/
+        ${BLS_WITH_FF_INCLUDE_DIR}
+        ${BLS_INCLUDE_DIRS}
 	"${UTILS_INCLUDE_DIR}"
 	${SKUTILS_INCLUDE_DIRS}
 	)
 
 target_link_libraries( web3jsonrpc
+    bls
     ethashseal
-	skutils
+    skutils
     ${DEPS_INSTALL_ROOT}/lib/libjsonrpccpp-server.a
     ${DEPS_INSTALL_ROOT}/lib/libjsonrpccpp-common.a
     ${DEPS_INSTALL_ROOT}/lib/libjsonrpccpp-client.a

--- a/libweb3jsonrpc/SkaleStats.cpp
+++ b/libweb3jsonrpc/SkaleStats.cpp
@@ -1216,32 +1216,42 @@ Json::Value SkaleStats::skale_imaVerifyAndSign( const Json::Value& request ) {
             //
             // compose message to sign
             //
-
+            auto fnInvert = []( uint8_t* arr, size_t cnt ) -> void {
+                size_t n = cnt / 2;
+                for ( size_t i = 0; i < n; ++i ) {
+                    uint8_t b1 = arr[i];
+                    uint8_t b2 = arr[cnt - i - 1];
+                    arr[i] = b2;
+                    arr[cnt - i - 1] = b1;
+                }
+            };
+            auto fnAlignRight = []( bytes& v, size_t cnt ) -> void {
+                while ( v.size() < cnt )
+                    v.push_back( 0 );
+            };
             uint8_t arr[32];
+            bytes v;
+            const size_t cntArr = sizeof( arr ) / sizeof( arr[0] );
             //
-            dev::BMPBN::encode< dev::u256 >(
-                uMessageSender, arr, sizeof( arr ) / sizeof( arr[0] ) );
-            vecAllTogetherMessages.insert(
-                vecAllTogetherMessages.end(), arr + 0, arr + sizeof( arr ) / sizeof( arr[0] ) );
+            v = dev::BMPBN::encode2vec< dev::u256 >( uMessageSender, true );
+            fnAlignRight( v, 32 );
+            vecAllTogetherMessages.insert( vecAllTogetherMessages.end(), v.begin(), v.end() );
             //
-            dev::BMPBN::encode< dev::u256 >(
-                uDestinationContract, arr, sizeof( arr ) / sizeof( arr[0] ) );
-            vecAllTogetherMessages.insert(
-                vecAllTogetherMessages.end(), arr + 0, arr + sizeof( arr ) / sizeof( arr[0] ) );
-
-            dev::BMPBN::encode< dev::u256 >(
-                uDestinationAddressTo, arr, sizeof( arr ) / sizeof( arr[0] ) );
-            vecAllTogetherMessages.insert(
-                vecAllTogetherMessages.end(), arr + 0, arr + sizeof( arr ) / sizeof( arr[0] ) );
+            v = dev::BMPBN::encode2vec< dev::u256 >( uDestinationContract, true );
+            fnAlignRight( v, 32 );
+            vecAllTogetherMessages.insert( vecAllTogetherMessages.end(), v.begin(), v.end() );
             //
-            dev::BMPBN::encode< dev::u256 >(
-                uMessageAmount, arr, sizeof( arr ) / sizeof( arr[0] ) );
-            vecAllTogetherMessages.insert(
-                vecAllTogetherMessages.end(), arr + 0, arr + sizeof( arr ) / sizeof( arr[0] ) );
+            v = dev::BMPBN::encode2vec< dev::u256 >( uDestinationAddressTo, true );
+            fnAlignRight( v, 32 );
+            vecAllTogetherMessages.insert( vecAllTogetherMessages.end(), v.begin(), v.end() );
             //
-            dev::bytes vecData = dev::fromHex( strMessageData, dev::WhenError::DontThrow );
-            vecAllTogetherMessages.insert(
-                vecAllTogetherMessages.end(), vecData.begin(), vecData.end() );
+            dev::BMPBN::encode< dev::u256 >( uMessageAmount, arr, cntArr );
+            fnInvert( arr, cntArr );
+            vecAllTogetherMessages.insert( vecAllTogetherMessages.end(), arr + 0, arr + cntArr );
+            //
+            v = dev::fromHex( strMessageData, dev::WhenError::DontThrow );
+            fnInvert( v.data(), v.size() );
+            vecAllTogetherMessages.insert( vecAllTogetherMessages.end(), v.begin(), v.end() );
         }
         //
         //

--- a/libweb3jsonrpc/SkaleStats.cpp
+++ b/libweb3jsonrpc/SkaleStats.cpp
@@ -28,12 +28,14 @@
 #include <jsonrpccpp/common/exception.h>
 #include <libweb3jsonrpc/JsonHelper.h>
 
-#include <csignal>
-#include <exception>
+#include <libdevcore/CommonJS.h>
 
 #include <skutils/console_colors.h>
 #include <skutils/eth_utils.h>
 #include <skutils/rest_call.h>
+
+#include <csignal>
+#include <exception>
 
 namespace dev {
 namespace rpc {
@@ -518,6 +520,75 @@ Json::Value SkaleStats::skale_imaVerifyAndSign( const Json::Value& request ) {
                       << cc::num10( idxMessage ) << cc::debug( " of " )
                       << cc::num10( cntMessagesToSign ) << cc::debug( " with content: " )
                       << cc::info( strMessageToSign ) << "\n";
+            bytes vecBytes = dev::jsToBytes( strMessageToSign, dev::OnFailed::Throw );
+            size_t cntMessageBytes = vecBytes.size();
+            if ( cntMessageBytes == 0 )
+                throw std::runtime_error( "bad empty message data to sign" );
+            //            _byte_ b0 = vecBytes[0];
+            //            switch ( b0 ) {
+            //            case 1:
+            //                // ETH transfer, see
+            //                //
+            //                https://github.com/skalenetwork/IMA/blob/develop/proxy/contracts/DepositBox.sol
+            //                break;
+            //            case 3:
+            //                // ERC20 transfer, see encodeData() in
+            //                //
+            //                https://github.com/skalenetwork/IMA/blob/develop/proxy/contracts/ERC20ModuleForMainnet.sol
+            //                /*
+            //                function encodeData(
+            //                    address contractHere,
+            //                    uint contractPosition,
+            //                    address to,
+            //                    uint amount) internal view returns (bytes memory data)
+            //                    {
+            //                    string memory name = ERC20Detailed(contractHere).name();
+            //                    uint8 decimals = ERC20Detailed(contractHere).decimals();
+            //                    string memory symbol = ERC20Detailed(contractHere).symbol();
+            //                    uint totalSupply = ERC20Detailed(contractHere).totalSupply();
+            //                    data = abi.encodePacked(
+            //                        bytes1(uint8(3)),
+            //                        bytes32(contractPosition),
+            //                        bytes32(bytes20(to)),
+            //                        bytes32(amount),
+            //                        bytes(name).length,
+            //                        name,
+            //                        bytes(symbol).length,
+            //                        symbol,
+            //                        decimals,
+            //                        totalSupply
+            //                        );
+            //                }
+            //                */
+            //                break;
+            //            case 5:
+            //                // ERC 721 transfer, see encodeData() in
+            //                //
+            //                https://github.com/skalenetwork/IMA/blob/develop/proxy/contracts/ERC721ModuleForMainnet.sol
+            //                /*
+            //                function encodeData(
+            //                    address contractHere,
+            //                    uint contractPosition,
+            //                    address to,
+            //                    uint tokenId) internal view returns (bytes memory data)
+            //                {
+            //                    string memory name = IERC721Full(contractHere).name();
+            //                    string memory symbol = IERC721Full(contractHere).symbol();
+            //                    data = abi.encodePacked(
+            //                        bytes1(uint8(5)),
+            //                        bytes32(contractPosition),
+            //                        bytes32(bytes20(to)),
+            //                        bytes32(tokenId),
+            //                        bytes(name).length,
+            //                        name,
+            //                        bytes(symbol).length,
+            //                        symbol
+            //                        );
+            //                }
+            //                */
+            //                break;
+            //            }  // switch( b0 )
+
             //
             //
             //

--- a/test/unittests/libdevcore/core.cpp
+++ b/test/unittests/libdevcore/core.cpp
@@ -22,10 +22,15 @@
  * CORE test functions.
  */
 
+#include <libdevcore/BMPBN.h>
+#include <libdevcore/BMPBN_tests.h>
+#include <libdevcore/Common.h>
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/Log.h>
 #include <test/tools/libtesteth/TestOutputHelper.h>
 #include <boost/test/unit_test.hpp>
+
+#include <skutils/console_colors.h>
 
 using namespace dev::test;
 
@@ -73,6 +78,50 @@ BOOST_AUTO_TEST_CASE( isHex ) {
     BOOST_CHECK( !dev::isHex( " " ) );
     BOOST_CHECK( dev::isHex( "aa" ) );
     BOOST_CHECK( dev::isHex( "003" ) );
+}
+
+BOOST_AUTO_TEST_CASE( BMPBN ) {
+    auto bPrev = cc::_on_;
+    cc::_on_ = true;
+
+    bool bIsVerbose = true;
+
+    BOOST_CHECK_MESSAGE( dev::BMPBN::test< dev::bigint >( false, true, bIsVerbose, "dev::bigint" ),
+        "BMPBN set of simple checks failed for dev::bigint" );
+    BOOST_CHECK_MESSAGE( dev::BMPBN::test< dev::u64 >( true, false, bIsVerbose, "dev::u64" ),
+        "BMPBN set of simple checks failed for dev::u64" );
+
+    BOOST_CHECK_MESSAGE( dev::BMPBN::test< dev::u128 >( false, false, bIsVerbose, "dev::u128" ),
+        "BMPBN set of simple checks failed for dev::u128" );
+
+    BOOST_CHECK_MESSAGE( dev::BMPBN::test< dev::u160 >( false, false, bIsVerbose, "dev::u160" ),
+        "BMPBN set of simple checks failed for dev::u160" );
+    BOOST_CHECK_MESSAGE( dev::BMPBN::test< dev::s160 >( true, false, bIsVerbose, "dev::s160" ),
+        "BMPBN set of simple checks failed for dev::s160" );
+
+    BOOST_CHECK_MESSAGE( dev::BMPBN::test< dev::u256 >( false, true, bIsVerbose, "dev::u256" ),
+        "BMPBN set of simple checks failed for dev::u256" );
+    BOOST_CHECK_MESSAGE( dev::BMPBN::test< dev::s256 >( true, true, bIsVerbose, "dev::s256" ),
+        "BMPBN set of simple checks failed for dev::s256" );
+
+    BOOST_CHECK_MESSAGE( dev::BMPBN::test< dev::u512 >( false, true, bIsVerbose, "dev::u512" ),
+        "BMPBN set of simple checks failed for dev::u512" );
+    BOOST_CHECK_MESSAGE( dev::BMPBN::test< dev::s512 >( true, true, bIsVerbose, "dev::s512" ),
+        "BMPBN set of simple checks failed for dev::s512" );
+
+    BOOST_CHECK( dev::BMPBN::test_limit_limbs_and_halves< dev::u64 >(
+        "9223372036854775807", 64, bIsVerbose ) );
+    BOOST_CHECK( dev::BMPBN::test_limit_limbs_and_halves< dev::u128 >(
+        "170141183460469231731687303715884105727", 128, bIsVerbose ) );
+    BOOST_CHECK( dev::BMPBN::test_limit_limbs_and_halves< dev::u256 >(
+        "115792089237316195423570985008687907853269984665640564039457584007913129639935", 256,
+        bIsVerbose ) );
+    BOOST_CHECK( dev::BMPBN::test_limit_limbs_and_halves< dev::u512 >(
+        "134078079299425970995740249982058461274793658205923933777235614437217640300735469768018742"
+        "98166903427690031858186486050853753882811946569946433649006084095",
+        512, bIsVerbose ) );
+
+    cc::_on_ = bPrev;
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
All the **IMA messages** disassembled and verified using calls to **MessageProxy** contract pre-installed at well known address. This work is done by the **skale_imaVerifyAndSign** JSON RPC method.

Added conversion tools for **Big Numbers of boost::multiprecision** library to extract values from IMA encoded messages. Test can be run as **testeth -t CoreLibTests/BMPBN**. See **libdevcore/BMPBN.h**, **libdevcore/BMPBN_tests.h** and **core.cpp** file of **testeth** project.

First, basic **IMA message** verification is performed; **skaled** verifies **data** filed is formed correctly, then verifies appropriate event is present in **MessageProxy**.

Second, found **log record**s contain transaction references, so **skaled** verifies referred transactions by comparing **to** field from **transaction** with **sender** filed from **IMA message**. 

Third, **skaled** searches **transaction receipt** containing call **data** and set of **topics** and verifies **IMA message*** exactly patches existing **transaction receipt**.

