### PR TITLE
SKALE-1947 JSON RPC call time tracking stats added

### DIFF
--- a/libskale/httpserveroverride.h
+++ b/libskale/httpserveroverride.h
@@ -272,6 +272,10 @@ private:
     fn_binary_snapshot_download_t fn_binary_snapshot_download_;
 
 public:
+    const double lfExecutionDurationMaxForPerformanceWarning_;                 // in seconds
+    static const double g_lfDefaultExecutionDurationMaxForPerformanceWarning;  // in seconds,
+                                                                               // default 1 second
+
     SkaleServerOverride( dev::eth::ChainParams& chainParams,
         fn_binary_snapshot_download_t fn_binary_snapshot_download, size_t cntServers,
         dev::eth::Interface* pEth, const std::string& strAddrHTTP4, int nBasePortHTTP4,
@@ -280,7 +284,9 @@ public:
         const std::string& strAddrWS4, int nBasePortWS4, const std::string& strAddrWS6,
         int nBasePortWS6, const std::string& strAddrWSS4, int nBasePortWSS4,
         const std::string& strAddrWSS6, int nBasePortWSS6, const std::string& strPathSslKey,
-        const std::string& strPathSslCert );
+        const std::string& strPathSslCert,
+        double lfExecutionDurationMaxForPerformanceWarning  // in seconds
+    );
     ~SkaleServerOverride() override;
 
     dev::eth::Interface* ethereum() const;
@@ -307,6 +313,8 @@ public:
     void SetUrlHandler( const std::string& url, jsonrpc::IClientConnectionHandler* handler );
 
 private:
+    void logPerformanceWarning( double lfExecutionDuration, int ipVer, const char* strProtocol,
+        int nServerIndex, const char* strOrigin, const char* strMethod, nlohmann::json joID );
     void logTraceServerEvent( bool isError, int ipVer, const char* strProtocol, int nServerIndex,
         const std::string& strMessage );
     void logTraceServerTraffic( bool isRX, bool isError, int ipVer, const char* strProtocol,

--- a/libskale/httpserveroverride.h
+++ b/libskale/httpserveroverride.h
@@ -88,7 +88,7 @@ protected:
 
     struct subscription_data_t {
         subscription_id_t m_idSubscription = 0;
-        SkaleWsPeer* m_pPeer = nullptr;
+        skutils::retain_release_ptr< SkaleWsPeer > m_pPeer;
         size_t m_nIntervalMilliseconds = 0;
         skutils::dispatch::job_id_t m_idDispatchJob;
     };  /// struct subscription_data_t

--- a/libskutils/include/skutils/stats.h
+++ b/libskutils/include/skutils/stats.h
@@ -178,7 +178,75 @@ double stat_compute_bps(
 double stat_compute_bps_last_known(
     const traffic_queue_t& qtr, bytes_count_t* p_nSummary = nullptr );
 double stat_compute_bps_til_now( const traffic_queue_t& qtr, bytes_count_t* p_nSummary = nullptr );
-}  // namespace named_traffic_stats
+};  // namespace named_traffic_stats
+
+namespace time_tracker {
+
+class element : public skutils::ref_retain_release {
+public:
+    typedef std::pair< skutils::stats::time_point, void* > id_t;
+
+    typedef std::chrono::steady_clock clock;
+    typedef std::chrono::time_point< clock > time_point;
+
+    typedef std::chrono::duration< double, std::milli > duration;
+
+private:
+    typedef skutils::multithreading::recursive_mutex_type mutex_type;
+    typedef std::lock_guard< mutex_type > lock_type;
+    static mutex_type& mtx() { return skutils::get_ref_mtx(); }
+
+    mutable volatile bool isError_ = false, isStopped_ = false;
+    mutable std::string strSubSystem_, strProtocol_, strMethod_;
+
+    mutable time_point tpStart_, tpEnd_;
+
+    void do_register();
+    void do_unregister();
+
+public:
+    static const char g_strMethodNameUnknown[];
+
+    element( const char* strSubSystem, const char* strProtocol, const char* strMethod,
+        int /*nServerIndex*/, int /*ipVer*/ );
+    virtual ~element();
+    void stop() const;
+    void setMethod( const char* strMethod ) const;
+    void setError() const;
+    double getDurationInSeconds() const;
+    id_t getID() { return id_t( tpStart_, this ); }
+    const std::string& getProtocol() const { return strProtocol_; }
+    const std::string& getMethod() const { return strMethod_; }
+};  /// class element
+
+typedef skutils::retain_release_ptr< element > element_ptr_t;
+
+class queue : public skutils::ref_retain_release {
+    typedef skutils::multithreading::recursive_mutex_type mutex_type;
+    typedef std::lock_guard< mutex_type > lock_type;
+    static mutex_type& mtx() { return skutils::get_ref_mtx(); }
+
+    typedef std::map< element::id_t, element_ptr_t > map_rtte_t;  // rttID -> rttElement
+    typedef std::map< std::string, map_rtte_t > map_pq_t;         // protocol name -> map_rtte_t
+    map_pq_t map_pq_;
+
+    size_t nMaxItemsInQueue = 100;
+
+public:
+    typedef std::map< std::string, skutils::retain_release_ptr< queue > >
+        map_subsystem_time_trackers_t;
+
+    queue();
+    virtual ~queue();
+    static queue& getQueueForSubsystem( const char* strSubSystem );
+    void do_register( element_ptr_t& rttElement );
+    void do_unregister( element_ptr_t& rttElement );
+    std::list< std::string > getProtocols();
+    nlohmann::json getProtocolStats( const char* strProtocol );
+    nlohmann::json getAllStats();
+};  /// class queue
+
+};  // namespace time_tracker
 
 };  // namespace stats
 };  // namespace skutils

--- a/libskutils/src/stats.cpp
+++ b/libskutils/src/stats.cpp
@@ -433,7 +433,7 @@ void queue::do_register( element_ptr_t& rttElement ) {
         return;
     lock_type lock( mtx() );
     std::string strProtocol = rttElement->getProtocol();
-    std::string strMethod = rttElement->getMethod();
+    // std::string strMethod = rttElement->getMethod();
     element::id_t id = rttElement->getID();
     if ( map_pq_.find( strProtocol ) == map_pq_.end() )
         map_pq_[strProtocol] = map_rtte_t();

--- a/libskutils/src/stats.cpp
+++ b/libskutils/src/stats.cpp
@@ -345,8 +345,235 @@ double stat_compute_bps_til_now(
     return stat_compute_bps( qtr, clock::now(), p_nSummary );
 }
 
-}  // namespace named_traffic_stats
+};  // namespace named_traffic_stats
 
+namespace time_tracker {
+
+const char element::g_strMethodNameUnknown[] = "unknown-method";
+
+element::element( const char* strSubSystem, const char* strProtocol, const char* strMethod,
+    int /*nServerIndex*/, int /*ipVer*/ )
+    : strSubSystem_( strSubSystem ),
+      strProtocol_( strProtocol ),
+      strMethod_(
+          ( strMethod != nullptr && strMethod[0] != '\0' ) ? strMethod : g_strMethodNameUnknown ),
+      tpStart_( skutils::stats::clock::now() ) {
+    if ( strSubSystem_.empty() )
+        strSubSystem_ = "N/A";
+    if ( strProtocol_.empty() )
+        strProtocol_ = "N/A";
+    if ( strMethod_.empty() )
+        strMethod_ = g_strMethodNameUnknown;
+    do_register();
+}
+element::~element() {
+    stop();
+}
+
+void element::do_register() {
+    element_ptr_t rttElement = this;
+    queue::getQueueForSubsystem( strSubSystem_.c_str() ).do_register( rttElement );
+}
+void element::do_unregister() {
+    element_ptr_t rttElement = this;
+    queue::getQueueForSubsystem( strSubSystem_.c_str() ).do_unregister( rttElement );
+}
+
+void element::stop() const {
+    lock_type lock( mtx() );
+    if ( isStopped_ )
+        return;
+    isStopped_ = true;
+    tpEnd_ = skutils::stats::clock::now();
+}
+
+void element::setMethod( const char* strMethod ) const {
+    lock_type lock( mtx() );
+    if ( isStopped_ )
+        return;
+    if ( ( strMethod_.empty() || strMethod_ == g_strMethodNameUnknown ) && strMethod != nullptr &&
+         strMethod[0] != '\0' )
+        strMethod_ = strMethod;
+}
+
+void element::setError() const {
+    lock_type lock( mtx() );
+    isError_ = true;
+}
+
+double element::getDurationInSeconds() const {
+    lock_type lock( mtx() );
+    time_point tpEnd = isStopped_ ? tpEnd_ : skutils::stats::clock::now();
+    duration d = tpEnd - tpStart_;
+    return double( d.count() ) / 1000.0;
+}
+
+queue::queue() {}
+queue::~queue() {}
+
+queue& queue::getQueueForSubsystem( const char* strSubSystem ) {
+    lock_type lock( mtx() );
+    static map_subsystem_time_trackers_t g_map_subsystem_time_trackers;
+    std::string sn = ( strSubSystem != nullptr && strSubSystem[0] != '\0' ) ?
+                         strSubSystem :
+                         "unknowm-time-tracker-subsystem";
+    map_subsystem_time_trackers_t::iterator itFind = g_map_subsystem_time_trackers.find( sn );
+    skutils::retain_release_ptr< queue > pq;
+    if ( itFind != g_map_subsystem_time_trackers.end() )
+        pq = itFind->second;
+    else {
+        pq = new queue;
+        g_map_subsystem_time_trackers[sn] = pq;
+    }
+    return ( *( pq.get() ) );
+}
+
+void queue::do_register( element_ptr_t& rttElement ) {
+    if ( !rttElement )
+        return;
+    lock_type lock( mtx() );
+    std::string strProtocol = rttElement->getProtocol();
+    std::string strMethod = rttElement->getMethod();
+    element::id_t id = rttElement->getID();
+    if ( map_pq_.find( strProtocol ) == map_pq_.end() )
+        map_pq_[strProtocol] = map_rtte_t();
+    map_rtte_t& map_rtte = map_pq_[strProtocol];
+    map_rtte[id] = rttElement;
+    while ( map_rtte.size() > nMaxItemsInQueue && map_rtte.size() > 0 ) {
+        auto it = map_rtte.begin();
+        auto key = it->first;
+        auto value = it->second;
+        map_rtte.erase( key );
+        value = nullptr;
+    }
+}
+
+void queue::do_unregister( element_ptr_t& rttElement ) {
+    if ( !rttElement )
+        return;
+    lock_type lock( mtx() );
+    rttElement->stop();
+    std::string strProtocol = rttElement->getProtocol();
+    if ( map_pq_.find( strProtocol ) == map_pq_.end() )
+        return;
+    map_rtte_t& map_rtte = map_pq_[strProtocol];
+    element::id_t id = rttElement->getID();
+    map_rtte.erase( id );
+}
+
+std::list< std::string > queue::getProtocols() {
+    std::list< std::string > listProtocols;
+    lock_type lock( mtx() );
+    auto pi = map_pq_.cbegin(), pe = map_pq_.cend();
+    for ( ; pi != pe; ++pi )
+        listProtocols.push_back( pi->first );
+    return listProtocols;
+}
+
+nlohmann::json queue::getProtocolStats( const char* strProtocol ) {
+    nlohmann::json joStatsProtocol = nlohmann::json::object();
+    double callTimeMin( 0.0 ), callTimeMax( 0.0 ), callTimeSum( 0.0 );
+    std::string strMethodMin( element::g_strMethodNameUnknown ),
+        strMethodMax( element::g_strMethodNameUnknown );
+    size_t cntEntries = 0;
+    lock_type lock( mtx() );
+    if ( map_pq_.find( strProtocol ) != map_pq_.end() ) {
+        map_rtte_t& map_rtte = map_pq_[strProtocol];
+        map_rtte_t::const_iterator iw = map_rtte.cbegin(), ie = map_rtte.cend();
+        for ( ; iw != ie; ++iw, ++cntEntries ) {
+            double d = iw->second->getDurationInSeconds();
+            callTimeSum += d;
+            const std::string& strMethod = iw->second->getMethod();
+            if ( cntEntries == 0 ) {
+                callTimeMin = callTimeMax = d;
+                strMethodMin = strMethodMax = strMethod;
+                continue;
+            }
+            if ( callTimeMin > d ) {
+                callTimeMin = d;
+                strMethodMin = strMethod;
+            } else if ( callTimeMax < d ) {
+                callTimeMax = d;
+                strMethodMax = strMethod;
+            }
+        }
+    }
+    double denom = ( cntEntries > 0 ) ? cntEntries : 1;
+    double callTimeAvg = callTimeSum / denom;
+    joStatsProtocol["callTimeMin"] = callTimeMin;
+    joStatsProtocol["callTimeMax"] = callTimeMax;
+    joStatsProtocol["callTimeAvg"] = callTimeAvg;
+    joStatsProtocol["callTimeSum"] =
+        callTimeSum;  // for computing callTimeAvg of all protocols only
+    joStatsProtocol["methodMin"] = strMethodMin;
+    joStatsProtocol["methodMax"] = strMethodMax;
+    joStatsProtocol["cntEntries"] = cntEntries;
+    return joStatsProtocol;
+}
+
+nlohmann::json queue::getAllStats() {
+    nlohmann::json joStatsAll = nlohmann::json::object();
+    nlohmann::json joProtocols = nlohmann::json::object();
+    double callTimeMin( 0.0 ), callTimeMax( 0.0 ), callTimeSum( 0.0 );
+    std::string protocolMin( "N/A" ), protocolMax( "N/A" );
+    std::string strMethodMin( element::g_strMethodNameUnknown ),
+        strMethodMax( element::g_strMethodNameUnknown );
+    size_t cntEntries = 0, i = 0;
+    lock_type lock( mtx() );
+    std::list< std::string > listProtocols = getProtocols();
+    std::list< std::string >::const_iterator pi = listProtocols.cbegin(), pe = listProtocols.cend();
+    for ( ; pi != pe; ++pi ) {
+        const std::string& strProtocol = ( *pi );
+        nlohmann::json joStatsProtocol = getProtocolStats( strProtocol.c_str() );
+        size_t cntProtocolEntries = joStatsProtocol["cntEntries"].get< size_t >();
+        if ( cntProtocolEntries == 0 )
+            continue;
+        double protocolTimeMin( joStatsProtocol["callTimeMin"].get< double >() ),
+            protocolTimeMax( joStatsProtocol["callTimeMax"].get< double >() );
+        std::string protocolMethodMin( joStatsProtocol["methodMin"].get< std::string >() ),
+            protocolMethodMax( joStatsProtocol["methodMax"].get< std::string >() );
+        double protocolTimeSum = ( joStatsProtocol["callTimeSum"].get< double >() );
+        callTimeSum += protocolTimeSum;
+        if ( i == 0 ) {
+            callTimeMin = protocolTimeMin;
+            callTimeMax = protocolTimeMax;
+            strMethodMin = protocolMethodMin;
+            strMethodMax = protocolMethodMax;
+            protocolMin = protocolMax = strProtocol;
+        } else {
+            if ( protocolTimeMin < callTimeMin ) {
+                callTimeMin = protocolTimeMin;
+                strMethodMin = protocolMethodMin;
+                protocolMin = strProtocol;
+            } else if ( protocolTimeMax > callTimeMax ) {
+                callTimeMax = protocolTimeMax;
+                strMethodMax = protocolMethodMax;
+                protocolMax = strProtocol;
+            }
+        }
+        cntEntries += cntProtocolEntries;
+        ++i;
+        joStatsProtocol.erase( "callTimeSum" );
+        joStatsProtocol.erase( "cntEntries" );
+        joProtocols[strProtocol] = joStatsProtocol;
+    }
+    double denom = ( cntEntries > 0 ) ? cntEntries : 1;
+    double callTimeAvg = callTimeSum / denom;
+    nlohmann::json joSummary = nlohmann::json::object();
+    joSummary["callTimeMin"] = callTimeMin;
+    joSummary["callTimeMax"] = callTimeMax;
+    joSummary["callTimeAvg"] = callTimeAvg;
+    joSummary["methodMin"] = strMethodMin;
+    joSummary["methodMax"] = strMethodMax;
+    joSummary["protocolMin"] = protocolMin;
+    joSummary["protocolMax"] = protocolMax;
+    // joSummary["cntEntries"] = cntEntries;
+    joStatsAll["summary"] = joSummary;
+    joStatsAll["protocols"] = joProtocols;
+    return joStatsAll;
+}
+
+};  // namespace time_tracker
 
 };  // namespace stats
 };  // namespace skutils

--- a/libskutils/src/ws.cpp
+++ b/libskutils/src/ws.cpp
@@ -3730,9 +3730,7 @@ void server::onOpen( hdl_t hdl ) {
         return;
     }
     onPeerRegister( pPeer );
-    size_t x = pPeer->ref_release();  // un-needed ref after instantiate
-    if ( x > 0 )
-        api_.setPeer( hdl, pPeer );
+    api_.setPeer( hdl, pPeer );
 }
 void server::onClose( hdl_t hdl, const std::string& reason, int local_close_code,
     const std::string& local_close_code_as_str ) {

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -412,6 +412,16 @@ int main( int argc, char** argv ) try {
         "Run web3 WSS(IPv6) server(s) on specified port(and next set of ports if --acceptors > "
         "1)" );
 
+    std::string strPerformanceWarningDurationOptionDescription =
+        "Specifies time margin in floating point format, in seconds, for displaying performance "
+        "warning messages in log output if JSON RPC call processing exeeds it, default is " +
+        std::to_string(
+            SkaleServerOverride::g_lfDefaultExecutionDurationMaxForPerformanceWarning ) +
+        " seconds";
+    addClientOption( "performance-warning-duration",
+        po::value< double >()->value_name( "<seconds>" ),
+        strPerformanceWarningDurationOptionDescription.c_str() );
+
     std::string str_ws_mode_description =
         "Run web3 WS and/or WSS server(s) using specified mode(" +
         skutils::ws::nlws::list_srvmodes_as_str() + "); default mode is " +
@@ -1686,6 +1696,16 @@ int main( int argc, char** argv ) try {
                 if ( ( !strPathSslKey.empty() ) && ( !strPathSslCert.empty() ) )
                     bHaveSSL = true;
             }
+
+            double lfExecutionDurationMaxForPerformanceWarning = SkaleServerOverride::
+                g_lfDefaultExecutionDurationMaxForPerformanceWarning;  // in seconds, default 1
+                                                                       // second
+            if ( vm.count( "performance-warning-duration" ) > 0 ) {
+                lfExecutionDurationMaxForPerformanceWarning = vm["ssl-key"].as< double >();
+                if ( lfExecutionDurationMaxForPerformanceWarning < 0.0 )
+                    lfExecutionDurationMaxForPerformanceWarning = 0.0;
+            }
+
             if ( !bHaveSSL )
                 nExplicitPortHTTPS4 = nExplicitPortWSS4 = nExplicitPortHTTPS6 = nExplicitPortWSS6 =
                     -1;
@@ -1799,14 +1819,14 @@ int main( int argc, char** argv ) try {
                 [=]( const nlohmann::json& joRequest ) -> std::vector< uint8_t > {
                 return skaleFace->impl_skale_downloadSnapshotFragmentBinary( joRequest );
             };
-            auto skale_server_connector =
-                new SkaleServerOverride( chainParams, fn_binary_snapshot_download, cntServers,
-                    client.get(), chainParams.nodeInfo.ip, nExplicitPortHTTP4,
-                    chainParams.nodeInfo.ip6, nExplicitPortHTTP6, chainParams.nodeInfo.ip,
-                    nExplicitPortHTTPS4, chainParams.nodeInfo.ip6, nExplicitPortHTTPS6,
-                    chainParams.nodeInfo.ip, nExplicitPortWS4, chainParams.nodeInfo.ip6,
-                    nExplicitPortWS6, chainParams.nodeInfo.ip, nExplicitPortWSS4,
-                    chainParams.nodeInfo.ip6, nExplicitPortWSS6, strPathSslKey, strPathSslCert );
+            auto skale_server_connector = new SkaleServerOverride( chainParams,
+                fn_binary_snapshot_download, cntServers, client.get(), chainParams.nodeInfo.ip,
+                nExplicitPortHTTP4, chainParams.nodeInfo.ip6, nExplicitPortHTTP6,
+                chainParams.nodeInfo.ip, nExplicitPortHTTPS4, chainParams.nodeInfo.ip6,
+                nExplicitPortHTTPS6, chainParams.nodeInfo.ip, nExplicitPortWS4,
+                chainParams.nodeInfo.ip6, nExplicitPortWS6, chainParams.nodeInfo.ip,
+                nExplicitPortWSS4, chainParams.nodeInfo.ip6, nExplicitPortWSS6, strPathSslKey,
+                strPathSslCert, lfExecutionDurationMaxForPerformanceWarning );
             skale_server_connector->max_http_handler_queues_ = max_http_handler_queues;
             //
             skaleStatsFace->setProvider( skale_server_connector );


### PR DESCRIPTION
- Extended stats provided by **skaled**
- Stats include JSON RPC method call time information
- Feature allows to analyze **skaled** performance
- **skaled** prints configurable performance warnings in logs