### PR TITLE
SKALE-978 contract code size limit customization via SKALE-specific EVM Schedule settings

### DIFF
--- a/libethcore/CMakeLists.txt
+++ b/libethcore/CMakeLists.txt
@@ -1,6 +1,13 @@
-file(GLOB sources "*.cpp" "*.h")
+file( GLOB sources "*.cpp" "*.h" )
 
-add_library(ethcore ${sources})
+add_library( ethcore ${sources} )
 
-target_include_directories(ethcore PRIVATE "${UTILS_INCLUDE_DIR}")
-target_link_libraries(ethcore PUBLIC devcrypto devcore)
+target_include_directories( ethcore PRIVATE
+	"${UTILS_INCLUDE_DIR}"
+	${SKUTILS_INCLUDE_DIRS}
+	)
+
+target_link_libraries( ethcore PUBLIC
+	devcrypto
+	devcore
+	)

--- a/libethcore/ChainOperationParams.cpp
+++ b/libethcore/ChainOperationParams.cpp
@@ -24,6 +24,9 @@
 #include "ChainOperationParams.h"
 #include <libdevcore/CommonData.h>
 #include <libdevcore/Log.h>
+
+#include <skutils/utils.h>
+
 using namespace std;
 using namespace dev;
 using namespace eth;
@@ -50,7 +53,23 @@ ChainOperationParams::ChainOperationParams()
       durationLimit( 0x0d ) {}
 
 EVMSchedule const& ChainOperationParams::scheduleForBlockNumber( u256 const& _blockNumber ) const {
-    if ( _blockNumber >= experimentalForkBlock )
+    if ( _blockNumber >= skale16ForkBlock )
+        return SkaleSchedule_16k;
+    else if ( _blockNumber >= skale32ForkBlock )
+        return SkaleSchedule_32k;
+    else if ( _blockNumber >= skale64ForkBlock )
+        return SkaleSchedule_64k;
+    else if ( _blockNumber >= skale128ForkBlock )
+        return SkaleSchedule_128k;
+    else if ( _blockNumber >= skale256ForkBlock )
+        return SkaleSchedule_256k;
+    else if ( _blockNumber >= skale512ForkBlock )
+        return SkaleSchedule_512k;
+    else if ( _blockNumber >= skale1024ForkBlock )
+        return SkaleSchedule_1024k;
+    else if ( _blockNumber >= skaleUnlimitedForkBlock )
+        return SkaleSchedule_Unlimited;
+    else if ( _blockNumber >= experimentalForkBlock )
         return ExperimentalSchedule;
     else if ( _blockNumber >= istanbulForkBlock )
         return IstanbulSchedule;

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -156,6 +156,14 @@ public:
     u256 daoHardforkBlock = c_infiniteBlockNumber;
     u256 experimentalForkBlock = c_infiniteBlockNumber;
     u256 istanbulForkBlock = c_infiniteBlockNumber;
+    u256 skale16ForkBlock = c_infiniteBlockNumber;
+    u256 skale32ForkBlock = c_infiniteBlockNumber;
+    u256 skale64ForkBlock = c_infiniteBlockNumber;
+    u256 skale128ForkBlock = c_infiniteBlockNumber;
+    u256 skale256ForkBlock = c_infiniteBlockNumber;
+    u256 skale512ForkBlock = c_infiniteBlockNumber;
+    u256 skale1024ForkBlock = c_infiniteBlockNumber;
+    u256 skaleUnlimitedForkBlock = c_infiniteBlockNumber;
     int chainID = 0;    // Distinguishes different chains (mainnet, Ropsten, etc).
     int networkID = 0;  // Distinguishes different sub protocols.
 

--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -155,15 +155,78 @@ static const EVMSchedule IstanbulSchedule = [] {
     schedule.extcodehashGas = 700;
     schedule.haveChainID = true;
     schedule.haveSelfbalance = true;
+    // schedule.eip2200Mode = true;
+    schedule.sstoreUnchangedGas = 800;
+    return schedule;
+}();
+
+static const EVMSchedule BerlinSchedule = [] {
+    EVMSchedule schedule = IstanbulSchedule;
+    // schedule.precompileStaticCallGas = 40;
+    // schedule.callSelfGas = 40;
     return schedule;
 }();
 
 static const EVMSchedule ExperimentalSchedule = [] {
-    EVMSchedule schedule = IstanbulSchedule;
+    EVMSchedule schedule = BerlinSchedule;
     schedule.accountVersion = 1;
     schedule.blockhashGas = 800;
     return schedule;
 }();
+
+static const EVMSchedule SkaleSchedule_base = [] {
+    EVMSchedule schedule = ConstantinopleSchedule;
+    return schedule;
+}();
+
+static const EVMSchedule SkaleSchedule_16k = [] {
+    EVMSchedule schedule = SkaleSchedule_base;
+    schedule.maxCodeSize = 1024 * 16;
+    return schedule;
+}();
+
+static const EVMSchedule SkaleSchedule_32k = [] {
+    EVMSchedule schedule = SkaleSchedule_base;
+    schedule.maxCodeSize = 1024 * 32;
+    return schedule;
+}();
+
+static const EVMSchedule SkaleSchedule_64k = [] {
+    EVMSchedule schedule = SkaleSchedule_base;
+    schedule.maxCodeSize = 1024 * 64;
+    return schedule;
+}();
+
+static const EVMSchedule SkaleSchedule_128k = [] {
+    EVMSchedule schedule = SkaleSchedule_base;
+    schedule.maxCodeSize = 1024 * 128;
+    return schedule;
+}();
+
+static const EVMSchedule SkaleSchedule_256k = [] {
+    EVMSchedule schedule = SkaleSchedule_base;
+    schedule.maxCodeSize = 1024 * 256;
+    return schedule;
+}();
+
+static const EVMSchedule SkaleSchedule_512k = [] {
+    EVMSchedule schedule = SkaleSchedule_base;
+    schedule.maxCodeSize = 1024 * 512;
+    return schedule;
+}();
+
+static const EVMSchedule SkaleSchedule_1024k = [] {
+    EVMSchedule schedule = SkaleSchedule_base;
+    schedule.maxCodeSize = 1024 * 1024;
+    return schedule;
+}();
+
+static const EVMSchedule SkaleSchedule_Unlimited = [] {
+    EVMSchedule schedule = SkaleSchedule_base;
+    schedule.maxCodeSize = std::numeric_limits< unsigned >::max();
+    return schedule;
+}();
+
 
 inline EVMSchedule const& latestScheduleForAccountVersion( u256 const& _version ) {
     if ( _version == 0 )

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -176,6 +176,16 @@ ChainParams ChainParams::loadConfig(
     setOptionalU256Parameter( cp.constantinopleFixForkBlock, c_constantinopleFixForkBlock );
     setOptionalU256Parameter( cp.istanbulForkBlock, c_istanbulForkBlock );
     setOptionalU256Parameter( cp.experimentalForkBlock, c_experimentalForkBlock );
+
+    setOptionalU256Parameter( cp.skale16ForkBlock, c_skale16ForkBlock );
+    setOptionalU256Parameter( cp.skale32ForkBlock, c_skale32ForkBlock );
+    setOptionalU256Parameter( cp.skale64ForkBlock, c_skale64ForkBlock );
+    setOptionalU256Parameter( cp.skale128ForkBlock, c_skale128ForkBlock );
+    setOptionalU256Parameter( cp.skale256ForkBlock, c_skale256ForkBlock );
+    setOptionalU256Parameter( cp.skale512ForkBlock, c_skale512ForkBlock );
+    setOptionalU256Parameter( cp.skale1024ForkBlock, c_skale1024ForkBlock );
+    setOptionalU256Parameter( cp.skaleUnlimitedForkBlock, c_skaleUnlimitedForkBlock );
+
     setOptionalU256Parameter( cp.daoHardforkBlock, c_daoHardforkBlock );
     setOptionalU256Parameter( cp.minimumDifficulty, c_minimumDifficulty );
     setOptionalU256Parameter( cp.difficultyBoundDivisor, c_difficultyBoundDivisor );

--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -63,6 +63,16 @@ string const c_constantinopleForkBlock = "constantinopleForkBlock";
 string const c_constantinopleFixForkBlock = "constantinopleFixForkBlock";
 string const c_istanbulForkBlock = "istanbulForkBlock";
 string const c_experimentalForkBlock = "experimentalForkBlock";
+
+string const c_skale16ForkBlock = "skale16ForkBlock";
+string const c_skale32ForkBlock = "skale32ForkBlock";
+string const c_skale64ForkBlock = "skale64ForkBlock";
+string const c_skale128ForkBlock = "skale128ForkBlock";
+string const c_skale256ForkBlock = "skale256ForkBlock";
+string const c_skale512ForkBlock = "skale512ForkBlock";
+string const c_skale1024ForkBlock = "skale1024ForkBlock";
+string const c_skaleUnlimitedForkBlock = "skaleUnlimitedForkBlock";
+
 string const c_accountStartNonce = "accountStartNonce";
 string const c_maximumExtraDataSize = "maximumExtraDataSize";
 string const c_tieBreakingGas = "tieBreakingGas";

--- a/libethereum/ValidationSchemes.h
+++ b/libethereum/ValidationSchemes.h
@@ -60,6 +60,16 @@ extern std::string const c_constantinopleForkBlock;
 extern std::string const c_constantinopleFixForkBlock;
 extern std::string const c_istanbulForkBlock;
 extern std::string const c_experimentalForkBlock;
+
+extern std::string const c_skale16ForkBlock;
+extern std::string const c_skale32ForkBlock;
+extern std::string const c_skale64ForkBlock;
+extern std::string const c_skale128ForkBlock;
+extern std::string const c_skale256ForkBlock;
+extern std::string const c_skale512ForkBlock;
+extern std::string const c_skale1024ForkBlock;
+extern std::string const c_skaleUnlimitedForkBlock;
+
 extern std::string const c_accountStartNonce;
 extern std::string const c_maximumExtraDataSize;
 extern std::string const c_tieBreakingGas;


### PR DESCRIPTION
To specify custom code size limit - add one of new SKALE-specific **EVM Schedules** into "params" group of **config.json** file. Here is example for unlimited code size:
        "skaleUnlimitedForkBlock": "0x0",
Here is example for 16k-bytes code size limit:
        "skale16kForkBlock": "0x0",
Here is example for 256k-bytes code size limit:
        "skale256kForkBlock": "0x0",
Here is list of supported code size limits: 16, 32, 64, 128, 256. 512. 1024 k-bytes and unlimited.

No new functions/classes added. No new tests needed. Custom **EVM Schedules** are tested by existing **testeth** app.