### PR TITLE
Feature/skale 1811 calculate hash of filesystem

### DIFF
--- a/libdevcore/Exceptions.h
+++ b/libdevcore/Exceptions.h
@@ -75,7 +75,6 @@ DEV_SIMPLE_EXCEPTION( MissingField );
 DEV_SIMPLE_EXCEPTION( WrongFieldType );
 DEV_SIMPLE_EXCEPTION( InterfaceNotSupported );
 DEV_SIMPLE_EXCEPTION( ExternalFunctionFailure );
-DEV_SIMPLE_EXCEPTION( NoSuchFileOrDirectory );
 
 // error information to be added to exceptions
 using errinfo_invalidSymbol = boost::error_info< struct tag_invalidSymbol, char >;

--- a/libethcore/Precompiled.cpp
+++ b/libethcore/Precompiled.cpp
@@ -448,9 +448,6 @@ ETH_REGISTER_PRECOMPILED( deleteFile )( bytesConstRef _in ) {
 
         const fs::path fileHashPath =
             getFileStorageDir( Address( address ) ) / ( filename + "._hash" );
-        if ( remove( fileHashPath.c_str() ) != 0 ) {
-            throw std::runtime_error( "File's hash cannot be deleted" );
-        }
 
         u256 code = 1;
         bytes response = toBigEndian( code );

--- a/libethcore/Precompiled.cpp
+++ b/libethcore/Precompiled.cpp
@@ -556,34 +556,35 @@ ETH_REGISTER_PRECOMPILED( calculateFileHash )( bytesConstRef _in ) {
 
         const fs::path filePath = getFileStorageDir( Address( address ) ) / filename;
 
-        if (!fs::exists(filePath)) {
-            throw std::runtime_error("calculateFileHash() failed because file does not exist");
+        if ( !fs::exists( filePath ) ) {
+            throw std::runtime_error( "calculateFileHash() failed because file does not exist" );
         }
 
         std::string fileContent;
-        std::ifstream file(filePath.string());
+        std::ifstream file( filePath.string() );
         file >> fileContent;
 
-        const fs::path fileHashPath = filePath.parent_path() / (filePath.string() + "._hash");
+        const fs::path fileHashPath = filePath.parent_path() / ( filePath.string() + "._hash" );
 
-        if (!fs::exists(fileHashPath)) {
-            throw std::runtime_error("calculateFileHash() failed because file with hash does not exist");
+        if ( !fs::exists( fileHashPath ) ) {
+            throw std::runtime_error(
+                "calculateFileHash() failed because file with hash does not exist" );
         }
 
         std::fstream fileHash;
-        fileHash.open(fileHashPath.string(), ios::binary | ios::out | ios::in);
+        fileHash.open( fileHashPath.string(), ios::binary | ios::out | ios::in );
 
         dev::h256 filePathHash;
         fileHash >> filePathHash;
 
-        dev::h256 fileContentHash = dev::sha256(fileContent);
+        dev::h256 fileContentHash = dev::sha256( fileContent );
 
         secp256k1_sha256_t ctx;
-        secp256k1_sha256_write(&ctx, filePathHash.data(), filePathHash.size);
-        secp256k1_sha256_write(&ctx, fileContentHash.data(), fileContentHash.size);
+        secp256k1_sha256_write( &ctx, filePathHash.data(), filePathHash.size );
+        secp256k1_sha256_write( &ctx, fileContentHash.data(), fileContentHash.size );
 
         dev::h256 commonFileHash;
-        secp256k1_sha256_finalize(&ctx, commonFileHash.data());
+        secp256k1_sha256_finalize( &ctx, commonFileHash.data() );
 
         fileHash.clear();
         fileHash << commonFileHash;

--- a/libethcore/Precompiled.cpp
+++ b/libethcore/Precompiled.cpp
@@ -284,13 +284,6 @@ ETH_REGISTER_PRECOMPILED( createFile )( bytesConstRef _in ) {
             file.write( "0", 1 );
         }
 
-        const std::string filePathStr = ( fsFilePath / filePath.filename() ).string();
-
-        dev::h256 filePathHash = dev::sha256( filePathStr );
-
-        std::ofstream hashFile( filePathStr + "._hash" );
-        hashFile << filePathHash;
-
         u256 code = 1;
         bytes response = toBigEndian( code );
         return {true, response};
@@ -563,16 +556,10 @@ ETH_REGISTER_PRECOMPILED( calculateFileHash )( bytesConstRef _in ) {
 
         const std::string fileHashName = filePath.string() + "._hash";
 
-        if ( !fs::exists( fileHashName ) ) {
-            throw std::runtime_error(
-                "calculateFileHash() failed because file with hash does not exist" );
-        }
-
         std::fstream fileHash;
         fileHash.open( fileHashName, ios::binary | ios::out | ios::in );
 
-        dev::h256 filePathHash;
-        fileHash >> filePathHash;
+        dev::h256 filePathHash = dev::sha256( filePath.string() );
 
         dev::h256 fileContentHash = dev::sha256( fileContent );
 

--- a/libethcore/Precompiled.cpp
+++ b/libethcore/Precompiled.cpp
@@ -561,7 +561,8 @@ ETH_REGISTER_PRECOMPILED( calculateFileHash )( bytesConstRef _in ) {
         std::ifstream file( filePath.string() );
         file >> fileContent;
 
-        const fs::path fileHashPath = filePath.parent_path() / ( filePath.string() + "._hash" );
+        const fs::path fileHashPath =
+            filePath.parent_path() / ( filePath.filename().string() + "._hash" );
 
         if ( !fs::exists( fileHashPath ) ) {
             throw std::runtime_error(
@@ -577,6 +578,7 @@ ETH_REGISTER_PRECOMPILED( calculateFileHash )( bytesConstRef _in ) {
         dev::h256 fileContentHash = dev::sha256( fileContent );
 
         secp256k1_sha256_t ctx;
+        secp256k1_sha256_initialize( &ctx );
         secp256k1_sha256_write( &ctx, filePathHash.data(), filePathHash.size );
         secp256k1_sha256_write( &ctx, fileContentHash.data(), fileContentHash.size );
 
@@ -594,9 +596,10 @@ ETH_REGISTER_PRECOMPILED( calculateFileHash )( bytesConstRef _in ) {
         std::string strError = ex.what();
         if ( strError.empty() )
             strError = "exception without description";
-        LOG( getLogger( VerbosityError ) ) << "Exception in deleteDirectory: " << strError << "\n";
+        LOG( getLogger( VerbosityError ) )
+            << "Exception in calculateFileHash: " << strError << "\n";
     } catch ( ... ) {
-        LOG( getLogger( VerbosityError ) ) << "Unknown exception in deleteDirectory\n";
+        LOG( getLogger( VerbosityError ) ) << "Unknown exception in calculateFileHash\n";
     }
     u256 code = 0;
     bytes response = toBigEndian( code );

--- a/libskale/SnapshotHashAgent.cpp
+++ b/libskale/SnapshotHashAgent.cpp
@@ -121,6 +121,6 @@ std::vector< std::string > SnapshotHashAgent::getNodesToDownloadSnapshotFrom(
 }
 
 dev::h256 SnapshotHashAgent::getVotedHash() const {
-    assert( voted_hash_ != dev::h256() );
+    assert( this->voted_hash_ != dev::h256() );
     return this->voted_hash_;
 }

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -364,7 +364,7 @@ void SnapshotManager::proceedFileSystemDirectory( const boost::filesystem::path&
         if ( boost::filesystem::is_regular_file( *it ) ) {
             if ( boost::filesystem::extension( it->path() ) != "._hash" ) {
                 if ( !is_checking ) {
-                    if ( !boost::filesystem::exists( fileHashPathStr )) {
+                    if ( !boost::filesystem::exists( fileHashPathStr ) ) {
                         throw SnapshotManager::CannotRead( fileHashPathStr );
                     }
                     std::ifstream hash_file( fileHashPathStr );
@@ -382,7 +382,8 @@ void SnapshotManager::proceedFileSystemDirectory( const boost::filesystem::path&
                     std::string fileContent;
                     file >> fileContent;
                     dev::h256 fileContentHash = dev::sha256( fileContent );
-                    secp256k1_sha256_write( &fileData, fileContentHash.data(), fileContentHash.size );
+                    secp256k1_sha256_write(
+                        &fileData, fileContentHash.data(), fileContentHash.size );
 
                     dev::h256 fileHash;
                     secp256k1_sha256_finalize( &fileData, fileHash.data() );
@@ -392,7 +393,7 @@ void SnapshotManager::proceedFileSystemDirectory( const boost::filesystem::path&
             }
         } else {
             if ( !is_checking ) {
-                if ( !boost::filesystem::exists( fileHashPathStr )) {
+                if ( !boost::filesystem::exists( fileHashPathStr ) ) {
                     throw SnapshotManager::CannotRead( fileHashPathStr );
                 }
                 std::ifstream hash_file( fileHashPathStr );

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -354,19 +354,20 @@ void SnapshotManager::computeVolumeHash(
     std::throw_with_nested( CannotRead( ex.path1() ) );
 }
 
-void SnapshotManager::proceedFileSystemDirectory(const boost::filesystem::path& _fileSystemDir, secp256k1_sha256_t* ctx) const {
-    boost::filesystem::recursive_directory_iterator it(_fileSystemDir), end;
+void SnapshotManager::proceedFileSystemDirectory(
+    const boost::filesystem::path& _fileSystemDir, secp256k1_sha256_t* ctx ) const {
+    boost::filesystem::recursive_directory_iterator it( _fileSystemDir ), end;
 
-    while (it != end) {
-        if (fs::is_regular_file(*it)) {
-            if (boost::filesystem::extension(it->path()) != "._hash") {
-                std::ifstream hash_file(it->path().string());
+    while ( it != end ) {
+        if ( fs::is_regular_file( *it ) ) {
+            if ( boost::filesystem::extension( it->path() ) != "._hash" ) {
+                std::ifstream hash_file( it->path().string() );
                 dev::h256 hash;
                 hash_file >> hash;
-                secp256k1_sha256_write( ctx, hash.data(), hash.size);
+                secp256k1_sha256_write( ctx, hash.data(), hash.size );
             }
         } else {
-            this->proceedFileSystemDirectory(*it, ctx);
+            this->proceedFileSystemDirectory( *it, ctx );
         }
 
         ++it;
@@ -380,7 +381,7 @@ void SnapshotManager::computeFileSystemHash(
                                 _fileSystemDir.string() + " doesn't exist" );
     }
 
-    this->proceedFileSystemDirectory(_fileSystemDir, ctx);
+    this->proceedFileSystemDirectory( _fileSystemDir, ctx );
 }
 
 void SnapshotManager::computeAllVolumesHash(
@@ -397,9 +398,10 @@ void SnapshotManager::computeAllVolumesHash(
 
     this->computeVolumeHash(
         this->snapshots_dir / std::to_string( _blockNumber ) / this->volumes[0] / "blocks", ctx );
-  
-    this->computeFileSystemHash(this->snapshots_dir / std::to_string( _blockNumber ) / "filestorage", ctx );
-  
+
+    this->computeFileSystemHash(
+        this->snapshots_dir / std::to_string( _blockNumber ) / "filestorage", ctx );
+
     for ( const string& vol : this->volumes ) {
         if ( vol.find( "prices_" ) == 0 )
             this->computeVolumeHash(

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -362,6 +362,7 @@ void SnapshotManager::proceedFileSystemDirectory( const boost::filesystem::path&
     while ( it != end ) {
         std::string fileHashPathStr = it->path().string() + "._hash";
         if ( boost::filesystem::is_regular_file( *it ) ) {
+            ;
             if ( boost::filesystem::extension( it->path() ) != "._hash" ) {
                 if ( !is_checking ) {
                     if ( !boost::filesystem::exists( fileHashPathStr ) ) {
@@ -372,12 +373,21 @@ void SnapshotManager::proceedFileSystemDirectory( const boost::filesystem::path&
                         dev::h256 filePathHash = dev::sha256( it->path().string() );
                         secp256k1_sha256_write( &fileData, filePathHash.data(), filePathHash.size );
 
+                        std::ifstream originFile( it->path().string() );
+                        std::string fileContent;
+                        originFile >> fileContent;
+                        dev::h256 fileContentHash = dev::sha256( fileContent );
+
+                        secp256k1_sha256_write(
+                            &fileData, fileContentHash.data(), fileContentHash.size );
+
                         dev::h256 fileHash;
                         secp256k1_sha256_finalize( &fileData, fileHash.data() );
 
                         std::ofstream hash( fileHashPathStr );
                         hash << fileHash;
                     }
+
                     std::ifstream hash_file( fileHashPathStr );
                     dev::h256 hash;
                     hash_file >> hash;
@@ -399,6 +409,10 @@ void SnapshotManager::proceedFileSystemDirectory( const boost::filesystem::path&
                     dev::h256 fileHash;
                     secp256k1_sha256_finalize( &fileData, fileHash.data() );
 
+                    std::ofstream hash( fileHashPathStr );
+                    hash.clear();
+                    hash << fileHash;
+
                     secp256k1_sha256_write( ctx, fileHash.data(), fileHash.size );
                 }
             }
@@ -414,47 +428,12 @@ void SnapshotManager::proceedFileSystemDirectory( const boost::filesystem::path&
             } else {
                 dev::h256 directoryHash = dev::sha256( it->path().string() );
                 secp256k1_sha256_write( ctx, directoryHash.data(), directoryHash.size );
+
+                std::ofstream hash( fileHashPathStr );
+                hash.clear();
+                hash << directoryHash;
             }
         }
-        // if ( !is_checking ) {
-        //     std::string fileHashPathStr = it->path().string();
-        //     if ( fs::is_regular_file( *it ) ) {
-        //         if ( boost::filesystem::extension( it->path() ) == "._hash" ) {
-        //             std::ifstream hash_file( it->path().string() );
-        //             dev::h256 hash;
-        //             hash_file >> hash;
-        //             secp256k1_sha256_write( ctx, hash.data(), hash.size );
-        //         } else {
-        //             if ( !boost::filesystem::exists( it->path().string() + "._hash" ) ) {
-        //                 throw SnapshotManager::CannotRead( it->path().string() + "._hash" );
-        //             }
-        //         }
-        //     } else {
-        //         if ( !boost::filesystem::exists( it->path().string() + "._hash" ) ) {
-        //             throw SnapshotManager::CannotRead( it->path().string() + "._hash" );
-        //         }
-        //         this->proceedFileSystemDirectory( *it, ctx, is_checking );
-        //     }
-        // } else {
-        //     std::string fileHashPathStr = it->path().string();
-        //     if ( fs::is_regular_file( *it ) ) {
-        //         if ( boost::filesystem::extension( it->path() ) == "._hash" ) {
-        //             std::ifstream hash_file( it->path().string() );
-        //             dev::h256 hash;
-        //             hash_file >> hash;
-        //             secp256k1_sha256_write( ctx, hash.data(), hash.size );
-        //         } else {
-        //             if ( !boost::filesystem::exists( it->path().string() + "._hash" ) ) {
-        //                 throw SnapshotManager::CannotRead( it->path().string() + "._hash" );
-        //             }
-        //         }
-        //     } else {
-        //         if ( !boost::filesystem::exists( it->path().string() + "._hash" ) ) {
-        //             throw SnapshotManager::CannotRead( it->path().string() + "._hash" );
-        //         }
-        //         this->proceedFileSystemDirectory( *it, ctx, is_checking );
-        //     }
-        // }
 
         ++it;
     }
@@ -530,6 +509,7 @@ void SnapshotManager::computeSnapshotHash( unsigned _blockNumber, bool is_checki
     try {
         std::lock_guard< std::mutex > lock( hash_file_mutex );
         std::ofstream out( hash_file );
+        out.clear();
         out << hash;
     } catch ( const std::exception& ex ) {
         std::throw_with_nested( SnapshotManager::CannotCreate( hash_file ) );

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -25,6 +25,7 @@
 #include "SnapshotManager.h"
 
 #include <libdevcore/LevelDB.h>
+#include <libdevcrypto/Hash.h>
 #include <skutils/btrfs.h>
 
 #include <boost/interprocess/sync/named_mutex.hpp>

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -360,7 +360,7 @@ void SnapshotManager::proceedFileSystemDirectory(
 
     while ( it != end ) {
         if ( fs::is_regular_file( *it ) ) {
-            if ( boost::filesystem::extension( it->path() ) != "._hash" ) {
+            if ( boost::filesystem::extension( it->path() ) == "._hash" ) {
                 std::ifstream hash_file( it->path().string() );
                 dev::h256 hash;
                 hash_file >> hash;

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -360,7 +360,6 @@ void SnapshotManager::proceedFileSystemDirectory(
 
     while ( it != end ) {
         std::string fileHashPathStr = it->path().string();
-        fileHashPathStr.replace( fileHashPathStr.begin(), fileHashPathStr.end(), '/', '-' );
         if ( fs::is_regular_file( *it ) ) {
             if ( boost::filesystem::extension( it->path() ) == "._hash" ) {
                 std::ifstream hash_file( it->path().string() );
@@ -368,15 +367,13 @@ void SnapshotManager::proceedFileSystemDirectory(
                 hash_file >> hash;
                 secp256k1_sha256_write( ctx, hash.data(), hash.size );
             } else {
-                if ( !boost::filesystem::exists( it->path().parent_path() / fileHashPathStr ) ) {
-                    throw SnapshotManager::CannotRead(
-                        ( it->path().parent_path() / fileHashPathStr ).string() );
+                if ( !boost::filesystem::exists( it->path().string() + "._hash" ) ) {
+                    throw SnapshotManager::CannotRead( it->path().string() + "._hash" );
                 }
             }
         } else {
-            if ( !boost::filesystem::exists( it->path().parent_path() / fileHashPathStr ) ) {
-                throw SnapshotManager::CannotRead(
-                    ( it->path().parent_path() / fileHashPathStr ).string() );
+            if ( !boost::filesystem::exists( it->path().string() + "._hash" ) ) {
+                throw SnapshotManager::CannotRead( it->path().string() + "._hash" );
             }
             this->proceedFileSystemDirectory( *it, ctx );
         }

--- a/libskale/SnapshotManager.h
+++ b/libskale/SnapshotManager.h
@@ -152,7 +152,7 @@ public:
 
     dev::h256 getSnapshotHash( unsigned _blockNumber ) const;
     bool isSnapshotHashPresent( unsigned _blockNumber ) const;
-    void computeSnapshotHash( unsigned _blockNumber );
+    void computeSnapshotHash( unsigned _blockNumber, bool is_checking = false );
 
 private:
     boost::filesystem::path data_dir;
@@ -163,11 +163,12 @@ private:
     static const std::string snapshot_hash_file_name;
     mutable std::mutex hash_file_mutex;
 
-    void computeFileSystemHash(
-        const boost::filesystem::path& _fileSystemDir, secp256k1_sha256_t* ctx ) const;
-    void proceedFileSystemDirectory(
-        const boost::filesystem::path& _fileSystemDir, secp256k1_sha256_t* ctx ) const;
-    void computeAllVolumesHash( unsigned _blockNumber, secp256k1_sha256_t* ctx ) const;
+    void computeFileSystemHash( const boost::filesystem::path& _fileSystemDir,
+        secp256k1_sha256_t* ctx, bool is_checking ) const;
+    void proceedFileSystemDirectory( const boost::filesystem::path& _fileSystemDir,
+        secp256k1_sha256_t* ctx, bool is_checking ) const;
+    void computeAllVolumesHash(
+        unsigned _blockNumber, secp256k1_sha256_t* ctx, bool is_checking ) const;
     void computeVolumeHash(
         const boost::filesystem::path& _volumeDir, secp256k1_sha256_t* ctx ) const;
 };

--- a/libskale/SnapshotManager.h
+++ b/libskale/SnapshotManager.h
@@ -165,6 +165,7 @@ private:
 
     void computeFileSystemHash(
         const boost::filesystem::path& _fileSystemDir, secp256k1_sha256_t* ctx ) const;
+    void proceedFileSystemDirectory(const boost::filesystem::path& _fileSystemDir, secp256k1_sha256_t* ctx) const;
     void computeAllVolumesHash( unsigned _blockNumber, secp256k1_sha256_t* ctx ) const;
     void computeVolumeHash(
         const boost::filesystem::path& _volumeDir, secp256k1_sha256_t* ctx ) const;

--- a/libskale/SnapshotManager.h
+++ b/libskale/SnapshotManager.h
@@ -165,7 +165,8 @@ private:
 
     void computeFileSystemHash(
         const boost::filesystem::path& _fileSystemDir, secp256k1_sha256_t* ctx ) const;
-    void proceedFileSystemDirectory(const boost::filesystem::path& _fileSystemDir, secp256k1_sha256_t* ctx) const;
+    void proceedFileSystemDirectory(
+        const boost::filesystem::path& _fileSystemDir, secp256k1_sha256_t* ctx ) const;
     void computeAllVolumesHash( unsigned _blockNumber, secp256k1_sha256_t* ctx ) const;
     void computeVolumeHash(
         const boost::filesystem::path& _volumeDir, secp256k1_sha256_t* ctx ) const;

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1102,7 +1102,7 @@ int main( int argc, char** argv ) try {
 
             downloadSnapshot( blockNumber, snapshotManager, urlToDownloadSnapshot, chainParams );
 
-            snapshotManager->computeSnapshotHash( blockNumber );
+            snapshotManager->computeSnapshotHash( blockNumber, true );
 
             dev::h256 calculated_hash = snapshotManager->getSnapshotHash( blockNumber );
 

--- a/test/unittests/libethcore/PrecompiledTest.cpp
+++ b/test/unittests/libethcore/PrecompiledTest.cpp
@@ -1671,7 +1671,7 @@ BOOST_AUTO_TEST_CASE( calculateFileHash ) {
     std::string fileHashName = pathToFile.string() + "._hash";
 
     std::ofstream fileHash( fileHashName );
-    dev::h256 hash = dev::sha256( fileHashName );
+    dev::h256 hash = dev::sha256( pathToFile.string() );
     fileHash << hash;
 
     fileHash.close();

--- a/test/unittests/libethcore/PrecompiledTest.cpp
+++ b/test/unittests/libethcore/PrecompiledTest.cpp
@@ -1582,7 +1582,6 @@ BOOST_AUTO_TEST_CASE( createFile ) {
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( boost::filesystem::exists( path ) );
     BOOST_REQUIRE( boost::filesystem::file_size( path ) == fileSize );
-    BOOST_REQUIRE( boost::filesystem::exists( path.string() + "._hash" ) );
     remove( path.c_str() );
 }
 
@@ -1703,6 +1702,7 @@ BOOST_AUTO_TEST_CASE( calculateFileHash ) {
     secp256k1_sha256_finalize( &ctx, commonFileHash.data() );
 
     BOOST_REQUIRE( calculatedHash == commonFileHash );
+    BOOST_REQUIRE( boost::filesystem::exists( fileHashName ) );
 
     remove( ( pathToFile.parent_path() / fileHashName ).c_str() );
 }

--- a/test/unittests/libethcore/PrecompiledTest.cpp
+++ b/test/unittests/libethcore/PrecompiledTest.cpp
@@ -1704,7 +1704,7 @@ BOOST_AUTO_TEST_CASE( calculateFileHash ) {
 
     BOOST_REQUIRE( calculatedHash == commonFileHash );
 
-    remove( ( pathToFile.parent_path() / ( fileName + "._hash" ) ).c_str() );
+    remove( ( pathToFile.parent_path() / ( fileHashName + "._hash" ) ).c_str() );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libethcore/PrecompiledTest.cpp
+++ b/test/unittests/libethcore/PrecompiledTest.cpp
@@ -1665,7 +1665,10 @@ BOOST_AUTO_TEST_CASE( deleteDirectory ) {
 BOOST_AUTO_TEST_CASE( calculateFileHash ) {
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "calculateFileHash" );
 
-    boost::filesystem::path fileHashPath = pathToFile.parent_path() / ( fileName + "._hash" );
+    std::string fileHashName = pathToFile.string();
+    fileHashName.replace( fileHashName.begin(), fileHashName.end(), '/', '-' );
+
+    boost::filesystem::path fileHashPath = pathToFile.parent_path() / ( fileHashName + "._hash" );
 
     std::ofstream fileHash( fileHashPath.string() );
     dev::h256 hash = dev::sha256( fileHashPath.string() );
@@ -1679,9 +1682,9 @@ BOOST_AUTO_TEST_CASE( calculateFileHash ) {
 
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE(
-        boost::filesystem::exists( pathToFile.parent_path() / ( fileName + "._hash" ) ) );
+        boost::filesystem::exists( pathToFile.parent_path() / ( fileHashName + "._hash" ) ) );
 
-    std::ifstream resultFile( ( pathToFile.parent_path() / ( fileName + "._hash" ) ).string() );
+    std::ifstream resultFile( ( pathToFile.parent_path() / ( fileHashName + "._hash" ) ).string() );
     dev::h256 calculatedHash;
     resultFile >> calculatedHash;
 

--- a/test/unittests/libskale/HashSnapshot.cpp
+++ b/test/unittests/libskale/HashSnapshot.cpp
@@ -165,7 +165,8 @@ struct SnapshotHashingFixture : public TestOutputHelperFixture, public FixtureCo
             ( boost::filesystem::path( BTRFS_DIR_PATH ) / "filestorage" / "test_dir._hash" )
                 .string();
         std::ofstream directoryHashFile( tmp_str );
-        dev::h256 directoryPathHash = dev::sha256( tmp_str );
+        dev::h256 directoryPathHash = dev::sha256(
+            ( boost::filesystem::path( BTRFS_DIR_PATH ) / "filestorage" / "test_dir" ).string() );
         directoryHashFile << directoryPathHash;
         directoryHashFile.close();
 
@@ -292,6 +293,24 @@ BOOST_FIXTURE_TEST_CASE( SnapshotHashingTest, SnapshotHashingFixture ) {
     BOOST_REQUIRE_THROW( mgr->getSnapshotHash( 4 ), SnapshotManager::SnapshotAbsent );
 
     // TODO check hash absence separately
+}
+
+BOOST_FIXTURE_TEST_CASE( SnapshotHashingFileStorageTest, SnapshotHashingFixture ) {
+    mgr->doSnapshot( 4 );
+
+    mgr->computeSnapshotHash( 4, true );
+
+    BOOST_REQUIRE( mgr->isSnapshotHashPresent( 4 ) );
+
+    dev::h256 hash4_dbl = mgr->getSnapshotHash( 4 );
+
+    mgr->computeSnapshotHash( 4 );
+
+    BOOST_REQUIRE( mgr->isSnapshotHashPresent( 4 ) );
+
+    dev::h256 hash4 = mgr->getSnapshotHash( 4 );
+
+    BOOST_REQUIRE( hash4_dbl == hash4 );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libskale/HashSnapshot.cpp
+++ b/test/unittests/libskale/HashSnapshot.cpp
@@ -1,5 +1,6 @@
 #include <libdevcore/TransientDirectory.h>
 #include <libethcore/KeyManager.h>
+#include <libdevcrypto/Hash.h>
 #include <libethereum/ClientTest.h>
 #include <libp2p/Network.h>
 #include <libskale/SnapshotManager.h>
@@ -156,6 +157,15 @@ struct SnapshotHashingFixture : public TestOutputHelperFixture, public FixtureCo
 
         mgr.reset( new SnapshotManager( boost::filesystem::path( BTRFS_DIR_PATH ),
             {BlockChain::getChainDirName( chainParams ), "filestorage"} ) );
+
+        boost::filesystem::create_directory(
+            boost::filesystem::path( BTRFS_DIR_PATH ) / "filestorage" / "test_dir" );
+
+        std::string tmp_str = (boost::filesystem::path( BTRFS_DIR_PATH ) / "filestorage" / "test_dir._hash").string();
+        std::ofstream directoryHashFile(tmp_str);
+        dev::h256 directoryPathHash =  dev::sha256(tmp_str);
+        directoryHashFile << directoryPathHash;
+        directoryHashFile.close();
 
         client.reset( new eth::ClientTest( chainParams, ( int ) chainParams.networkID,
             shared_ptr< GasPricer >(), NULL, boost::filesystem::path( BTRFS_DIR_PATH ),

--- a/test/unittests/libskale/HashSnapshot.cpp
+++ b/test/unittests/libskale/HashSnapshot.cpp
@@ -1,6 +1,6 @@
 #include <libdevcore/TransientDirectory.h>
-#include <libethcore/KeyManager.h>
 #include <libdevcrypto/Hash.h>
+#include <libethcore/KeyManager.h>
 #include <libethereum/ClientTest.h>
 #include <libp2p/Network.h>
 #include <libskale/SnapshotManager.h>
@@ -161,9 +161,11 @@ struct SnapshotHashingFixture : public TestOutputHelperFixture, public FixtureCo
         boost::filesystem::create_directory(
             boost::filesystem::path( BTRFS_DIR_PATH ) / "filestorage" / "test_dir" );
 
-        std::string tmp_str = (boost::filesystem::path( BTRFS_DIR_PATH ) / "filestorage" / "test_dir._hash").string();
-        std::ofstream directoryHashFile(tmp_str);
-        dev::h256 directoryPathHash =  dev::sha256(tmp_str);
+        std::string tmp_str =
+            ( boost::filesystem::path( BTRFS_DIR_PATH ) / "filestorage" / "test_dir._hash" )
+                .string();
+        std::ofstream directoryHashFile( tmp_str );
+        dev::h256 directoryPathHash = dev::sha256( tmp_str );
         directoryHashFile << directoryPathHash;
         directoryHashFile.close();
 

--- a/test/unittests/libskale/HashSnapshot.cpp
+++ b/test/unittests/libskale/HashSnapshot.cpp
@@ -155,7 +155,7 @@ struct SnapshotHashingFixture : public TestOutputHelperFixture, public FixtureCo
         //            true ) );
 
         mgr.reset( new SnapshotManager( boost::filesystem::path( BTRFS_DIR_PATH ),
-            {BlockChain::getChainDirName( chainParams )} ) );
+            {BlockChain::getChainDirName( chainParams ), "filestorage"} ) );
 
         client.reset( new eth::ClientTest( chainParams, ( int ) chainParams.networkID,
             shared_ptr< GasPricer >(), NULL, boost::filesystem::path( BTRFS_DIR_PATH ),


### PR DESCRIPTION
medium risk
add functionality to calculate filestorage hash
required tests are here : 
1. test/unittests/libethcore/PrecompiledTest.cpp - `calculateFileHash` and `createDirectory`
2. test/unittests/libskale/HashSnapshot.cpp - `SnapshotHashingFileStorageTest`