### PR TITLE
Bug/skale 1854 default queue leaks

### DIFF
--- a/libethereum/ConsensusStub.cpp
+++ b/libethereum/ConsensusStub.cpp
@@ -40,9 +40,10 @@ using namespace dev;
 
 using namespace std;
 
-ConsensusStub::ConsensusStub( ConsensusExtFace& _extFace )
+ConsensusStub::ConsensusStub( ConsensusExtFace& _extFace, uint64_t _lastCommittedBlockID )
     : dev::Worker( "consensus_stub", 0 ),  // call doWork in a tight loop
-      m_extFace( _extFace ) {
+      m_extFace( _extFace ),
+      blockCounter( _lastCommittedBlockID ) {
     // TODO Auto-generated constructor stub
 }
 

--- a/libethereum/ConsensusStub.cpp
+++ b/libethereum/ConsensusStub.cpp
@@ -77,7 +77,7 @@ void ConsensusStub::doWork() {
     // Then return block
 
     static const unsigned wanted_txn_count = 10;
-    static const unsigned max_sleep = 2000;
+    //    static const unsigned max_sleep = 2000;
 
     using transactions_vector = ConsensusExtFace::transactions_vector;
 
@@ -100,8 +100,8 @@ void ConsensusStub::doWork() {
         ++it;
     }
 
-    this_thread::sleep_for( std::chrono::milliseconds(
-        static_cast< unsigned int >( rand() ) % ( max_sleep - 1000 ) + 1000 ) );
+    //    this_thread::sleep_for( std::chrono::milliseconds(
+    //        static_cast< unsigned int >( rand() ) % ( max_sleep - 1000 ) + 1000 ) );
 
     try {
         ++blockCounter;

--- a/libethereum/ConsensusStub.h
+++ b/libethereum/ConsensusStub.h
@@ -36,15 +36,13 @@ class ConsensusExtFace;
 
 class ConsensusStub : private dev::Worker, public ConsensusInterface {
 public:
-    ConsensusStub( ConsensusExtFace& _extFace );
+    ConsensusStub( ConsensusExtFace& _extFace, uint64_t _lastCommittedBlockID );
     ~ConsensusStub() override;
     void parseFullConfigAndCreateNode( const std::string& _jsonConfig ) override;
     void startAll() override;
     void bootStrapAll() override;
     void exitGracefully() override;
-    u256 getPriceForBlockId(uint64_t /*_blockId*/) const override {
-        return 1000;
-    }
+    u256 getPriceForBlockId( uint64_t /*_blockId*/ ) const override { return 1000; }
 
     void stop();
 

--- a/libethereum/ConsensusStub.h
+++ b/libethereum/ConsensusStub.h
@@ -42,6 +42,10 @@ public:
     void startAll() override;
     void bootStrapAll() override;
     void exitGracefully() override;
+    u256 getPriceForBlockId(uint64_t /*_blockId*/) const override {
+        return 1000;
+    }
+
     void stop();
 
 private:

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -66,7 +66,7 @@ std::unique_ptr< ConsensusInterface > DefaultConsensusFactory::create(
     auto ts = nfo.timestamp();
     return make_unique< ConsensusEngine >( _extFace, m_client.number(), ts );
 #else
-    return make_unique< ConsensusStub >( _extFace );
+    return make_unique< ConsensusStub >( _extFace, m_client.number() );
 #endif
 }
 

--- a/libskale/httpserveroverride.cpp
+++ b/libskale/httpserveroverride.cpp
@@ -1735,9 +1735,10 @@ SkaleRelayHTTP::SkaleRelayHTTP( int ipVer, const char* strBindAddr, int nPort,
                           true :
                           false ) {
     if ( m_bHelperIsSSL )
-        m_pServer.reset( new skutils::http::SSL_server( cert_path, private_key_path ) );
+        m_pServer.reset( new skutils::http::SSL_server(
+            cert_path, private_key_path, a_max_http_handler_queues ) );
     else
-        m_pServer.reset( new skutils::http::server );
+        m_pServer.reset( new skutils::http::server( a_max_http_handler_queues ) );
     m_pServer->ipVer_ = ipVer_;  // not known before listen
 }
 

--- a/libskale/httpserveroverride.cpp
+++ b/libskale/httpserveroverride.cpp
@@ -688,8 +688,7 @@ void SkaleWsPeer::onMessage( const std::string& msg, skutils::ws::opcv eOpCode )
                                          cc::num10( getRelay().serverIndex() ) )
             << ( cc::ws_rx_inv( " >>> " + getRelay().nfoGetSchemeUC() + "/" +
                                 std::to_string( getRelay().serverIndex() ) + "/RX >>> " ) +
-                   desc() + cc::ws_rx( " >>> " ) +
-                   cc::warn( "Skipping arrived payload while in shutdown mode" ) );
+                   desc() + cc::ws_rx( " >>> " ) + cc::warn( "" ) );
         skutils::dispatch::remove( m_strPeerQueueID );  // remove queue earlier
         return;
     }
@@ -1665,6 +1664,7 @@ void SkaleRelayWS::waitWhileInLoop() {
 }
 
 bool SkaleRelayWS::start( SkaleServerOverride* pSO ) {
+    SkaleRelayWS* pThis = this;
     stop();
     m_pSO = pSO;
     server_disable_ipv6_ = ( ipVer_ == 6 ) ? false : true;
@@ -1675,14 +1675,14 @@ bool SkaleRelayWS::start( SkaleServerOverride* pSO ) {
             << ( cc::error( "Failed to start server on port " ) + cc::c( m_nPort ) );
         return false;
     }
-    std::thread( [&]() {
-        m_isRunning = true;
-        skutils::multithreading::threadNameAppender tn( "/" + m_strSchemeUC + "-listener" );
+    std::thread( [pThis]() {
+        pThis->m_isRunning = true;
+        skutils::multithreading::threadNameAppender tn( "/" + pThis->m_strSchemeUC + "-listener" );
         try {
-            run( [&]() -> bool { return m_isRunning; } );
+            pThis->run( [pThis]() -> bool { return pThis->m_isRunning; } );
         } catch ( ... ) {
         }
-        // m_isRunning = false;
+        // pThis->m_isRunning = false;
     } )
         .detach();
     clog( dev::VerbosityInfo, cc::info( m_strSchemeUC ) )
@@ -1902,8 +1902,7 @@ bool SkaleServerOverride::implStartListening( std::shared_ptr< SkaleRelayHTTP >&
             if ( isShutdownMode() ) {
                 logTraceServerEvent( false, ipVer, bIsSSL ? "HTTPS" : "HTTP", pSrv->serverIndex(),
                     cc::notice( bIsSSL ? "HTTPS" : "HTTP" ) + cc::debug( "/" ) +
-                        cc::num10( pSrv->serverIndex() ) + " " +
-                        cc::warn( "Skipping arrived payload while in shutdown mode" ) );
+                        cc::num10( pSrv->serverIndex() ) + " " + cc::warn( "" ) );
                 pSrv->m_pServer->close_all_handler_queues();  // remove queues earlier
                 return true;
             }

--- a/libskale/httpserveroverride.cpp
+++ b/libskale/httpserveroverride.cpp
@@ -1700,7 +1700,8 @@ dev::eth::Interface* SkaleRelayWS::ethereum() const {
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 SkaleRelayHTTP::SkaleRelayHTTP( int ipVer, const char* strBindAddr, int nPort,
-    const char* cert_path, const char* private_key_path, int nServerIndex )
+    const char* cert_path, const char* private_key_path, int nServerIndex,
+    size_t a_max_http_handler_queues )
     : SkaleServerHelper( nServerIndex ),
       ipVer_( ipVer ),
       strBindAddr_( strBindAddr ),
@@ -1850,7 +1851,7 @@ void SkaleServerOverride::logTraceServerTraffic( bool isRX, bool isError, int ip
 
 bool SkaleServerOverride::implStartListening( std::shared_ptr< SkaleRelayHTTP >& pSrv, int ipVer,
     const std::string& strAddr, int nPort, const std::string& strPathSslKey,
-    const std::string& strPathSslCert, int nServerIndex ) {
+    const std::string& strPathSslCert, int nServerIndex, size_t a_max_http_handler_queues ) {
     bool bIsSSL = false;
     if ( ( !strPathSslKey.empty() ) && ( !strPathSslCert.empty() ) )
         bIsSSL = true;
@@ -1865,10 +1866,10 @@ bool SkaleServerOverride::implStartListening( std::shared_ptr< SkaleRelayHTTP >&
                 cc::debug( "..." ) );
         if ( bIsSSL )
             pSrv.reset( new SkaleRelayHTTP( ipVer, strAddr.c_str(), nPort, strPathSslCert.c_str(),
-                strPathSslKey.c_str(), nServerIndex ) );
+                strPathSslKey.c_str(), nServerIndex, a_max_http_handler_queues ) );
         else
-            pSrv.reset( new SkaleRelayHTTP(
-                ipVer, strAddr.c_str(), nPort, nullptr, nullptr, nServerIndex ) );
+            pSrv.reset( new SkaleRelayHTTP( ipVer, strAddr.c_str(), nPort, nullptr, nullptr,
+                nServerIndex, a_max_http_handler_queues ) );
         pSrv->m_pServer->Options(
             "/", [=]( const skutils::http::request& req, skutils::http::response& res ) {
                 stats::register_stats_message(
@@ -2116,7 +2117,7 @@ bool SkaleServerOverride::StartListening() {
         for ( nServerIndex = 0; nServerIndex < cntServers; ++nServerIndex ) {
             std::shared_ptr< SkaleRelayHTTP > pServer;
             if ( !implStartListening( pServer, 4, m_strAddrHTTP4, m_nBasePortHTTP4 + nServerIndex,
-                     "", "", nServerIndex ) )
+                     "", "", nServerIndex, max_http_handler_queues_ ) )
                 return false;
             m_serversHTTP4.push_back( pServer );
         }
@@ -2126,7 +2127,7 @@ bool SkaleServerOverride::StartListening() {
         for ( nServerIndex = 0; nServerIndex < cntServers; ++nServerIndex ) {
             std::shared_ptr< SkaleRelayHTTP > pServer;
             if ( !implStartListening( pServer, 6, m_strAddrHTTP6, m_nBasePortHTTP6 + nServerIndex,
-                     "", "", nServerIndex ) )
+                     "", "", nServerIndex, max_http_handler_queues_ ) )
                 return false;
             m_serversHTTP6.push_back( pServer );
         }
@@ -2137,7 +2138,7 @@ bool SkaleServerOverride::StartListening() {
         for ( nServerIndex = 0; nServerIndex < cntServers; ++nServerIndex ) {
             std::shared_ptr< SkaleRelayHTTP > pServer;
             if ( !implStartListening( pServer, 4, m_strAddrHTTPS4, m_nBasePortHTTPS4 + nServerIndex,
-                     m_strPathSslKey, m_strPathSslCert, nServerIndex ) )
+                     m_strPathSslKey, m_strPathSslCert, nServerIndex, max_http_handler_queues_ ) )
                 return false;
             m_serversHTTPS4.push_back( pServer );
         }
@@ -2148,7 +2149,7 @@ bool SkaleServerOverride::StartListening() {
         for ( nServerIndex = 0; nServerIndex < cntServers; ++nServerIndex ) {
             std::shared_ptr< SkaleRelayHTTP > pServer;
             if ( !implStartListening( pServer, 6, m_strAddrHTTPS6, m_nBasePortHTTPS6 + nServerIndex,
-                     m_strPathSslKey, m_strPathSslCert, nServerIndex ) )
+                     m_strPathSslKey, m_strPathSslCert, nServerIndex, max_http_handler_queues_ ) )
                 return false;
             m_serversHTTPS6.push_back( pServer );
         }

--- a/libskale/httpserveroverride.cpp
+++ b/libskale/httpserveroverride.cpp
@@ -678,7 +678,10 @@ void SkaleWsPeer::onPeerUnregister() {  // peer will no longer receive onMessage
             << ( desc() + cc::notice( " peer unregistered" ) );
     skutils::ws::peer::onPeerUnregister();
     uninstallAllWatches();
-    skutils::dispatch::remove( m_strPeerQueueID );  // remove queue earlier
+    std::string strQueueIdToRemove = m_strPeerQueueID;
+    skutils::dispatch::async( "ws-queue-remover", [strQueueIdToRemove]() -> void {
+        skutils::dispatch::remove( strQueueIdToRemove );  // remove queue earlier
+    } );
 }
 
 void SkaleWsPeer::onMessage( const std::string& msg, skutils::ws::opcv eOpCode ) {

--- a/libskale/httpserveroverride.h
+++ b/libskale/httpserveroverride.h
@@ -333,6 +333,7 @@ private:
 
 public:
     bool m_bTraceCalls;
+    std::atomic_bool m_bShutdownMode = false;
 
 private:
     std::list< std::shared_ptr< SkaleRelayHTTP > > m_serversHTTP4, m_serversHTTP6, m_serversHTTPS4,
@@ -365,6 +366,8 @@ public:
     bool handleRequestWithBinaryAnswer(
         const nlohmann::json& joRequest, std::vector< uint8_t >& buffer );
     bool handleAdminOriginFilter( const std::string& strMethod, const std::string& strOriginURL );
+
+    bool isShutdownMode() const { return m_bShutdownMode; }
 
     friend class SkaleRelayWS;
     friend class SkaleWsPeer;

--- a/libskale/httpserveroverride.h
+++ b/libskale/httpserveroverride.h
@@ -249,7 +249,8 @@ public:
     const bool m_bHelperIsSSL : 1;
     std::shared_ptr< skutils::http::server > m_pServer;
     SkaleRelayHTTP( int ipVer, const char* strBindAddr, int nPort, const char* cert_path = nullptr,
-        const char* private_key_path = nullptr, int nServerIndex = -1 );
+        const char* private_key_path = nullptr, int nServerIndex = -1,
+        size_t a_max_http_handler_queues = __SKUTILS_HTTP_DEFAULT_MAX_PARALLEL_QUEUES_COUNT );
     ~SkaleRelayHTTP() override;
 };  /// class SkaleRelayHTTP
 
@@ -290,7 +291,8 @@ public:
 private:
     bool implStartListening( std::shared_ptr< SkaleRelayHTTP >& pSrv, int ipVer,
         const std::string& strAddr, int nPort, const std::string& strPathSslKey,
-        const std::string& strPathSslCert, int nServerIndex );
+        const std::string& strPathSslCert, int nServerIndex,
+        size_t a_max_http_handler_queues = __SKUTILS_HTTP_DEFAULT_MAX_PARALLEL_QUEUES_COUNT );
     bool implStartListening( std::shared_ptr< SkaleRelayWS >& pSrv, int ipVer,
         const std::string& strAddr, int nPort, const std::string& strPathSslKey,
         const std::string& strPathSslCert, int nServerIndex );
@@ -298,6 +300,7 @@ private:
     bool implStopListening( std::shared_ptr< SkaleRelayWS >& pSrv, int ipVer, bool bIsSSL );
 
 public:
+    size_t max_http_handler_queues_ = __SKUTILS_HTTP_DEFAULT_MAX_PARALLEL_QUEUES_COUNT;
     virtual bool StartListening() override;
     virtual bool StopListening() override;
 

--- a/libskutils/include/skutils/http.h
+++ b/libskutils/include/skutils/http.h
@@ -322,6 +322,11 @@ protected:
         ++current_handler_queue_;
         return id;
     }
+    void close_all_handler_quueues() {
+        for ( size_t i = 0; i < max_handler_queues_; ++i ) {
+            skutils::dispatch::remove( handler_queue_id_at_index( i ) );
+        }
+    }
 };  /// class server
 
 class client {
@@ -1521,7 +1526,9 @@ inline server::server( size_t a_max_handler_queues )
 #endif
 }
 
-inline server::~server() {}
+inline server::~server() {
+    close_all_handler_quueues();
+}
 
 inline server& server::Get( const char* pattern, Handler handler ) {
     get_handlers_.push_back( std::make_pair( std::regex( pattern ), handler ) );
@@ -1597,6 +1604,7 @@ inline bool server::is_running() const {
 }
 
 inline void server::stop() {
+    close_all_handler_quueues();
     if ( is_running_ ) {
         is_running_ = false;
         wait_while_in_loop();

--- a/libskutils/include/skutils/http.h
+++ b/libskutils/include/skutils/http.h
@@ -80,12 +80,15 @@ typedef int socket_t;
 #include <skutils/dispatch.h>
 #include <skutils/network.h>
 #include <skutils/url.h>
+#include <skutils/utils.h>
 
 /// configuration
 
 #define __SKUTILS_HTTP_ACCEPT_WAIT_MILLISECONDS__ ( 5 * 1000 )
 #define __SKUTILS_HTTP_KEEPALIVE_TIMEOUT_MILLISECONDS__ ( 30 * 1000 )
 #define __SKUTILS_HTTP_KEEPALIVE_MAX_COUNT ( 5 )
+
+#define __SKUTILS_HTTP_DEFAULT_MAX_PARALLEL_QUEUES_COUNT ( 16 )
 
 namespace skutils {
 namespace http {
@@ -208,10 +211,11 @@ private:
 class server {
 public:
     mutable int ipVer_ = -1;  // not known before listen
+    mutable int boundToPort_ = -1;
     typedef std::function< void( const request&, response& ) > Handler;
     typedef std::function< void( const request&, const response& ) > Logger;
 
-    server();
+    server( size_t a_max_handler_queues = __SKUTILS_HTTP_DEFAULT_MAX_PARALLEL_QUEUES_COUNT );
 
     virtual ~server();
 
@@ -300,6 +304,24 @@ public:
         while ( is_in_loop() )
             std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
     }
+
+protected:
+    std::mutex queue_handlers_mutex_;
+    size_t max_handler_queues_, current_handler_queue_;
+    skutils::dispatch::queue_id_t handler_queue_id_at_index( size_t i ) const {
+        skutils::dispatch::queue_id_t id;
+        id = skutils::tools::format(
+            "%s/%d/%d-%p-%zu", is_ssl() ? "https" : "http", ipVer_, boundToPort_, this, i );
+        return id;
+    }
+    skutils::dispatch::queue_id_t next_handler_queue_id() {
+        std::lock_guard< std::mutex > guard( queue_handlers_mutex_ );
+        if ( current_handler_queue_ >= max_handler_queues_ )
+            current_handler_queue_ = 0;
+        skutils::dispatch::queue_id_t id = handler_queue_id_at_index( current_handler_queue_ );
+        ++current_handler_queue_;
+        return id;
+    }
 };  /// class server
 
 class client {
@@ -377,7 +399,8 @@ private:
 
 class SSL_server : public server {
 public:
-    SSL_server( const char* cert_path, const char* private_key_path );
+    SSL_server( const char* cert_path, const char* private_key_path,
+        size_t a_max_handler_queues = __SKUTILS_HTTP_DEFAULT_MAX_PARALLEL_QUEUES_COUNT );
     ~SSL_server() override;
     bool is_valid() const override;
     bool is_ssl() const override { return true; }
@@ -1484,11 +1507,15 @@ inline const std::string& buffer_stream::get_buffer() const {
 
 /// HTTP server implementation
 
-inline server::server()
+inline server::server( size_t a_max_handler_queues )
     : keep_alive_max_count_( __SKUTILS_HTTP_KEEPALIVE_MAX_COUNT ),
       is_running_( false ),
       svr_sock_( INVALID_SOCKET ),
-      running_connectoin_handlers_( 0 ) {
+      running_connectoin_handlers_( 0 ),
+      max_handler_queues_( a_max_handler_queues ),
+      current_handler_queue_( 0 ) {
+    if ( max_handler_queues_ < 1 )
+        max_handler_queues_ = 1;
 #ifndef _WIN32
     ::signal( SIGPIPE, SIG_IGN );
 #endif
@@ -1692,10 +1719,11 @@ inline socket_t server::create_server_socket(
     detail::auto_detect_ipVer( ipVer, host );
     ipVer_ = ipVer;
     return detail::create_socket( ipVer, host, port,
-        []( socket_t sock, struct addrinfo& ai ) -> bool {
+        [this, port]( socket_t sock, struct addrinfo& ai ) -> bool {
             if (::bind( sock, ai.ai_addr, static_cast< int >( ai.ai_addrlen ) ) ) {
                 return false;
             }
+            boundToPort_ = port;
             if (::listen( sock, 5 ) ) {  // Listen through 5 channels
                 return false;
             }
@@ -1757,7 +1785,7 @@ inline bool server::listen_internal() {
                 read_and_close_socket( sock );
                 running_connectoin_handlers_decrement();
             };
-            skutils::dispatch::async( fn );
+            skutils::dispatch::async( next_handler_queue_id(), fn );
         }
         for ( ; is_running_; ) {
             std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
@@ -2244,7 +2272,9 @@ inline std::string SSL_socket_stream::get_remote_addr() const {
 
 /// SSL HTTP server implementation
 
-inline SSL_server::SSL_server( const char* cert_path, const char* private_key_path ) {
+inline SSL_server::SSL_server(
+    const char* cert_path, const char* private_key_path, size_t a_max_handler_queues )
+    : server( a_max_handler_queues ) {
     ctx_ = SSL_CTX_new( SSLv23_server_method() );
 
     if ( ctx_ ) {

--- a/libskutils/include/skutils/http.h
+++ b/libskutils/include/skutils/http.h
@@ -1606,7 +1606,7 @@ inline bool server::is_running() const {
 }
 
 inline void server::stop() {
-    close_all_handler_queues();
+    // close_all_handler_queues();
     if ( is_running_ ) {
         is_running_ = false;
         wait_while_in_loop();

--- a/libskutils/include/skutils/http.h
+++ b/libskutils/include/skutils/http.h
@@ -322,7 +322,9 @@ protected:
         ++current_handler_queue_;
         return id;
     }
-    void close_all_handler_quueues() {
+
+public:
+    void close_all_handler_queues() {
         for ( size_t i = 0; i < max_handler_queues_; ++i ) {
             skutils::dispatch::remove( handler_queue_id_at_index( i ) );
         }
@@ -1527,7 +1529,7 @@ inline server::server( size_t a_max_handler_queues )
 }
 
 inline server::~server() {
-    close_all_handler_quueues();
+    close_all_handler_queues();
 }
 
 inline server& server::Get( const char* pattern, Handler handler ) {
@@ -1604,7 +1606,7 @@ inline bool server::is_running() const {
 }
 
 inline void server::stop() {
-    close_all_handler_quueues();
+    close_all_handler_queues();
     if ( is_running_ ) {
         is_running_ = false;
         wait_while_in_loop();

--- a/libweb3jsonrpc/CMakeLists.txt
+++ b/libweb3jsonrpc/CMakeLists.txt
@@ -119,7 +119,7 @@ target_include_directories( web3jsonrpc PRIVATE
 	)
 
 target_link_libraries( web3jsonrpc
-    bls
+#    bls
     ethashseal
     skutils
     ${DEPS_INSTALL_ROOT}/lib/libjsonrpccpp-server.a

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -2000,7 +2000,6 @@ int main( int argc, char** argv ) try {
     if ( client ) {
         unsigned int n = client->blockChain().details().number;
         unsigned int mining = 0;
-
         while ( !exitHandler.shouldExit() )
             stopSealingAfterXBlocks( client.get(), n, mining );
     } else

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -421,6 +421,9 @@ int main( int argc, char** argv ) try {
     addClientOption( "max-connections", po::value< size_t >()->value_name( "<count>" ),
         "Max number of RPC connections(such as web3) summary for all protocols(0 is default and "
         "means unlimited)" );
+    addClientOption( "max-http-queues", po::value< size_t >()->value_name( "<count>" ),
+        "Max number of handler queues for HTTP/S connections per endpoint server" );
+
     addClientOption( "acceptors", po::value< size_t >()->value_name( "<count>" ),
         "Number of parallel RPC connection(such as web3) acceptor threads per protocol(1 is "
         "default and "
@@ -1674,7 +1677,9 @@ int main( int argc, char** argv ) try {
             }
             //
             //
-            size_t maxConnections = 0, cntServers = 1;
+            size_t maxConnections = 0,
+                   max_http_handler_queues = __SKUTILS_HTTP_DEFAULT_MAX_PARALLEL_QUEUES_COUNT,
+                   cntServers = 1;
 
             // First, get "max-connections" true/false from config.json
             // Second, get it from command line parameter (higher priority source)
@@ -1688,6 +1693,19 @@ int main( int argc, char** argv ) try {
             }
             if ( vm.count( "max-connections" ) )
                 maxConnections = vm["max-connections"].as< size_t >();
+            //
+            // First, get "max-http-queues" true/false from config.json
+            // Second, get it from command line parameter (higher priority source)
+            if ( chainConfigParsed ) {
+                try {
+                    max_http_handler_queues =
+                        joConfig["skaleConfig"]["nodeInfo"]["max-http-queues"].get< size_t >();
+                } catch ( ... ) {
+                    maxConnections = __SKUTILS_HTTP_DEFAULT_MAX_PARALLEL_QUEUES_COUNT;
+                }
+            }
+            if ( vm.count( "max-http-queues" ) )
+                maxConnections = vm["max-http-queues"].as< size_t >();
 
             // First, get "acceptors" true/false from config.json
             // Second, get it from command line parameter (higher priority source)
@@ -1747,6 +1765,12 @@ int main( int argc, char** argv ) try {
                 << ( ( maxConnections > 0 ) ? cc::size10( maxConnections ) :
                                               cc::error( "disabled" ) );
             clog( VerbosityInfo, "main" )
+                << cc::debug( "...." ) + cc::info( "Max HTTP queues" )
+                << cc::debug( ".......................... " )
+                << ( ( max_http_handler_queues > 0 ) ? cc::size10( max_http_handler_queues ) :
+                                                       cc::notice( "default" ) );
+            //
+            clog( VerbosityInfo, "main" )
                 << cc::debug( "...." ) + cc::info( "Parallel RPC connection acceptors" )
                 << cc::debug( "........ " ) << cc::size10( cntServers );
             SkaleServerOverride::fn_binary_snapshot_download_t fn_binary_snapshot_download =
@@ -1761,6 +1785,7 @@ int main( int argc, char** argv ) try {
                     chainParams.nodeInfo.ip, nExplicitPortWS4, chainParams.nodeInfo.ip6,
                     nExplicitPortWS6, chainParams.nodeInfo.ip, nExplicitPortWSS4,
                     chainParams.nodeInfo.ip6, nExplicitPortWSS6, strPathSslKey, strPathSslCert );
+            skale_server_connector->max_http_handler_queues_ = max_http_handler_queues;
             //
             skaleStatsFace->setProvider( skale_server_connector );
             skale_server_connector->setConsumer( skaleStatsFace );


### PR DESCRIPTION
- HTTP(S) queues count is limited and configurable
- Servers support and understand shutdown mode
- Arrived message payloads ignored in shutdown mode
- new WS(S) connections rejected in shutdown mode
- fixed bad WS peer reference capture in lambda functions causing crash on shutdown
- no new functions/classes added
- no new tests required