### PR TITLE
Feature/skale 1790 integrate snapshot hashes into skaled

### DIFF
--- a/libdevcore/Exceptions.h
+++ b/libdevcore/Exceptions.h
@@ -75,6 +75,7 @@ DEV_SIMPLE_EXCEPTION( MissingField );
 DEV_SIMPLE_EXCEPTION( WrongFieldType );
 DEV_SIMPLE_EXCEPTION( InterfaceNotSupported );
 DEV_SIMPLE_EXCEPTION( ExternalFunctionFailure );
+DEV_SIMPLE_EXCEPTION( NoSuchFileOrDirectory );
 
 // error information to be added to exceptions
 using errinfo_invalidSymbol = boost::error_info< struct tag_invalidSymbol, char >;

--- a/libethashseal/genesis/skale.cpp
+++ b/libethashseal/genesis/skale.cpp
@@ -89,7 +89,7 @@ static std::string const c_genesisInfoSkale = std::string() +
         "schainName": "TestChain",
         "schainID": 1,
         "nodes": [
-          { "nodeID": 1112, "ip": "127.0.0.1", "basePort": 1231, "ip6": "::1", "basePort6": 1231, "schainIndex" : 0}
+          { "nodeID": 1112, "ip": "127.0.0.1", "basePort": 1231, "ip6": "::1", "basePort6": 1231, "schainIndex" : 1}
         ]
     }
   },

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -576,6 +576,8 @@ void Client::onChainChanged( ImportRoute const& _ir ) {
     if ( chainParams().nodeInfo.snapshotInterval > 0 &&
          number() % chainParams().nodeInfo.snapshotInterval == 0 ) {
         m_snapshotManager->doSnapshot( number() );
+        std::thread( [this]() { this->m_snapshotManager->computeSnapshotHash( this->number() ); } )
+            .detach();
         // TODO Make this number configurable
         m_snapshotManager->leaveNLastSnapshots( 2 );
     }  // if snapshot

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -576,7 +576,18 @@ void Client::onChainChanged( ImportRoute const& _ir ) {
     if ( chainParams().nodeInfo.snapshotInterval > 0 &&
          number() % chainParams().nodeInfo.snapshotInterval == 0 ) {
         m_snapshotManager->doSnapshot( number() );
-        std::thread( [this]() { this->m_snapshotManager->computeSnapshotHash( this->number() ); } )
+        std::thread( [this]() {
+            try {
+                this->m_snapshotManager->computeSnapshotHash( this->number() );
+            } catch ( const std::exception& ex ) {
+                cerror << "CRITICAL " << dev::nested_exception_what( ex )
+                       << " in computeSnapshotHash(). Exiting";
+                ExitHandler::exitHandler( 0 );
+            } catch ( ... ) {
+                cerror << "CRITICAL unknown exception in computeSnapshotHash(). Exiting";
+                ExitHandler::exitHandler( 0 );
+            }
+        } )
             .detach();
         // TODO Make this number configurable
         m_snapshotManager->leaveNLastSnapshots( 2 );

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -270,7 +270,7 @@ public:
         return path;
     }
 
-    dev::h256 getSnapshotHash( unsigned _blockNumber ) {
+    dev::h256 getSnapshotHash( unsigned _blockNumber ) const {
         return this->m_snapshotManager->getSnapshotHash( _blockNumber );
     }
 

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -270,6 +270,10 @@ public:
         return path;
     }
 
+    dev::h256 getSnapshotHash( unsigned _blockNumber ) {
+        return this->m_snapshotManager->getSnapshotHash( _blockNumber );
+    }
+
 protected:
     /// As syncTransactionQueue - but get list of transactions explicitly
     /// returns number of successfullty executed transactions

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -436,7 +436,7 @@ void SkaleHost::broadcastFunc() {
             Transaction& txn = txns[0];
             h256 sha = txn.sha3();
 
-            // TODO XXX such blocks suck :(
+            // TODO XXX such blocks are bad :(
             size_t received;
             {
                 std::lock_guard< std::mutex > lock( m_receivedMutex );

--- a/libskale/CMakeLists.txt
+++ b/libskale/CMakeLists.txt
@@ -10,6 +10,7 @@ set(sources
     SkaleDebug.cpp
     ConsensusGasPricer.cpp
     SnapshotManager.cpp
+    SnapshotHashAgent.cpp
 )
 
 set(headers
@@ -21,6 +22,7 @@ set(headers
     SkaleDebug.h
     ConsensusGasPricer.h
     SnapshotManager.h
+    SnapshotHashAgent.h
 )
 
 add_library(skale ${sources} ${headers})

--- a/libskale/SnapshotHashAgent.cpp
+++ b/libskale/SnapshotHashAgent.cpp
@@ -95,16 +95,14 @@ std::vector< std::string > SnapshotHashAgent::getNodesToDownloadSnapshotFrom(
 
                 this->hashes_[i] = dev::h256( str_hash );
             } catch ( std::exception& ex ) {
-                std::cerr << cc::fatal( "FATAL:" )
-                          << cc::error(
-                                 " Exception while collecting snapshot hash from other skaleds: " )
+                std::cerr << cc::error(
+                                 "Exception while collecting snapshot hash from other skaleds: " )
                           << cc::warn( ex.what() ) << "\n";
             }
         } ) );
     }
 
     for ( auto& thr : threads ) {
-        std::cout << "WAITING FOR THREAD TO JOIN " << thr.get_id() << '\n';
         thr.join();
     }
 
@@ -123,5 +121,6 @@ std::vector< std::string > SnapshotHashAgent::getNodesToDownloadSnapshotFrom(
 }
 
 dev::h256 SnapshotHashAgent::getVotedHash() const {
+    assert( voted_hash_ != dev::h256() );
     return this->voted_hash_;
 }

--- a/libskale/SnapshotHashAgent.cpp
+++ b/libskale/SnapshotHashAgent.cpp
@@ -27,7 +27,7 @@
 #include <libethcore/CommonJS.h>
 #include <skutils/rest_call.h>
 
-unsigned SnapshotHashAgent::getBlockNumber(const std::string& strURLWeb3) {
+unsigned SnapshotHashAgent::getBlockNumber( const std::string& strURLWeb3 ) {
     skutils::rest::client cli;
     if ( !cli.open( strURLWeb3 ) ) {
         throw std::runtime_error( "REST failed to connect to server" );
@@ -49,18 +49,18 @@ unsigned SnapshotHashAgent::getBlockNumber(const std::string& strURLWeb3) {
 }
 
 dev::h256 SnapshotHashAgent::voteForHash() const {
-    std::map<dev::h256, size_t> map_hash;
-    for (const auto& hash : this->hashes_) {
+    std::map< dev::h256, size_t > map_hash;
+    for ( const auto& hash : this->hashes_ ) {
         map_hash[hash] += 1;
     }
 
-    for (const auto& hash : map_hash) {
-        if (3 * hash.second > 2 * (n_ + 2)) {
+    for ( const auto& hash : map_hash ) {
+        if ( 3 * hash.second > 2 * ( n_ + 2 ) ) {
             return hash.first;
         }
     }
 
-    throw std::logic_error("note enough votes to choose hash");
+    throw std::logic_error( "note enough votes to choose hash" );
 }
 
 void SnapshotHashAgent::getHashFromOthers() const {

--- a/libskale/SnapshotHashAgent.cpp
+++ b/libskale/SnapshotHashAgent.cpp
@@ -116,6 +116,7 @@ std::vector< std::string > SnapshotHashAgent::getNodesToDownloadSnapshotFrom(
             std::string( "http://" ) + std::string( this->chain_params_.sChain.nodes[idx].ip ) +
             std::string( ":" ) +
             ( this->chain_params_.sChain.nodes[idx].port + 3 ).convert_to< std::string >();
+        ret.push_back( ret_value );
     }
 
     return ret;

--- a/libskale/SnapshotHashAgent.cpp
+++ b/libskale/SnapshotHashAgent.cpp
@@ -1,0 +1,69 @@
+/*
+    Copyright (C) 2019-present, SKALE Labs
+
+    This file is part of skaled.
+
+    skaled is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skaled is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with skaled.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @file SnapshotHashAgent.cpp
+ * @author oleh Nikolaiev
+ * @date 2019
+ */
+
+#include "SnapshotHashAgent.h"
+
+#include <libethcore/CommonJS.h>
+#include <skutils/rest_call.h>
+
+unsigned SnapshotHashAgent::getBlockNumber(const std::string& strURLWeb3) {
+    skutils::rest::client cli;
+    if ( !cli.open( strURLWeb3 ) ) {
+        throw std::runtime_error( "REST failed to connect to server" );
+    }
+
+    nlohmann::json joIn = nlohmann::json::object();
+    joIn["jsonrpc"] = "2.0";
+    joIn["method"] = "eth_blockNumber";
+    joIn["params"] = nlohmann::json::object();
+    skutils::rest::data_t d = cli.call( joIn );
+    if ( d.empty() ) {
+        throw std::runtime_error( "cannot get blockNumber to download snapshot" );
+    }
+    nlohmann::json joAnswer = nlohmann::json::parse( d.s_ );
+    this->block_number_ = dev::eth::jsToBlockNumber( joAnswer["result"].get< std::string >() );
+    this->block_number_ -= this->block_number_ % this->chain_params_.nodeInfo.snapshotInterval;
+
+    return this->block_number_;
+}
+
+dev::h256 SnapshotHashAgent::voteForHash() const {
+    std::map<dev::h256, size_t> map_hash;
+    for (const auto& hash : this->hashes_) {
+        map_hash[hash] += 1;
+    }
+
+    for (const auto& hash : map_hash) {
+        if (3 * hash.second > 2 * (n_ + 2)) {
+            return hash.first;
+        }
+    }
+
+    throw std::logic_error("note enough votes to choose hash");
+}
+
+void SnapshotHashAgent::getHashFromOthers() const {
+    int a = 2 + 2;
+    a *= 2;
+}

--- a/libskale/SnapshotHashAgent.h
+++ b/libskale/SnapshotHashAgent.h
@@ -50,6 +50,7 @@ private:
     std::vector< dev::h256 > hashes_;
     std::vector< size_t > nodes_to_download_snapshot_from_;
     unsigned idx_;
+    std::mutex hashes_mutex;
 };
 
 #endif  // SNAPSHOTHASHAGENT_H

--- a/libskale/SnapshotHashAgent.h
+++ b/libskale/SnapshotHashAgent.h
@@ -1,0 +1,47 @@
+/*
+    Copyright (C) 2019-present, SKALE Labs
+
+    This file is part of skaled.
+
+    skaled is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    skaled is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with skaled.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @file SnapshotHashAgent.h
+ * @author oleh Nikolaiev
+ * @date 2019
+ */
+
+#ifndef SNAPSHOTHASHAGENT_H
+#define SNAPSHOTHASHAGENT_H
+
+#include <libethereum/ChainParams.h>
+
+class SnapshotHashAgent {
+public:
+    SnapshotHashAgent( const dev::eth::ChainParams& chain_params ) : chain_params_(chain_params), n_(chain_params.sChain.nodes.size()) {}
+
+    unsigned getBlockNumber(const std::string& strURLWeb3);
+
+    void getHashFromOthers() const;
+
+    dev::h256 voteForHash() const;
+private:
+    unsigned block_number_;
+    unsigned n_;
+    dev::eth::ChainParams chain_params_;
+    std::vector<dev::h256> hashes_;
+    std::vector<size_t> nodes_to_download_snapshot_;
+};
+
+#endif // SNAPSHOTHASHAGENT_H

--- a/libskale/SnapshotHashAgent.h
+++ b/libskale/SnapshotHashAgent.h
@@ -30,27 +30,24 @@
 class SnapshotHashAgent {
 public:
     SnapshotHashAgent( const dev::eth::ChainParams& chain_params )
-        : chain_params_( chain_params ), n_( chain_params.sChain.nodes.size() ), idx_( 0 ) {
+        : chain_params_( chain_params ), n_( chain_params.sChain.nodes.size() ) {
         this->hashes_.resize( n_ );
     }
 
-    unsigned getBlockNumber( const std::string& strURLWeb3 );
+    std::vector< std::string > getNodesToDownloadSnapshotFrom( unsigned block_number );
 
-    void getHashFromOthers();
-
-    dev::h256 voteForHash();
-
-    std::string getNodeToDownloadSnapshotFrom();
+    dev::h256 getVotedHash() const;
 
 private:
     dev::eth::ChainParams chain_params_;
     unsigned n_;
 
-    unsigned block_number_;
     std::vector< dev::h256 > hashes_;
     std::vector< size_t > nodes_to_download_snapshot_from_;
-    unsigned idx_;
     std::mutex hashes_mutex;
+
+    dev::h256 voteForHash();
+    dev::h256 voted_hash_;
 };
 
 #endif  // SNAPSHOTHASHAGENT_H

--- a/libskale/SnapshotHashAgent.h
+++ b/libskale/SnapshotHashAgent.h
@@ -18,7 +18,7 @@
 */
 /**
  * @file SnapshotHashAgent.h
- * @author oleh Nikolaiev
+ * @author Oleh Nikolaiev
  * @date 2019
  */
 

--- a/libskale/SnapshotHashAgent.h
+++ b/libskale/SnapshotHashAgent.h
@@ -30,20 +30,26 @@
 class SnapshotHashAgent {
 public:
     SnapshotHashAgent( const dev::eth::ChainParams& chain_params )
-        : chain_params_( chain_params ), n_( chain_params.sChain.nodes.size() ) {}
+        : chain_params_( chain_params ), n_( chain_params.sChain.nodes.size() ), idx_( 0 ) {
+        this->hashes_.resize( n_ );
+    }
 
     unsigned getBlockNumber( const std::string& strURLWeb3 );
 
-    void getHashFromOthers() const;
+    void getHashFromOthers();
 
-    dev::h256 voteForHash() const;
+    dev::h256 voteForHash();
+
+    std::string getNodeToDownloadSnapshotFrom();
 
 private:
-    unsigned block_number_;
-    unsigned n_;
     dev::eth::ChainParams chain_params_;
+    unsigned n_;
+
+    unsigned block_number_;
     std::vector< dev::h256 > hashes_;
-    std::vector< size_t > nodes_to_download_snapshot_;
+    std::vector< size_t > nodes_to_download_snapshot_from_;
+    unsigned idx_;
 };
 
 #endif  // SNAPSHOTHASHAGENT_H

--- a/libskale/SnapshotHashAgent.h
+++ b/libskale/SnapshotHashAgent.h
@@ -29,19 +29,21 @@
 
 class SnapshotHashAgent {
 public:
-    SnapshotHashAgent( const dev::eth::ChainParams& chain_params ) : chain_params_(chain_params), n_(chain_params.sChain.nodes.size()) {}
+    SnapshotHashAgent( const dev::eth::ChainParams& chain_params )
+        : chain_params_( chain_params ), n_( chain_params.sChain.nodes.size() ) {}
 
-    unsigned getBlockNumber(const std::string& strURLWeb3);
+    unsigned getBlockNumber( const std::string& strURLWeb3 );
 
     void getHashFromOthers() const;
 
     dev::h256 voteForHash() const;
+
 private:
     unsigned block_number_;
     unsigned n_;
     dev::eth::ChainParams chain_params_;
-    std::vector<dev::h256> hashes_;
-    std::vector<size_t> nodes_to_download_snapshot_;
+    std::vector< dev::h256 > hashes_;
+    std::vector< size_t > nodes_to_download_snapshot_;
 };
 
-#endif // SNAPSHOTHASHAGENT_H
+#endif  // SNAPSHOTHASHAGENT_H

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -290,6 +290,15 @@ void SnapshotManager::leaveNLastDiffs( unsigned n ) {
 }
 
 dev::h256 SnapshotManager::getSnapshotHash( unsigned block_number ) const {
+    fs::path snapshot_dir = snapshots_dir / to_string( block_number );
+
+    try {
+        if ( !fs::exists( snapshot_dir ) )
+            throw SnapshotAbsent( block_number );
+    } catch ( const fs::filesystem_error& ) {
+        std::throw_with_nested( CannotRead( snapshot_dir ) );
+    }  // catch
+
     std::string hash_file =
         ( this->snapshots_dir / std::to_string( block_number ) / this->snapshot_hash_file_name )
             .string();
@@ -312,6 +321,15 @@ dev::h256 SnapshotManager::getSnapshotHash( unsigned block_number ) const {
 }
 
 bool SnapshotManager::isSnapshotHashPresent( unsigned _blockNumber ) const {
+    fs::path snapshot_dir = snapshots_dir / to_string( _blockNumber );
+
+    try {
+        if ( !fs::exists( snapshot_dir ) )
+            throw SnapshotAbsent( _blockNumber );
+    } catch ( const fs::filesystem_error& ) {
+        std::throw_with_nested( CannotRead( snapshot_dir ) );
+    }  // catch
+
     boost::filesystem::path hash_file =
         this->snapshots_dir / std::to_string( _blockNumber ) / this->snapshot_hash_file_name;
     try {

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -281,8 +281,7 @@ dev::h256 SnapshotManager::getSnapshotHash( unsigned block_number ) const {
         throw std::logic_error( "hash doesn't exist" );
     }
 
-    boost::interprocess::named_mutex m_lock(
-        boost::interprocess::open_or_create, "hashFileLockRead" );
+    boost::interprocess::named_mutex m_lock( boost::interprocess::open_or_create, "hashFileLock" );
     m_lock.lock();
 
     std::ifstream in( hash_file );
@@ -366,8 +365,7 @@ void SnapshotManager::computeSnapshotHash( unsigned _blockNumber ) const {
     dev::h256 hash;
     secp256k1_sha256_finalize( &ctx, hash.data() );
 
-    boost::interprocess::named_mutex m_lock(
-        boost::interprocess::open_or_create, "hashFileLockWrite" );
+    boost::interprocess::named_mutex m_lock( boost::interprocess::open_or_create, "hashFileLock" );
     m_lock.lock();
 
     std::ofstream out( ( this->snapshots_dir / std::to_string( _blockNumber ) ).string() + '/' +

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -272,7 +272,7 @@ void SnapshotManager::leaveNLastDiffs( unsigned n ) {
     }      // for
 }
 
-dev::h256 SnapshotManager::getSnapshotHash( unsigned block_number ) {
+dev::h256 SnapshotManager::getSnapshotHash( unsigned block_number ) const {
     std::string hash_file =
         ( this->snapshots_dir / std::to_string( block_number ) / this->snapshot_hash_file_name )
             .string();
@@ -295,14 +295,14 @@ dev::h256 SnapshotManager::getSnapshotHash( unsigned block_number ) {
     return hash;
 }
 
-bool SnapshotManager::isSnapshotHashPresent( unsigned _blockNumber ) {
+bool SnapshotManager::isSnapshotHashPresent( unsigned _blockNumber ) const {
     boost::filesystem::path hash_file =
         this->snapshots_dir / std::to_string( _blockNumber ) / this->snapshot_hash_file_name;
     return boost::filesystem::exists( hash_file );
 }
 
 void SnapshotManager::computeVolumeHash(
-    const boost::filesystem::path& _volumeDir, secp256k1_sha256_t* ctx ) {
+    const boost::filesystem::path& _volumeDir, secp256k1_sha256_t* ctx ) const {
     if ( !boost::filesystem::exists( _volumeDir ) ) {
         throw std::logic_error(
             "btrfs volume was corrupted - folder " + _volumeDir.string() + " doesn't exist" );
@@ -314,7 +314,8 @@ void SnapshotManager::computeVolumeHash(
     secp256k1_sha256_write( ctx, hash_volume.data(), hash_volume.size );
 }
 
-void SnapshotManager::computeAllVolumesHash( unsigned _blockNumber, secp256k1_sha256_t* ctx ) {
+void SnapshotManager::computeAllVolumesHash(
+    unsigned _blockNumber, secp256k1_sha256_t* ctx ) const {
     if ( this->volumes.size() == 0 ) {
         throw std::logic_error( "No btrfs volumes present - nothing to calculate hash of" );
     }
@@ -336,7 +337,7 @@ void SnapshotManager::computeAllVolumesHash( unsigned _blockNumber, secp256k1_sh
     }
 }
 
-void SnapshotManager::computeSnapshotHash( unsigned _blockNumber ) {
+void SnapshotManager::computeSnapshotHash( unsigned _blockNumber ) const {
     secp256k1_sha256_t ctx;
     secp256k1_sha256_initialize( &ctx );
 

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -234,6 +234,17 @@ boost::filesystem::path SnapshotManager::getDiffPath( unsigned _fromBlock, unsig
     return diffs_dir / ( to_string( _fromBlock ) + "_" + to_string( _toBlock ) );
 }
 
+void SnapshotManager::removeSnapshot( unsigned _blockNumber ) {
+    for ( const auto& volume : this->volumes ) {
+        int res = btrfs.subvolume._delete(
+            ( this->snapshots_dir / std::to_string( _blockNumber ) / volume ).string().c_str() );
+
+        if ( res != 0 ) {
+            throw CannotPerformBtrfsOperation( btrfs.last_cmd(), btrfs.strerror() );
+        }
+    }
+}
+
 // exeptions: filesystem
 void SnapshotManager::leaveNLastSnapshots( unsigned n ) {
     multimap< time_t, fs::path, std::greater< time_t > > time_map;

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -235,6 +235,10 @@ boost::filesystem::path SnapshotManager::getDiffPath( unsigned _fromBlock, unsig
 }
 
 void SnapshotManager::removeSnapshot( unsigned _blockNumber ) {
+    if ( !fs::exists( snapshots_dir / to_string( _blockNumber ) ) ) {
+        throw SnapshotAbsent( _blockNumber );
+    }
+
     for ( const auto& volume : this->volumes ) {
         int res = btrfs.subvolume._delete(
             ( this->snapshots_dir / std::to_string( _blockNumber ) / volume ).string().c_str() );
@@ -289,7 +293,7 @@ dev::h256 SnapshotManager::getSnapshotHash( unsigned block_number ) const {
             .string();
 
     if ( !boost::filesystem::exists( hash_file ) ) {
-        throw std::logic_error( "hash doesn't exist" );
+        BOOST_THROW_EXCEPTION( dev::NoSuchFileOrDirectory() );
     }
 
     boost::interprocess::named_mutex m_lock( boost::interprocess::open_or_create, "hashFileLock" );

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -328,6 +328,14 @@ void SnapshotManager::computeVolumeHash(
     secp256k1_sha256_write( ctx, hash_volume.data(), hash_volume.size );
 }
 
+void SnapshotManager::computeFileSystemHash(
+    const boost::filesystem::path& _fileSystemDir, secp256k1_sha256_t* ctx ) const {
+    if ( !boost::filesystem::exists( _fileSystemDir ) ) {
+        throw std::logic_error( "filestorage btrfs subvolume was corrupted - " +
+                                _fileSystemDir.string() + " doesn't exist" );
+    }
+}
+
 void SnapshotManager::computeAllVolumesHash(
     unsigned _blockNumber, secp256k1_sha256_t* ctx ) const {
     if ( this->volumes.size() == 0 ) {
@@ -344,6 +352,9 @@ void SnapshotManager::computeAllVolumesHash(
 
     this->computeVolumeHash(
         this->snapshots_dir / std::to_string( _blockNumber ) / this->volumes[0] / "blocks", ctx );
+
+    this->computeFileSystemHash(
+        this->snapshots_dir / std::to_string( _blockNumber ) / "filestorage", ctx );
 
     for ( size_t i = 1; i < this->volumes.size(); ++i ) {
         this->computeVolumeHash(

--- a/libskale/SnapshotManager.h
+++ b/libskale/SnapshotManager.h
@@ -159,6 +159,8 @@ private:
     boost::filesystem::path diffs_dir;
     const std::string snapshot_hash_file_name = "snapshot_hash.txt";
 
+    void computeFileSystemHash(
+        const boost::filesystem::path& _fileSystemDir, secp256k1_sha256_t* ctx ) const;
     void computeAllVolumesHash( unsigned _blockNumber, secp256k1_sha256_t* ctx ) const;
     void computeVolumeHash(
         const boost::filesystem::path& _volumeDir, secp256k1_sha256_t* ctx ) const;

--- a/libskale/SnapshotManager.h
+++ b/libskale/SnapshotManager.h
@@ -143,6 +143,7 @@ public:
     boost::filesystem::path makeOrGetDiff( unsigned _fromBlock, unsigned _toBlock );
     void importDiff( unsigned _fromBlock, unsigned _toBlock );
     boost::filesystem::path getDiffPath( unsigned _fromBlock, unsigned _toBlock );
+    void removeSnapshot( unsigned _blockNumber );
 
     void leaveNLastSnapshots( unsigned n );
     void leaveNLastDiffs( unsigned n );

--- a/libskale/SnapshotManager.h
+++ b/libskale/SnapshotManager.h
@@ -29,6 +29,8 @@
 #include <secp256k1_sha256.h>
 
 #include <boost/filesystem.hpp>
+
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -150,14 +152,16 @@ public:
 
     dev::h256 getSnapshotHash( unsigned _blockNumber ) const;
     bool isSnapshotHashPresent( unsigned _blockNumber ) const;
-    void computeSnapshotHash( unsigned _blockNumber ) const;
+    void computeSnapshotHash( unsigned _blockNumber );
 
 private:
     boost::filesystem::path data_dir;
     std::vector< std::string > volumes;
     boost::filesystem::path snapshots_dir;
     boost::filesystem::path diffs_dir;
-    const std::string snapshot_hash_file_name = "snapshot_hash.txt";
+
+    static const std::string snapshot_hash_file_name;
+    mutable std::mutex hash_file_mutex;
 
     void computeAllVolumesHash( unsigned _blockNumber, secp256k1_sha256_t* ctx ) const;
     void computeVolumeHash(

--- a/libskale/SnapshotManager.h
+++ b/libskale/SnapshotManager.h
@@ -147,19 +147,20 @@ public:
     void leaveNLastSnapshots( unsigned n );
     void leaveNLastDiffs( unsigned n );
 
-    dev::h256 getSnapshotHash( unsigned _blockNumber );
-    bool isSnapshotHashPresent( unsigned _blockNumber );
-    void computeSnapshotHash( unsigned _blockNumber );
+    dev::h256 getSnapshotHash( unsigned _blockNumber ) const;
+    bool isSnapshotHashPresent( unsigned _blockNumber ) const;
+    void computeSnapshotHash( unsigned _blockNumber ) const;
 
 private:
     boost::filesystem::path data_dir;
     std::vector< std::string > volumes;
     boost::filesystem::path snapshots_dir;
     boost::filesystem::path diffs_dir;
-    std::string snapshot_hash_file_name = "snapshot_hash.txt";
+    const std::string snapshot_hash_file_name = "snapshot_hash.txt";
 
-    void computeAllVolumesHash( unsigned _blockNumber, secp256k1_sha256_t* ctx );
-    void computeVolumeHash( const boost::filesystem::path& _volumeDir, secp256k1_sha256_t* ctx );
+    void computeAllVolumesHash( unsigned _blockNumber, secp256k1_sha256_t* ctx ) const;
+    void computeVolumeHash(
+        const boost::filesystem::path& _volumeDir, secp256k1_sha256_t* ctx ) const;
 };
 
 #endif  // SNAPSHOTAGENT_H

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -268,8 +268,29 @@ Json::Value Skale::skale_downloadSnapshotFragment( const Json::Value& request ) 
     }
 }
 
+nlohmann::json Skale::impl_skale_getSnapshotHash( const nlohmann::json& joRequest, Client& client) {
+    nlohmann::json joResponse = nlohmann::json::object();
+
+    unsigned blockNumber = joRequest["blockNumber"].get< unsigned >();
+    dev::h256 snapshot_hash = client.getSnapshotHash( blockNumber );
+       
+    joResponse["snapshotHash"] = snapshot_hash.hex();
+    return joResponse;
+}
+
 Json::Value Skale::skale_getSnapshotHash( const Json::Value& request ) {
-    return request;
+    try {
+        Json::FastWriter fastWriter;
+        std::string strRequest = fastWriter.write( request );
+        nlohmann::json joRequest = nlohmann::json::parse( strRequest );
+        nlohmann::json joResponse = impl_skale_getSnapshotHash( joRequest, this->m_client );
+        std::string strResponse = joResponse.dump();
+        Json::Value response;
+        Json::Reader().parse( strResponse, response );
+        return response;
+    } catch ( Exception const& ) {
+        throw jsonrpc::JsonRpcException( exceptionToErrorMessage() );
+    }
 }
 
 namespace snapshot {

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -272,7 +272,7 @@ std::string Skale::skale_getSnapshotHash( unsigned blockNumber ) {
     try {
         dev::h256 snapshot_hash = this->m_client.getSnapshotHash( blockNumber );
         return snapshot_hash.hex();
-    } catch ( Exception const& ) {
+    } catch ( const std::exception& ) {
         throw jsonrpc::JsonRpcException( exceptionToErrorMessage() );
     }
 }

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -268,27 +268,10 @@ Json::Value Skale::skale_downloadSnapshotFragment( const Json::Value& request ) 
     }
 }
 
-nlohmann::json Skale::impl_skale_getSnapshotHash(
-    const nlohmann::json& joRequest, const Client& client ) {
-    nlohmann::json joResponse = nlohmann::json::object();
-
-    unsigned blockNumber = joRequest["blockNumber"].get< unsigned >();
-    dev::h256 snapshot_hash = client.getSnapshotHash( blockNumber );
-
-    joResponse["snapshotHash"] = snapshot_hash.hex();
-    return joResponse;
-}
-
-Json::Value Skale::skale_getSnapshotHash( const Json::Value& request ) {
+std::string Skale::skale_getSnapshotHash( unsigned blockNumber ) {
     try {
-        Json::FastWriter fastWriter;
-        std::string strRequest = fastWriter.write( request );
-        nlohmann::json joRequest = nlohmann::json::parse( strRequest );
-        nlohmann::json joResponse = impl_skale_getSnapshotHash( joRequest, this->m_client );
-        std::string strResponse = joResponse.dump();
-        Json::Value response;
-        Json::Reader().parse( strResponse, response );
-        return response;
+        dev::h256 snapshot_hash = this->m_client.getSnapshotHash( blockNumber );
+        return snapshot_hash.hex();
     } catch ( Exception const& ) {
         throw jsonrpc::JsonRpcException( exceptionToErrorMessage() );
     }

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -268,12 +268,13 @@ Json::Value Skale::skale_downloadSnapshotFragment( const Json::Value& request ) 
     }
 }
 
-nlohmann::json Skale::impl_skale_getSnapshotHash( const nlohmann::json& joRequest, Client& client) {
+nlohmann::json Skale::impl_skale_getSnapshotHash(
+    const nlohmann::json& joRequest, Client& client ) {
     nlohmann::json joResponse = nlohmann::json::object();
 
     unsigned blockNumber = joRequest["blockNumber"].get< unsigned >();
     dev::h256 snapshot_hash = client.getSnapshotHash( blockNumber );
-       
+
     joResponse["snapshotHash"] = snapshot_hash.hex();
     return joResponse;
 }

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -268,6 +268,10 @@ Json::Value Skale::skale_downloadSnapshotFragment( const Json::Value& request ) 
     }
 }
 
+Json::Value Skale::skale_getSnapshotHash( const Json::Value& request ) {
+    return request;
+}
+
 namespace snapshot {
 
 bool download( const std::string& strURLWeb3, unsigned& block_number, const fs::path& saveTo,

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -269,7 +269,7 @@ Json::Value Skale::skale_downloadSnapshotFragment( const Json::Value& request ) 
 }
 
 nlohmann::json Skale::impl_skale_getSnapshotHash(
-    const nlohmann::json& joRequest, Client& client ) {
+    const nlohmann::json& joRequest, const Client& client ) {
     nlohmann::json joResponse = nlohmann::json::object();
 
     unsigned blockNumber = joRequest["blockNumber"].get< unsigned >();

--- a/libweb3jsonrpc/Skale.h
+++ b/libweb3jsonrpc/Skale.h
@@ -65,6 +65,7 @@ public:
     std::string skale_shutdownInstance() noexcept( false ) override;
     Json::Value skale_getSnapshot( const Json::Value& request ) override;
     Json::Value skale_downloadSnapshotFragment( const Json::Value& request ) override;
+    Json::Value skale_getSnapshotHash( const Json::Value& request ) override;
 
     static bool isWeb3ShutdownEnabled();
     static void enableWeb3Shutdown( bool bEnable = true );

--- a/libweb3jsonrpc/Skale.h
+++ b/libweb3jsonrpc/Skale.h
@@ -83,7 +83,7 @@ public:
         const nlohmann::json& joRequest );
     nlohmann::json impl_skale_downloadSnapshotFragmentJSON( const nlohmann::json& joRequest );
     nlohmann::json impl_skale_getSnapshotHash(
-        const nlohmann::json& joRequest, dev::eth::Client& client );
+        const nlohmann::json& joRequest, const dev::eth::Client& client );
 
 private:
     static volatile bool g_bShutdownViaWeb3Enabled;

--- a/libweb3jsonrpc/Skale.h
+++ b/libweb3jsonrpc/Skale.h
@@ -65,7 +65,7 @@ public:
     std::string skale_shutdownInstance() noexcept( false ) override;
     Json::Value skale_getSnapshot( const Json::Value& request ) override;
     Json::Value skale_downloadSnapshotFragment( const Json::Value& request ) override;
-    Json::Value skale_getSnapshotHash( const Json::Value& request ) override;
+    std::string skale_getSnapshotHash( unsigned blockNumber ) override;
 
     static bool isWeb3ShutdownEnabled();
     static void enableWeb3Shutdown( bool bEnable = true );
@@ -82,8 +82,6 @@ public:
     std::vector< uint8_t > impl_skale_downloadSnapshotFragmentBinary(
         const nlohmann::json& joRequest );
     nlohmann::json impl_skale_downloadSnapshotFragmentJSON( const nlohmann::json& joRequest );
-    nlohmann::json impl_skale_getSnapshotHash(
-        const nlohmann::json& joRequest, const dev::eth::Client& client );
 
 private:
     static volatile bool g_bShutdownViaWeb3Enabled;

--- a/libweb3jsonrpc/Skale.h
+++ b/libweb3jsonrpc/Skale.h
@@ -82,7 +82,8 @@ public:
     std::vector< uint8_t > impl_skale_downloadSnapshotFragmentBinary(
         const nlohmann::json& joRequest );
     nlohmann::json impl_skale_downloadSnapshotFragmentJSON( const nlohmann::json& joRequest );
-    nlohmann::json impl_skale_getSnapshotHash( const nlohmann::json& joRequest, dev::eth::Client& client );
+    nlohmann::json impl_skale_getSnapshotHash(
+        const nlohmann::json& joRequest, dev::eth::Client& client );
 
 private:
     static volatile bool g_bShutdownViaWeb3Enabled;

--- a/libweb3jsonrpc/Skale.h
+++ b/libweb3jsonrpc/Skale.h
@@ -82,6 +82,7 @@ public:
     std::vector< uint8_t > impl_skale_downloadSnapshotFragmentBinary(
         const nlohmann::json& joRequest );
     nlohmann::json impl_skale_downloadSnapshotFragmentJSON( const nlohmann::json& joRequest );
+    nlohmann::json impl_skale_getSnapshotHash( const nlohmann::json& joRequest, dev::eth::Client& client );
 
 private:
     static volatile bool g_bShutdownViaWeb3Enabled;

--- a/libweb3jsonrpc/SkaleFace.h
+++ b/libweb3jsonrpc/SkaleFace.h
@@ -59,7 +59,7 @@ class SkaleFace : public ServerInterface< SkaleFace > {
 
     inline virtual void skale_getSnapshotHashI(
         const Json::Value& request, Json::Value& response ) {
-        unsigned blockNumber = request["blockNumber"].asInt();
+        unsigned blockNumber = request[0u].asInt();
         response = this->skale_getSnapshotHash( blockNumber );
     }
 
@@ -93,7 +93,7 @@ public:
             &dev::rpc::SkaleFace::skale_downloadSnapshotFragmentI );
         this->bindAndAddMethod(
             jsonrpc::Procedure( "skale_getSnapshotHash", jsonrpc::PARAMS_BY_POSITION,
-                jsonrpc::JSON_INTEGER, jsonrpc::JSON_STRING, NULL ),
+                jsonrpc::JSON_STRING, "param1", jsonrpc::JSON_INTEGER, NULL ),
             &dev::rpc::SkaleFace::skale_getSnapshotHashI );
     }
 };

--- a/libweb3jsonrpc/SkaleFace.h
+++ b/libweb3jsonrpc/SkaleFace.h
@@ -57,11 +57,17 @@ class SkaleFace : public ServerInterface< SkaleFace > {
         response = this->skale_downloadSnapshotFragment( request );
     }
 
+    inline virtual void skale_getSnapshotHashI(
+        const Json::Value& request, Json::Value& response ) {
+        response = this->skale_getSnapshotHash( request );
+    }
+
     virtual std::string skale_protocolVersion() = 0;
     virtual std::string skale_receiveTransaction( std::string const& _rlp ) = 0;
     virtual std::string skale_shutdownInstance() = 0;
     virtual Json::Value skale_getSnapshot( const Json::Value& request ) = 0;
     virtual Json::Value skale_downloadSnapshotFragment( const Json::Value& request ) = 0;
+    virtual Json::Value skale_getSnapshotHash( const Json::Value& request ) = 0;
 
 public:
     SkaleFace() {
@@ -84,6 +90,9 @@ public:
         this->bindAndAddMethod( jsonrpc::Procedure( "skale_downloadSnapshotFragment",
                                     jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, NULL ),
             &dev::rpc::SkaleFace::skale_downloadSnapshotFragmentI );
+        this->bindAndAddMethod( jsonrpc::Procedure( "skale_getSnapshotHash",
+                                    jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_INTEGER, NULL ),
+            &dev::rpc::SkaleFace::skale_getSnapshotHashI );
     }
 };
 

--- a/libweb3jsonrpc/SkaleFace.h
+++ b/libweb3jsonrpc/SkaleFace.h
@@ -59,7 +59,8 @@ class SkaleFace : public ServerInterface< SkaleFace > {
 
     inline virtual void skale_getSnapshotHashI(
         const Json::Value& request, Json::Value& response ) {
-        response = this->skale_getSnapshotHash( request );
+        unsigned blockNumber = request["blockNumber"].asInt();
+        response = this->skale_getSnapshotHash( blockNumber );
     }
 
     virtual std::string skale_protocolVersion() = 0;
@@ -67,7 +68,7 @@ class SkaleFace : public ServerInterface< SkaleFace > {
     virtual std::string skale_shutdownInstance() = 0;
     virtual Json::Value skale_getSnapshot( const Json::Value& request ) = 0;
     virtual Json::Value skale_downloadSnapshotFragment( const Json::Value& request ) = 0;
-    virtual Json::Value skale_getSnapshotHash( const Json::Value& request ) = 0;
+    virtual std::string skale_getSnapshotHash( unsigned blockNumber ) = 0;
 
 public:
     SkaleFace() {
@@ -90,8 +91,9 @@ public:
         this->bindAndAddMethod( jsonrpc::Procedure( "skale_downloadSnapshotFragment",
                                     jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, NULL ),
             &dev::rpc::SkaleFace::skale_downloadSnapshotFragmentI );
-        this->bindAndAddMethod( jsonrpc::Procedure( "skale_getSnapshotHash",
-                                    jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_INTEGER, NULL ),
+        this->bindAndAddMethod(
+            jsonrpc::Procedure( "skale_getSnapshotHash", jsonrpc::PARAMS_BY_POSITION,
+                jsonrpc::JSON_INTEGER, jsonrpc::JSON_STRING, NULL ),
             &dev::rpc::SkaleFace::skale_getSnapshotHashI );
     }
 };

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1092,7 +1092,7 @@ int main( int argc, char** argv ) try {
         } catch ( std::exception& ex ) {
             std::cerr << cc::fatal( "FATAL:" )
                       << cc::error(
-                             " Exception while collecting snapshot hash from other skaleds: " )
+                             " Exception while voting for snapshot hash from other skaleds: " )
                       << cc::warn( ex.what() ) << "\n";
         }
 

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1076,7 +1076,15 @@ int main( int argc, char** argv ) try {
         std::unique_ptr< SnapshotHashAgent > snapshotHashAgent;
         snapshotHashAgent.reset( new SnapshotHashAgent( chainParams ) );
         unsigned blockNumber = snapshotHashAgent->getBlockNumber( strURLWeb3 );
-        snapshotHashAgent->getHashFromOthers();
+
+        try {
+            snapshotHashAgent->getHashFromOthers();
+        } catch ( std::exception& ex ) {
+            std::cerr << cc::fatal( "FATAL:" )
+                      << cc::error(
+                             " Exception while collecting snapshot hash from other skaleds: " )
+                      << cc::warn( ex.what() ) << "\n";
+        }
 
         dev::h256 voted_hash;
         try {

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -277,8 +277,9 @@ void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >
                   << cc::u( to_string( block_number ) ) << std::endl;
 
     } catch ( ... ) {
-        std::throw_with_nested( std::runtime_error(
-                                    cc::fatal( "FATAL:" ) + " " + cc::error( "Exception while processing downloaded snapshot: " ) ) );
+        std::throw_with_nested(
+            std::runtime_error( cc::fatal( "FATAL:" ) + " " +
+                                cc::error( "Exception while processing downloaded snapshot: " ) ) );
     }
     if ( !saveTo.empty() )
         fs::remove( saveTo );

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1096,8 +1096,7 @@ int main( int argc, char** argv ) try {
                       << cc::warn( ex.what() ) << "\n";
         }
 
-        dev::h256 calculated_hash;
-        for ( ; calculated_hash != voted_hash; ) {
+        while ( true ) {
             std::string urlToDownloadSnapshot;
             try {
                 urlToDownloadSnapshot = snapshotHashAgent->getNodeToDownloadSnapshotFrom();
@@ -1112,7 +1111,13 @@ int main( int argc, char** argv ) try {
 
             snapshotManager->computeSnapshotHash( blockNumber );
 
-            calculated_hash = snapshotManager->getSnapshotHash( blockNumber );
+            dev::h256 calculated_hash = snapshotManager->getSnapshotHash( blockNumber );
+
+            if ( calculated_hash == voted_hash ) {
+                break;
+            } else {
+                snapshotManager->removeSnapshot( blockNumber );
+            }
         }
     }
 

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -71,8 +71,8 @@
 
 #include <libp2p/Network.h>
 
-#include <libskale/httpserveroverride.h>
 #include <libskale/SnapshotHashAgent.h>
+#include <libskale/httpserveroverride.h>
 
 #include "../libdevcore/microprofile.h"
 
@@ -189,7 +189,8 @@ void removeEmptyOptions( po::parsed_options& parsed ) {
         parsed.options.end() );
 }
 
-void downloadSnapshot(unsigned block_number, std::shared_ptr<SnapshotManager>& snapshotManager, const std::string& strURLWeb3, const ChainParams& chainParams) {
+void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >& snapshotManager,
+    const std::string& strURLWeb3, const ChainParams& chainParams ) {
     fs::path saveTo;
     try {
         std::cout << cc::normal( "Will download snapshot from " ) << cc::u( strURLWeb3 )
@@ -256,8 +257,8 @@ void downloadSnapshot(unsigned block_number, std::shared_ptr<SnapshotManager>& s
             return;
         }
         // TODO hope it won't throw
-        fs::rename( price_db_path, price_db_path.parent_path() /
-                                       ( "prices_" + chainParams.nodeInfo.id.str() + ".db" ) );
+        fs::rename( price_db_path,
+            price_db_path.parent_path() / ( "prices_" + chainParams.nodeInfo.id.str() + ".db" ) );
         //// HACK END ////
 
         snapshotManager->restoreSnapshot( block_number );
@@ -1072,20 +1073,21 @@ int main( int argc, char** argv ) try {
 
     if ( vm.count( "download-snapshot" ) ) {
         std::string strURLWeb3 = vm["download-snapshot"].as< string >();
-        std::unique_ptr<SnapshotHashAgent> snapshotHashAgent;
-        snapshotHashAgent.reset( new SnapshotHashAgent(chainParams));
-        unsigned blockNumber = snapshotHashAgent->getBlockNumber(strURLWeb3);
+        std::unique_ptr< SnapshotHashAgent > snapshotHashAgent;
+        snapshotHashAgent.reset( new SnapshotHashAgent( chainParams ) );
+        unsigned blockNumber = snapshotHashAgent->getBlockNumber( strURLWeb3 );
         snapshotHashAgent->getHashFromOthers();
 
         try {
             dev::h256 voted_hash = snapshotHashAgent->voteForHash();
         } catch ( std::exception& ex ) {
             std::cerr << cc::fatal( "FATAL:" )
-                      << cc::error( " Exception while collecting snapshot hash from other skaleds: " )
+                      << cc::error(
+                             " Exception while collecting snapshot hash from other skaleds: " )
                       << cc::warn( ex.what() ) << "\n";
         }
 
-        downloadSnapshot(blockNumber, snapshotManager, strURLWeb3, chainParams);
+        downloadSnapshot( blockNumber, snapshotManager, strURLWeb3, chainParams );
 
         snapshotManager->computeSnapshotHash( blockNumber );
         dev::h256 calculated_hash = snapshotManager->getSnapshotHash( blockNumber );

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -189,7 +189,8 @@ void removeEmptyOptions( po::parsed_options& parsed ) {
         parsed.options.end() );
 }
 
-unsigned getBlockNumber( const std::string& strURLWeb3, const ChainParams& chain_params ) {
+unsigned getLatestSnapshotBlockNumber(
+    const std::string& strURLWeb3, const ChainParams& chain_params ) {
     skutils::rest::client cli;
     if ( !cli.open( strURLWeb3 ) ) {
         throw std::runtime_error( "REST failed to connect to server" );
@@ -237,34 +238,22 @@ void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >
                     strErrorDescription = "download failed, connection problem during download";
                 throw std::runtime_error( strErrorDescription );
             }
-        } catch ( const std::exception& ex ) {
-            std::cerr << cc::fatal( "FATAL:" )
-                      << cc::error( " Exception while downloading snapshot: " )
-                      << cc::warn( ex.what() ) << "\n";
-            throw;
         } catch ( ... ) {
-            std::cerr << cc::fatal( "FATAL:" )
-                      << cc::error( " Exception while downloading snapshot: " )
-                      << cc::warn( "Unknown exception" ) << "\n";
-            throw;
+            std::throw_with_nested(
+                std::runtime_error( cc::fatal( "FATAL:" ) + " " +
+                                    cc::error( "Exception while downloading snapshot" ) ) );
         }
         std::cout << cc::success( "Snapshot download success for block " )
                   << cc::u( to_string( block_number ) ) << std::endl;
         try {
             snapshotManager->importDiff( 0, block_number );
-        } catch ( const std::exception& ex ) {
-            std::cerr << cc::fatal( "FATAL:" )
-                      << cc::error( " Exception while importing downloaded snapshot: " )
-                      << cc::warn( ex.what() ) << "\n";
-            throw;
         } catch ( ... ) {
-            std::cerr << cc::fatal( "FATAL:" )
-                      << cc::error( " Exception while importing downloaded snapshot: " )
-                      << cc::warn( "Unknown exception" ) << "\n";
-            throw;
+            std::throw_with_nested( std::runtime_error(
+                cc::fatal( "FATAL:" ) + " " +
+                cc::error( "Exception while importing downloaded snapshot: " ) ) );
         }
 
-        // HACK refactor this piece of code!
+        /// HACK refactor this piece of code! ///
         fs::path price_db_path;
         for ( auto& f :
             fs::directory_iterator( getDataDir() / "snapshots" / to_string( block_number ) ) ) {
@@ -274,10 +263,11 @@ void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >
             }  // if
         }
         if ( price_db_path.empty() ) {
-            std::cout << cc::fatal( "Snapshot downloaded without prices db" ) << std::endl;
+            clog( VerbosityError, "downloadSnapshot" )
+                << cc::fatal( "Snapshot downloaded without prices db" ) << std::endl;
             return;
         }
-        // TODO hope it won't throw
+
         fs::rename( price_db_path,
             price_db_path.parent_path() / ( "prices_" + chainParams.nodeInfo.id.str() + ".db" ) );
         //// HACK END ////
@@ -286,14 +276,9 @@ void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >
         std::cout << cc::success( "Snapshot restore success for block " )
                   << cc::u( to_string( block_number ) ) << std::endl;
 
-    } catch ( const std::exception& ex ) {
-        std::cerr << cc::fatal( "FATAL:" )
-                  << cc::error( " Exception while processing downloaded snapshot: " )
-                  << cc::warn( ex.what() ) << "\n";
     } catch ( ... ) {
-        std::cerr << cc::fatal( "FATAL:" )
-                  << cc::error( " Exception while processing downloaded snapshot: " )
-                  << cc::warn( "Unknown exception" ) << "\n";
+        std::throw_with_nested( std::runtime_error(
+                                    cc::fatal( "FATAL:" ) + " " + cc::error( "Exception while processing downloaded snapshot: " ) ) );
     }
     if ( !saveTo.empty() )
         fs::remove( saveTo );
@@ -1094,22 +1079,19 @@ int main( int argc, char** argv ) try {
 
     if ( vm.count( "download-snapshot" ) ) {
         std::string strURLWeb3 = vm["download-snapshot"].as< string >();
-        const unsigned blockNumber = getBlockNumber( strURLWeb3, chainParams );
+        const unsigned blockNumber = getLatestSnapshotBlockNumber( strURLWeb3, chainParams );
 
-        std::unique_ptr< SnapshotHashAgent > snapshotHashAgent;
-        snapshotHashAgent.reset( new SnapshotHashAgent( chainParams ) );
+        SnapshotHashAgent snapshotHashAgent( chainParams );
 
         dev::h256 voted_hash;
         std::vector< std::string > list_urls_to_download;
         try {
-            list_urls_to_download =
-                snapshotHashAgent->getNodesToDownloadSnapshotFrom( blockNumber );
-            voted_hash = snapshotHashAgent->getVotedHash();
+            list_urls_to_download = snapshotHashAgent.getNodesToDownloadSnapshotFrom( blockNumber );
+            voted_hash = snapshotHashAgent.getVotedHash();
         } catch ( std::exception& ex ) {
-            std::cerr << cc::fatal( "FATAL:" )
-                      << cc::error(
-                             " Exception while collecting snapshot hash from other skaleds: " )
-                      << cc::warn( ex.what() ) << "\n";
+            std::throw_with_nested( std::runtime_error(
+                cc::fatal( "FATAL:" ) + " " +
+                cc::error( "Exception while collecting snapshot hash from other skaleds " ) ) );
         }
 
         bool successfullDownload = false;
@@ -1132,8 +1114,7 @@ int main( int argc, char** argv ) try {
         }
 
         if ( !successfullDownload ) {
-            std::cerr << cc::fatal( "FATAL:" )
-                      << cc::error( " already tried to download hash from all sources " );
+            throw std::runtime_error( "FATAL: already tried to download hash from all sources" );
         }
     }
 

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1094,9 +1094,9 @@ int main( int argc, char** argv ) try {
 
     if ( vm.count( "download-snapshot" ) ) {
         std::string strURLWeb3 = vm["download-snapshot"].as< string >();
-        std::unique_ptr< SnapshotHashAgent > snapshotHashAgent;
-        unsigned blockNumber = getBlockNumber( strURLWeb3, chainParams );
+        const unsigned blockNumber = getBlockNumber( strURLWeb3, chainParams );
 
+        std::unique_ptr< SnapshotHashAgent > snapshotHashAgent;
         snapshotHashAgent.reset( new SnapshotHashAgent( chainParams ) );
 
         dev::h256 voted_hash;
@@ -1112,7 +1112,7 @@ int main( int argc, char** argv ) try {
                       << cc::warn( ex.what() ) << "\n";
         }
 
-        bool success = false;
+        bool successfullDownload = false;
         for ( size_t i = 0; i < list_urls_to_download.size(); ++i ) {
             std::string urlToDownloadSnapshot;
             urlToDownloadSnapshot = list_urls_to_download[i];
@@ -1124,14 +1124,14 @@ int main( int argc, char** argv ) try {
             dev::h256 calculated_hash = snapshotManager->getSnapshotHash( blockNumber );
 
             if ( calculated_hash == voted_hash ) {
-                success = true;
+                successfullDownload = true;
                 break;
             } else {
                 snapshotManager->removeSnapshot( blockNumber );
             }
         }
 
-        if ( !success ) {
+        if ( !successfullDownload ) {
             std::cerr << cc::fatal( "FATAL:" )
                       << cc::error( " already tried to download hash from all sources " );
         }

--- a/test/unittests/libskale/HashSnapshot.cpp
+++ b/test/unittests/libskale/HashSnapshot.cpp
@@ -275,9 +275,11 @@ BOOST_FIXTURE_TEST_CASE( SnapshotHashingTest, SnapshotHashingFixture ) {
 
     BOOST_REQUIRE( hash2 == hash2_dbl );
 
-    BOOST_REQUIRE( !mgr->isSnapshotHashPresent( 4 ) );
+    BOOST_REQUIRE_THROW( !mgr->isSnapshotHashPresent( 4 ), SnapshotManager::SnapshotAbsent );
 
-    BOOST_REQUIRE_THROW( mgr->getSnapshotHash( 4 ), dev::NoSuchFileOrDirectory );
+    BOOST_REQUIRE_THROW( mgr->getSnapshotHash( 4 ), SnapshotManager::SnapshotAbsent );
+
+    // TODO check hash absence separately
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libskale/HashSnapshot.cpp
+++ b/test/unittests/libskale/HashSnapshot.cpp
@@ -276,6 +276,8 @@ BOOST_FIXTURE_TEST_CASE( SnapshotHashingTest, SnapshotHashingFixture ) {
     BOOST_REQUIRE( hash2 == hash2_dbl );
 
     BOOST_REQUIRE( !mgr->isSnapshotHashPresent( 4 ) );
+
+    BOOST_REQUIRE_THROW( mgr->getSnapshotHash( 4 ), dev::NoSuchFileOrDirectory );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libskale/SnapshotManager.cpp
+++ b/test/unittests/libskale/SnapshotManager.cpp
@@ -201,6 +201,12 @@ BOOST_FIXTURE_TEST_CASE( SimplePositiveTest, BtrfsFixture ) {
     BOOST_REQUIRE( fs::exists( fs::path( BTRFS_DIR_PATH ) / "vol1" / "d11" ) );
     BOOST_REQUIRE( fs::exists( fs::path( BTRFS_DIR_PATH ) / "vol1" / "d12" ) );
     BOOST_REQUIRE( !fs::exists( fs::path( BTRFS_DIR_PATH ) / "vol2" / "d21" ) );
+
+    BOOST_REQUIRE_NO_THROW( mgr.removeSnapshot( 1 ) );
+    BOOST_REQUIRE_NO_THROW( mgr.removeSnapshot( 2 ) );
+
+    BOOST_REQUIRE_THROW( mgr.removeSnapshot( 2 ), SnapshotManager::CannotPerformBtrfsOperation );
+    BOOST_REQUIRE_THROW( mgr.removeSnapshot( 3 ), SnapshotManager::CannotPerformBtrfsOperation );
 }
 
 BOOST_FIXTURE_TEST_CASE( NoBtrfsTest, NoBtrfsFixture ) {

--- a/test/unittests/libskale/SnapshotManager.cpp
+++ b/test/unittests/libskale/SnapshotManager.cpp
@@ -204,9 +204,6 @@ BOOST_FIXTURE_TEST_CASE( SimplePositiveTest, BtrfsFixture ) {
 
     BOOST_REQUIRE_NO_THROW( mgr.removeSnapshot( 1 ) );
     BOOST_REQUIRE_NO_THROW( mgr.removeSnapshot( 2 ) );
-
-    BOOST_REQUIRE_THROW( mgr.removeSnapshot( 2 ), SnapshotManager::CannotPerformBtrfsOperation );
-    BOOST_REQUIRE_THROW( mgr.removeSnapshot( 3 ), SnapshotManager::CannotPerformBtrfsOperation );
 }
 
 BOOST_FIXTURE_TEST_CASE( NoBtrfsTest, NoBtrfsFixture ) {
@@ -417,6 +414,19 @@ BOOST_FIXTURE_TEST_CASE( DiffRotationTest, BtrfsFixture ) {
     BOOST_REQUIRE( !fs::exists( fs::path( BTRFS_DIR_PATH ) / "diffs" / "1_2" ) );
     BOOST_REQUIRE( fs::exists( fs::path( BTRFS_DIR_PATH ) / "diffs" / "1_3" ) );
     BOOST_REQUIRE( fs::exists( fs::path( BTRFS_DIR_PATH ) / "diffs" / "1_4" ) );
+}
+
+BOOST_FIXTURE_TEST_CASE( RemoveSnapshotTest, BtrfsFixture ) {
+    SnapshotManager mgr( fs::path( BTRFS_DIR_PATH ), {"vol1", "vol2"} );
+
+    mgr.doSnapshot( 1 );
+    mgr.doSnapshot( 2 );
+
+    mgr.removeSnapshot( 1 );
+    mgr.removeSnapshot( 2 );
+
+    BOOST_REQUIRE_THROW( mgr.removeSnapshot( 2 ), SnapshotManager::CannotPerformBtrfsOperation );
+    BOOST_REQUIRE_THROW( mgr.removeSnapshot( 3 ), SnapshotManager::SnapshotAbsent );
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
medium risk
add new snapshots downloading functionality - starting from now a node should first get snapshot's hash from all other nodes and takes the one that simillar to at least 2/3 of others. after that node randomly chooses a node to download snapshot from and checks snapshot hash after downloading.
test for this feature here -> https://github.com/skalenetwork/skale-node-tests/blob/master/sktest_snapshot.py