### PR TITLE
Bug/skale 1736 - bad value of contractAddress field in Transaction Receipt JSON

### DIFF
--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -858,7 +858,7 @@ ImportRoute BlockChain::insertBlockAndExtras( VerifiedBlockRef const& _block,
             }
 
             // Update database with them.
-            //ReadGuard l1( x_blocksBlooms );
+            // ReadGuard l1( x_blocksBlooms );
             WriteGuard l1( x_blocksBlooms );
             {
                 MICROPROFILE_SCOPEI( "insertBlockAndExtras", "insert_to_extras", MP_LIGHTSKYBLUE );

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -858,7 +858,8 @@ ImportRoute BlockChain::insertBlockAndExtras( VerifiedBlockRef const& _block,
             }
 
             // Update database with them.
-            ReadGuard l1( x_blocksBlooms );
+            //ReadGuard l1( x_blocksBlooms );
+            WriteGuard l1( x_blocksBlooms );
             {
                 MICROPROFILE_SCOPEI( "insertBlockAndExtras", "insert_to_extras", MP_LIGHTSKYBLUE );
 

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -416,8 +416,21 @@ LocalisedTransactionReceipt ClientBase::localisedTransactionReceipt(
     u256 gasUsed = tr.cumulativeGasUsed();
     if ( tl.second > 0 )
         gasUsed -= bc().transactionReceipt( tl.first, tl.second - 1 ).cumulativeGasUsed();
-    return LocalisedTransactionReceipt( tr, t.sha3(), tl.first, numberFromHash( tl.first ),
-        tl.second, gasUsed, toAddress( t.from(), t.nonce() ) );
+    //
+    // The "contractAddress" field must be null for all types of trasactions but contract deployment
+    // ones. The contract deployment transaction is special because it's the only type of
+    // transaction with "to" filed set to null.
+    //
+    dev::Address contractAddress;
+    dev::Address to = t.to();
+    if ( to == dev::Address( 0 ) ) {
+        // if this transaction is contract deployment
+        contractAddress = toAddress( t.from(), t.nonce() );
+    }
+    //
+    //
+    return LocalisedTransactionReceipt(
+        tr, t.sha3(), tl.first, numberFromHash( tl.first ), tl.second, gasUsed, contractAddress );
 }
 
 pair< h256, unsigned > ClientBase::transactionLocation( h256 const& _transactionHash ) const {

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -25,6 +25,7 @@
 #include "SkaleHost.h"
 
 #include <string>
+#include <atomic>
 
 using namespace std;
 
@@ -131,7 +132,7 @@ SkaleHost::~SkaleHost() {}
 void SkaleHost::logState() {
     LOG( m_debugLogger ) << cc::debug( "sent_to_consensus = " ) << total_sent
                          << cc::debug( " got_from_consensus = " ) << total_arrived
-                         << cc::debug( " m_transaction_cache = " ) << m_transaction_cache.size()
+                         << cc::debug( " m_transaction_cache = " ) << safe_transaction_cache_size()
                          << cc::debug( " m_tq = " ) << m_tq.status().current
                          << cc::debug( " m_bcast_counter = " ) << m_bcast_counter;
 }
@@ -230,11 +231,15 @@ ConsensusExtFace::transactions_vector SkaleHost::pendingTransactions( size_t _li
             Transaction& txn = txns[i];
 
             h256 sha = txn.sha3();
-            if ( m_transaction_cache.count( sha.asArray() ) == 0 ) {
-                m_debugTracer.tracepoint( "sent_txn_new" );
-                m_transaction_cache[sha.asArray()] = txn;
-            } else
-                m_debugTracer.tracepoint( "sent_txn_again" );
+            safe_transaction_cache_access_if_else(
+                sha.asArray(),
+                [&] ( const dev::eth::Transaction & ) -> void {
+                    m_debugTracer.tracepoint( "sent_txn_again" );
+                },
+                [&] () -> void {
+                    m_debugTracer.tracepoint( "sent_txn_new" );
+                    safe_transaction_cache_set( sha.asArray(), txn );
+                } );
             out_vector.push_back( txn.rlp() );
 
             ++total_sent;
@@ -280,7 +285,7 @@ void SkaleHost::createBlock( const ConsensusExtFace::transactions_vector& _appro
 
     std::vector< Transaction > out_txns;  // resultant Transaction vector
 
-    bool have_consensus_born = false;  // means we need to re-verify old txns
+    std::atomic_bool have_consensus_born = false;  // means we need to re-verify old txns
 
     m_debugTracer.tracepoint( "drop_good_transactions" );
 
@@ -301,29 +306,27 @@ void SkaleHost::createBlock( const ConsensusExtFace::transactions_vector& _appro
 
         // if already known
         // TODO clear occasionally this cache?!
-        if ( m_transaction_cache.count( sha.asArray() ) ) {
-            Transaction& t = m_transaction_cache[sha.asArray()];
+        safe_transaction_cache_access_if_else(
+            sha.asArray(),
+            [&] ( const dev::eth::Transaction & t) -> void {
+                out_txns.push_back( t );
+                LOG( m_debugLogger ) << "Dropping good txn " << sha << std::endl;
+                m_debugTracer.tracepoint( "drop_good" );
+                m_tq.dropGood( t );
+                MICROPROFILE_SCOPEI( "SkaleHost", "erase from caches", MP_GAINSBORO );
+                safe_transaction_cache_unset( sha.asArray() );
+                m_received.erase( sha );
 
-            out_txns.push_back( t );
-            LOG( m_debugLogger ) << "Dropping good txn " << sha << std::endl;
-            m_debugTracer.tracepoint( "drop_good" );
-            m_tq.dropGood( t );
-            MICROPROFILE_SCOPEI( "SkaleHost", "erase from caches", MP_GAINSBORO );
-            m_transaction_cache.erase( sha.asArray() );
-            m_received.erase( sha );
-
-            LOG( m_debugLogger ) << "m_received = " << m_received.size() << std::endl;
-        }
-        // if new
-        else {
-            Transaction t( data, CheckTransaction::Everything, true );
-            t.checkOutExternalGas( m_client.chainParams().externalGasDifficulty );
-            out_txns.push_back( t );
-            LOG( m_debugLogger ) << "Will import consensus-born txn!";
-            m_debugTracer.tracepoint( "import_consensus_born" );
-            have_consensus_born = true;
-        }  // else
-
+                LOG( m_debugLogger ) << "m_received = " << m_received.size() << std::endl;
+            },
+            [&] () -> void {
+                Transaction t( data, CheckTransaction::Everything, true );
+                t.checkOutExternalGas( m_client.chainParams().externalGasDifficulty );
+                out_txns.push_back( t );
+                LOG( m_debugLogger ) << "Will import consensus-born txn!";
+                m_debugTracer.tracepoint( "import_consensus_born" );
+                have_consensus_born = true;
+            } );
         if ( m_tq.knownTransactions().count( sha ) != 0 ) {
             // TODO fix this!!?
             clog( VerbosityWarning, "skale-host" )

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -24,8 +24,8 @@
 
 #include "SkaleHost.h"
 
-#include <string>
 #include <atomic>
+#include <string>
 
 using namespace std;
 
@@ -231,12 +231,11 @@ ConsensusExtFace::transactions_vector SkaleHost::pendingTransactions( size_t _li
             Transaction& txn = txns[i];
 
             h256 sha = txn.sha3();
-            safe_transaction_cache_access_if_else(
-                sha.asArray(),
-                [&] ( const dev::eth::Transaction & ) -> void {
+            safe_transaction_cache_access_if_else( sha.asArray(),
+                [&]( const dev::eth::Transaction& ) -> void {
                     m_debugTracer.tracepoint( "sent_txn_again" );
                 },
-                [&] () -> void {
+                [&]() -> void {
                     m_debugTracer.tracepoint( "sent_txn_new" );
                     safe_transaction_cache_set( sha.asArray(), txn );
                 } );
@@ -306,9 +305,8 @@ void SkaleHost::createBlock( const ConsensusExtFace::transactions_vector& _appro
 
         // if already known
         // TODO clear occasionally this cache?!
-        safe_transaction_cache_access_if_else(
-            sha.asArray(),
-            [&] ( const dev::eth::Transaction & t) -> void {
+        safe_transaction_cache_access_if_else( sha.asArray(),
+            [&]( const dev::eth::Transaction& t ) -> void {
                 out_txns.push_back( t );
                 LOG( m_debugLogger ) << "Dropping good txn " << sha << std::endl;
                 m_debugTracer.tracepoint( "drop_good" );
@@ -319,7 +317,7 @@ void SkaleHost::createBlock( const ConsensusExtFace::transactions_vector& _appro
 
                 LOG( m_debugLogger ) << "m_received = " << m_received.size() << std::endl;
             },
-            [&] () -> void {
+            [&]() -> void {
                 Transaction t( data, CheckTransaction::Everything, true );
                 t.checkOutExternalGas( m_client.chainParams().externalGasDifficulty );
                 out_txns.push_back( t );

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -313,9 +313,11 @@ void SkaleHost::createBlock( const ConsensusExtFace::transactions_vector& _appro
                 m_tq.dropGood( t );
                 MICROPROFILE_SCOPEI( "SkaleHost", "erase from caches", MP_GAINSBORO );
                 safe_transaction_cache_unset( sha.asArray() );
-                m_received.erase( sha );
-
-                LOG( m_debugLogger ) << "m_received = " << m_received.size() << std::endl;
+                {  // block
+                    std::lock_guard< std::mutex > localGuard( m_receivedMutex );
+                    m_received.erase( sha );
+                    LOG( m_debugLogger ) << "m_received = " << m_received.size() << std::endl;
+                }  // block
             },
             [&]() -> void {
                 Transaction t( data, CheckTransaction::Everything, true );

--- a/libethereum/SkaleHost.h
+++ b/libethereum/SkaleHost.h
@@ -40,13 +40,12 @@
 
 #include <jsonrpccpp/client/client.h>
 
+#include <atomic>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <queue>
 #include <string>
-#include <atomic>
-#include <mutex>
-#include <atomic>
 
 namespace dev {
 namespace eth {
@@ -171,44 +170,48 @@ private:
     mutable std::recursive_mutex m_mtx_4_safe_transaction_cache;
     typedef std::array< uint8_t, 32 > array_32_bytes_t;
     typedef std::map< array_32_bytes_t, dev::eth::Transaction > map_safe_transaction_cache_t;
-    map_safe_transaction_cache_t m_safe_transaction_cache;  // used to find Transaction objects when creating block
+    map_safe_transaction_cache_t m_safe_transaction_cache;  // used to find Transaction objects when
+                                                            // creating block
     size_t safe_transaction_cache_size() const {
-        std::lock_guard <std::recursive_mutex> lock( m_mtx_4_safe_transaction_cache );
+        std::lock_guard< std::recursive_mutex > lock( m_mtx_4_safe_transaction_cache );
         size_t cnt = m_safe_transaction_cache.size();
         return cnt;
     }
-//    size_t safe_transaction_cache_count_of( const array_32_bytes_t & refWhat ) const {
-//        std::lock_guard <std::recursive_mutex> lock( m_mtx_4_safe_transaction_cache );
-//        size_t cnt = m_safe_transaction_cache.count( refWhat );
-//        return cnt;
-//    }
-//    dev::eth::Transaction safe_transaction_cache_get( const array_32_bytes_t & k ) const {
-//        std::lock_guard <std::recursive_mutex> lock( m_mtx_4_safe_transaction_cache );
-//        dev::eth::Transaction v = m_safe_transaction_cache.at( k );
-//        return v;
-//    }
-    void safe_transaction_cache_set( const array_32_bytes_t & k, const dev::eth::Transaction & v ) {
-        std::lock_guard <std::recursive_mutex> lock( m_mtx_4_safe_transaction_cache );
-        m_safe_transaction_cache[ k ] = v;
+    //    size_t safe_transaction_cache_count_of( const array_32_bytes_t & refWhat ) const {
+    //        std::lock_guard <std::recursive_mutex> lock( m_mtx_4_safe_transaction_cache );
+    //        size_t cnt = m_safe_transaction_cache.count( refWhat );
+    //        return cnt;
+    //    }
+    //    dev::eth::Transaction safe_transaction_cache_get( const array_32_bytes_t & k ) const {
+    //        std::lock_guard <std::recursive_mutex> lock( m_mtx_4_safe_transaction_cache );
+    //        dev::eth::Transaction v = m_safe_transaction_cache.at( k );
+    //        return v;
+    //    }
+    void safe_transaction_cache_set( const array_32_bytes_t& k, const dev::eth::Transaction& v ) {
+        std::lock_guard< std::recursive_mutex > lock( m_mtx_4_safe_transaction_cache );
+        m_safe_transaction_cache[k] = v;
     }
-    void safe_transaction_cache_unset( const array_32_bytes_t & k ) {
-        std::lock_guard <std::recursive_mutex> lock( m_mtx_4_safe_transaction_cache );
+    void safe_transaction_cache_unset( const array_32_bytes_t& k ) {
+        std::lock_guard< std::recursive_mutex > lock( m_mtx_4_safe_transaction_cache );
         m_safe_transaction_cache.erase( k );
     }
-    typedef std::function < void( const dev::eth::Transaction & ) > fn_safe_transaction_cache_then_func_t;
-    typedef std::function < void() > fn_safe_transaction_cache_else_func_t;
-    void safe_transaction_cache_access_if_else( const array_32_bytes_t & k, fn_safe_transaction_cache_then_func_t fnThen, fn_safe_transaction_cache_else_func_t fnElse ) const {
-        { // block
-            std::lock_guard <std::recursive_mutex> lock( m_mtx_4_safe_transaction_cache );
-            if( m_safe_transaction_cache.find( k ) != m_safe_transaction_cache.cend() ) {
-                if( fnThen ) {
-                    const dev::eth::Transaction &v = m_safe_transaction_cache.at( k );
+    typedef std::function< void( const dev::eth::Transaction& ) >
+        fn_safe_transaction_cache_then_func_t;
+    typedef std::function< void() > fn_safe_transaction_cache_else_func_t;
+    void safe_transaction_cache_access_if_else( const array_32_bytes_t& k,
+        fn_safe_transaction_cache_then_func_t fnThen,
+        fn_safe_transaction_cache_else_func_t fnElse ) const {
+        {  // block
+            std::lock_guard< std::recursive_mutex > lock( m_mtx_4_safe_transaction_cache );
+            if ( m_safe_transaction_cache.find( k ) != m_safe_transaction_cache.cend() ) {
+                if ( fnThen ) {
+                    const dev::eth::Transaction& v = m_safe_transaction_cache.at( k );
                     fnThen( v );
                 }
                 return;
             }
-        }// block
-        if( fnElse )
+        }  // block
+        if ( fnElse )
             fnElse();
     }
 

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -112,6 +112,7 @@ ImportResult TransactionQueue::import( Transaction const& _transaction, IfDroppe
     ImportResult ret;
     {
         MICROPROFILE_SCOPEI( "TransactionQueue", "import", MP_THISTLE );
+        //WriteGuard l2( m_lock );
         UpgradableGuard l( m_lock );
         auto ir = check_WITH_LOCK( h, _ik );
         if ( ir != ImportResult::Success )
@@ -175,9 +176,13 @@ Transactions TransactionQueue::topTransactions_WITH_LOCK(
     return topTransactions;
 }
 
-const h256Hash& TransactionQueue::knownTransactions() const {
-    ReadGuard l( m_lock );
-    return m_known;
+const h256Hash TransactionQueue::knownTransactions() const {
+    h256Hash rv;
+    { // block
+        ReadGuard l( m_lock );
+        rv = m_known;
+    } // block
+    return rv;
 }
 
 ImportResult TransactionQueue::manageImport_WITH_LOCK(

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -112,7 +112,7 @@ ImportResult TransactionQueue::import( Transaction const& _transaction, IfDroppe
     ImportResult ret;
     {
         MICROPROFILE_SCOPEI( "TransactionQueue", "import", MP_THISTLE );
-        //WriteGuard l2( m_lock );
+        // WriteGuard l2( m_lock );
         UpgradableGuard l( m_lock );
         auto ir = check_WITH_LOCK( h, _ik );
         if ( ir != ImportResult::Success )
@@ -178,10 +178,10 @@ Transactions TransactionQueue::topTransactions_WITH_LOCK(
 
 const h256Hash TransactionQueue::knownTransactions() const {
     h256Hash rv;
-    { // block
+    {  // block
         ReadGuard l( m_lock );
         rv = m_known;
-    } // block
+    }  // block
     return rv;
 }
 

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -33,12 +33,12 @@
 #include <libdevcore/Guards.h>
 #include <libdevcore/Log.h>
 #include <libethcore/Common.h>
+#include <atomic>
 #include <condition_variable>
 #include <deque>
 #include <functional>
-#include <thread>
-#include <atomic>
 #include <mutex>
+#include <thread>
 
 namespace dev {
 namespace eth {
@@ -266,7 +266,7 @@ private:
     mutable SharedMutex m_lock;                    ///< General lock.
     mutable boost::condition_variable_any m_cond;  // for wait/notify
     Handler<> m_readyCondNotifier;
-    
+
     h256Hash m_known;  ///< Headers of transactions in both sets.
 
     std::unordered_map< h256, std::function< void( ImportResult ) > > m_callbacks;  ///< Called

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -37,6 +37,8 @@
 #include <deque>
 #include <functional>
 #include <thread>
+#include <atomic>
+#include <mutex>
 
 namespace dev {
 namespace eth {
@@ -111,7 +113,7 @@ public:
 
     /// Get a hash set of transactions in the queue
     /// @returns A hash set of all transactions in the queue
-    const h256Hash& knownTransactions() const;
+    const h256Hash knownTransactions() const;
 
     /// Get max nonce for an account
     /// @returns Max transaction nonce for account in the queue
@@ -264,7 +266,7 @@ private:
     mutable SharedMutex m_lock;                    ///< General lock.
     mutable boost::condition_variable_any m_cond;  // for wait/notify
     Handler<> m_readyCondNotifier;
-
+    
     h256Hash m_known;  ///< Headers of transactions in both sets.
 
     std::unordered_map< h256, std::function< void( ImportResult ) > > m_callbacks;  ///< Called

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -24,6 +24,8 @@
 
 #include "State.h"
 
+#include <mutex>
+
 #include <boost/filesystem.hpp>
 #include <boost/timer.hpp>
 #include <boost/utility/in_place_factory.hpp>
@@ -62,6 +64,10 @@ using dev::eth::TransactionReceipt;
 #define ETH_VMTRACE 0
 #endif
 
+typedef std::recursive_mutex mutex_type_state;
+typedef std::lock_guard< mutex_type_state > lock_type_state;
+
+static mutex_type_state g_mtx_state;
 
 State::State(
     u256 const& _accountStartNonce, OverlayDB const& _db, BaseState _bs, u256 _initialFunds )
@@ -650,6 +656,7 @@ void State::rollback( size_t _savepoint ) {
 }
 
 void State::updateToLatestVersion() {
+    lock_type_state lock( g_mtx_state );
     m_changeLog.clear();
     m_cache.clear();
     m_unchangedCacheEntries.clear();
@@ -662,6 +669,7 @@ void State::updateToLatestVersion() {
 }
 
 State State::startRead() const {
+    lock_type_state lock( g_mtx_state );
     State stateCopy = State( *this );
     stateCopy.m_db_read_lock.emplace( *stateCopy.x_db_ptr );
     stateCopy.updateToLatestVersion();
@@ -669,6 +677,7 @@ State State::startRead() const {
 }
 
 State State::startWrite() const {
+    lock_type_state lock( g_mtx_state );
     State stateCopy = State( *this );
     stateCopy.m_db_write_lock.emplace( *stateCopy.x_db_ptr );
     stateCopy.updateToLatestVersion();

--- a/libskale/httpserveroverride.cpp
+++ b/libskale/httpserveroverride.cpp
@@ -275,6 +275,7 @@ map_method_call_stats_t g_map_method_traffic_stats_out;
 static size_t g_nDefaultQueueSize = 10;
 
 static skutils::stats::named_event_stats& stat_sybsystem_call_queue( const char* strSubSystem ) {
+    lock_type_stats lock( g_mtx_stats );
     map_method_call_stats_t::iterator itFind = g_map_method_call_stats.find( strSubSystem ),
                                       itEnd = g_map_method_call_stats.end();
     if ( itFind != itEnd ) {
@@ -287,6 +288,7 @@ static skutils::stats::named_event_stats& stat_sybsystem_call_queue( const char*
     return ( *x );
 }
 static skutils::stats::named_event_stats& stat_sybsystem_answer_queue( const char* strSubSystem ) {
+    lock_type_stats lock( g_mtx_stats );
     map_method_call_stats_t::iterator itFind = g_map_method_answer_stats.find( strSubSystem ),
                                       itEnd = g_map_method_answer_stats.end();
     if ( itFind != itEnd ) {
@@ -299,6 +301,7 @@ static skutils::stats::named_event_stats& stat_sybsystem_answer_queue( const cha
     return ( *x );
 }
 static skutils::stats::named_event_stats& stat_sybsystem_error_queue( const char* strSubSystem ) {
+    lock_type_stats lock( g_mtx_stats );
     map_method_call_stats_t::iterator itFind = g_map_method_error_stats.find( strSubSystem ),
                                       itEnd = g_map_method_error_stats.end();
     if ( itFind != itEnd ) {
@@ -312,6 +315,7 @@ static skutils::stats::named_event_stats& stat_sybsystem_error_queue( const char
 }
 static skutils::stats::named_event_stats& stat_sybsystem_exception_queue(
     const char* strSubSystem ) {
+    lock_type_stats lock( g_mtx_stats );
     map_method_call_stats_t::iterator itFind = g_map_method_exception_stats.find( strSubSystem ),
                                       itEnd = g_map_method_exception_stats.end();
     if ( itFind != itEnd ) {
@@ -326,6 +330,7 @@ static skutils::stats::named_event_stats& stat_sybsystem_exception_queue(
 
 static skutils::stats::named_event_stats& stat_sybsystem_traffic_queue_in(
     const char* strSubSystem ) {
+    lock_type_stats lock( g_mtx_stats );
     const auto itFind = g_map_method_traffic_stats_in.find( strSubSystem );
     if ( itFind != std::end( g_map_method_traffic_stats_in ) ) {
         skutils::stats::named_event_stats* x = itFind->second;
@@ -338,6 +343,7 @@ static skutils::stats::named_event_stats& stat_sybsystem_traffic_queue_in(
 }
 static skutils::stats::named_event_stats& stat_sybsystem_traffic_queue_out(
     const char* strSubSystem ) {
+    lock_type_stats lock( g_mtx_stats );
     const auto itFind = g_map_method_traffic_stats_out.find( strSubSystem );
     if ( itFind != std::end( g_map_method_traffic_stats_out ) ) {
         skutils::stats::named_event_stats* x = itFind->second;
@@ -407,6 +413,7 @@ void register_stats_exception( const char* strSubSystem, const nlohmann::json& j
 }
 
 static nlohmann::json generate_subsystem_stats( const char* strSubSystem ) {
+    lock_type_stats lock( g_mtx_stats );
     nlohmann::json jo = nlohmann::json::object();
     skutils::stats::named_event_stats& cq = stat_sybsystem_call_queue( strSubSystem );
     skutils::stats::named_event_stats& aq = stat_sybsystem_answer_queue( strSubSystem );

--- a/libskale/httpserveroverride.h
+++ b/libskale/httpserveroverride.h
@@ -197,8 +197,8 @@ public:
 
 class SkaleRelayWS : public skutils::ws::server, public SkaleServerHelper {
 protected:
-    volatile bool m_isRunning = false;
-    volatile bool m_isInLoop = false;
+    std::atomic_bool m_isRunning = false;
+    std::atomic_bool m_isInLoop = false;
     int ipVer_;
     std::string strBindAddr_;
     std::string m_strScheme_;

--- a/libskale/httpserveroverride.h
+++ b/libskale/httpserveroverride.h
@@ -66,7 +66,7 @@ typedef intptr_t ssize_t;
 #include <libweb3jsonrpc/SkaleStatsSite.h>
 
 class SkaleStatsSubscriptionManager;
-class SkaleServerConnectionsTrackHelper;
+struct SkaleServerConnectionsTrackHelper;
 class SkaleWsPeer;
 class SkaleRelayWS;
 class SkaleServerOverride;

--- a/libskutils/include/skutils/http.h
+++ b/libskutils/include/skutils/http.h
@@ -264,8 +264,8 @@ private:
 
     virtual bool read_and_close_socket( socket_t sock );
 
-    volatile bool is_in_loop_ = false;
-    bool is_running_;
+    std::atomic_bool is_in_loop_ = false;
+    std::atomic_bool is_running_ = false;
     socket_t svr_sock_;
     std::string base_dir_;
     Handlers get_handlers_;
@@ -278,7 +278,7 @@ private:
     Logger logger_;
 
     std::mutex running_connectoin_handlers_mutex_;
-    volatile int running_connectoin_handlers_;
+    std::atomic_int running_connectoin_handlers_;
     int running_connectoin_handlers_get() {
         int n = 0;
         std::lock_guard< std::mutex > guard( running_connectoin_handlers_mutex_ );

--- a/libskutils/src/stats.cpp
+++ b/libskutils/src/stats.cpp
@@ -170,6 +170,7 @@ double named_event_stats::compute_eps( const std::string& eventName, const time_
 
 double named_event_stats::compute_eps( t_NamedEventsIt& itEvent, const time_point& tpNow,
     size_t* p_nSummary, size_t* p_nSummary1 ) const {
+    lock_type lock( const_cast < named_event_stats &> ( *this ) );
     const auto duration_milliseconds = std::chrono::duration_cast< std::chrono::milliseconds >(
         tpNow - itEvent->second.m_prevTime );
     const double seconds = static_cast< double >( duration_milliseconds.count() ) / 1000.0;

--- a/libskutils/src/stats.cpp
+++ b/libskutils/src/stats.cpp
@@ -170,7 +170,7 @@ double named_event_stats::compute_eps( const std::string& eventName, const time_
 
 double named_event_stats::compute_eps( t_NamedEventsIt& itEvent, const time_point& tpNow,
     size_t* p_nSummary, size_t* p_nSummary1 ) const {
-    lock_type lock( const_cast < named_event_stats &> ( *this ) );
+    lock_type lock( const_cast< named_event_stats& >( *this ) );
     const auto duration_milliseconds = std::chrono::duration_cast< std::chrono::milliseconds >(
         tpNow - itEvent->second.m_prevTime );
     const double seconds = static_cast< double >( duration_milliseconds.count() ) / 1000.0;

--- a/libweb3jsonrpc/JsonHelper.cpp
+++ b/libweb3jsonrpc/JsonHelper.cpp
@@ -174,7 +174,18 @@ Json::Value toJson( dev::eth::LocalisedTransactionReceipt const& _t ) {
     res["blockNumber"] = _t.blockNumber();
     res["cumulativeGasUsed"] = toJS( _t.cumulativeGasUsed() );
     res["gasUsed"] = toJS( _t.gasUsed() );
-    res["contractAddress"] = toJS( _t.contractAddress() );
+    //
+    // The "contractAddress" field must be null for all types of trasactions but contract deployment
+    // ones. The contract deployment transaction is special because it's the only type of
+    // transaction with "to" filed set to null.
+    //
+    dev::Address contractAddress = _t.contractAddress();
+    if ( contractAddress == dev::Address( 0 ) )
+        res["contractAddress"] = Json::Value::nullRef;
+    else
+        res["contractAddress"] = toJS( contractAddress );
+    //
+    //
     res["logs"] = dev::toJson( _t.localisedLogs() );
     res["logsBloom"] = toJS( _t.bloom() );
     if ( _t.hasStatusCode() )

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -232,7 +232,7 @@ int main( int argc, char** argv ) try {
     int nExplicitPortWSS6 = -1;
     bool bTraceJsonRpcCalls = false;
 
-    string jsonAdmin;
+    string strJsonAdminSessionKey;
     ChainParams chainParams;
     string privateChain;
 
@@ -450,7 +450,7 @@ int main( int argc, char** argv ) try {
     if ( vm.count( "import-presale" ) )
         presaleImports.push_back( vm["import-presale"].as< string >() );
     if ( vm.count( "admin" ) )
-        jsonAdmin = vm["admin"].as< string >();
+        strJsonAdminSessionKey = vm["admin"].as< string >();
 
     if ( vm.count( "config" ) ) {
         try {
@@ -1934,28 +1934,30 @@ int main( int argc, char** argv ) try {
         }  // if ( nExplicitPortHTTP > 0 || nExplicitPortHTTPS > 0 || nExplicitPortWS > 0 ||
            // nExplicitPortWSS > 0 )
 
-        if ( jsonAdmin.empty() )
-            jsonAdmin =
+        if ( strJsonAdminSessionKey.empty() )
+            strJsonAdminSessionKey =
                 sessionManager->newSession( rpc::SessionPermissions{{rpc::Privilege::Admin}} );
         else
             sessionManager->addSession(
-                jsonAdmin, rpc::SessionPermissions{{rpc::Privilege::Admin}} );
+                strJsonAdminSessionKey, rpc::SessionPermissions{{rpc::Privilege::Admin}} );
 
-        cout << "JSONRPC Admin Session Key: " << jsonAdmin << "\n";
+        clog( VerbosityInfo, "main" )
+            << cc::bright( "JSONRPC Admin Session Key: " ) << cc::sunny( strJsonAdminSessionKey );
     }  // if ( is_ipc || nExplicitPortHTTP > 0 || nExplicitPortHTTPS > 0  || nExplicitPortWS > 0 ||
        // nExplicitPortWSS > 0 )
 
     if ( bEnabledShutdownViaWeb3 ) {
-        std::cout << "Enabling programmatic shutdown via Web3...\n";
+        clog( VerbosityInfo, "main" ) << cc::debug( "Enabling programmatic shutdown via Web3..." );
         dev::rpc::Skale::enableWeb3Shutdown( true );
         dev::rpc::Skale::onShutdownInvoke( []() { ExitHandler::exitHandler( 0 ); } );
-        cout << "Done, programmatic shutdown via Web3 is enabled\n";
+        clog( VerbosityInfo, "main" )
+            << cc::debug( "Done, programmatic shutdown via Web3 is enabled" );
     } else {
-        std::cout << "Disabling programmatic shutdown via Web3...\n";
+        clog( VerbosityInfo, "main" ) << cc::debug( "Disabling programmatic shutdown via Web3..." );
         dev::rpc::Skale::enableWeb3Shutdown( false );
-        std::cout << "Done, programmatic shutdown via Web3 is disabled\n";
+        clog( VerbosityInfo, "main" )
+            << cc::debug( "Done, programmatic shutdown via Web3 is disabled" );
     }
-
 
     if ( client ) {
         unsigned int n = client->blockChain().details().number;


### PR DESCRIPTION
The **contractAddress** field of **Transaction Receipt** JSON must be **null** for all types of transactions but **contract deployment** ones. The **contract deployment** transaction is special because it's the only type of transaction with **to** filed set to **null**.
The **aleth** source code has the same bug not fixed yet.
The **geth** Etherereum client app behaves correctly and generates valid transaction receipts. Please take a look at line 313 [here](https://github.com/ethereum/go-ethereum/blob/master/core/types/receipt.go).
_No new functions classes added. No new tests required._