### PR TITLE
Feature/skale 2212 sign snapshot with old bls key

### DIFF
--- a/libskale/SnapshotHashAgent.cpp
+++ b/libskale/SnapshotHashAgent.cpp
@@ -115,17 +115,21 @@ bool SnapshotHashAgent::voteForHash( std::pair< dev::h256, libff::alt_bn128_G1 >
                       << cc::warn( ex.what() ) << "\n";
         }
 
-//        libff::alt_bn128_G2 common_public;
+        //        libff::alt_bn128_G2 common_public;
 
-//        common_public.X.c0 =
-//            libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[0].c_str() );
-//        common_public.X.c1 =
-//            libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[1].c_str() );
-//        common_public.Y.c0 =
-//            libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[2].c_str() );
-//        common_public.Y.c1 =
-//            libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[3].c_str() );
-//        common_public.Z = libff::alt_bn128_Fq2::one();
+        //        common_public.X.c0 =
+        //            libff::alt_bn128_Fq(
+        //            chain_params_.nodeInfo.insecureCommonBLSPublicKeys[0].c_str() );
+        //        common_public.X.c1 =
+        //            libff::alt_bn128_Fq(
+        //            chain_params_.nodeInfo.insecureCommonBLSPublicKeys[1].c_str() );
+        //        common_public.Y.c0 =
+        //            libff::alt_bn128_Fq(
+        //            chain_params_.nodeInfo.insecureCommonBLSPublicKeys[2].c_str() );
+        //        common_public.Y.c1 =
+        //            libff::alt_bn128_Fq(
+        //            chain_params_.nodeInfo.insecureCommonBLSPublicKeys[3].c_str() );
+        //        common_public.Z = libff::alt_bn128_Fq2::one();
 
         try {
             libff::inhibit_profiling_info = true;

--- a/libskale/SnapshotHashAgent.cpp
+++ b/libskale/SnapshotHashAgent.cpp
@@ -115,23 +115,23 @@ bool SnapshotHashAgent::voteForHash( std::pair< dev::h256, libff::alt_bn128_G1 >
                       << cc::warn( ex.what() ) << "\n";
         }
 
-        libff::alt_bn128_G2 common_public;
+//        libff::alt_bn128_G2 common_public;
 
-        common_public.X.c0 =
-            libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[0].c_str() );
-        common_public.X.c1 =
-            libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[1].c_str() );
-        common_public.Y.c0 =
-            libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[2].c_str() );
-        common_public.Y.c1 =
-            libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[3].c_str() );
-        common_public.Z = libff::alt_bn128_Fq2::one();
+//        common_public.X.c0 =
+//            libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[0].c_str() );
+//        common_public.X.c1 =
+//            libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[1].c_str() );
+//        common_public.Y.c0 =
+//            libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[2].c_str() );
+//        common_public.Y.c1 =
+//            libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[3].c_str() );
+//        common_public.Z = libff::alt_bn128_Fq2::one();
 
         try {
             libff::inhibit_profiling_info = true;
             if ( !this->bls_->Verification(
                      std::make_shared< std::array< uint8_t, 32 > >( ( *it ).first.asArray() ),
-                     common_signature, common_public ) ) {
+                     common_signature, this->common_public_key_ ) ) {
                 return false;
             }
         } catch ( signatures::Bls::IsNotWellFormed& ex ) {

--- a/libskale/SnapshotHashAgent.cpp
+++ b/libskale/SnapshotHashAgent.cpp
@@ -115,22 +115,6 @@ bool SnapshotHashAgent::voteForHash( std::pair< dev::h256, libff::alt_bn128_G1 >
                       << cc::warn( ex.what() ) << "\n";
         }
 
-        //        libff::alt_bn128_G2 common_public;
-
-        //        common_public.X.c0 =
-        //            libff::alt_bn128_Fq(
-        //            chain_params_.nodeInfo.insecureCommonBLSPublicKeys[0].c_str() );
-        //        common_public.X.c1 =
-        //            libff::alt_bn128_Fq(
-        //            chain_params_.nodeInfo.insecureCommonBLSPublicKeys[1].c_str() );
-        //        common_public.Y.c0 =
-        //            libff::alt_bn128_Fq(
-        //            chain_params_.nodeInfo.insecureCommonBLSPublicKeys[2].c_str() );
-        //        common_public.Y.c1 =
-        //            libff::alt_bn128_Fq(
-        //            chain_params_.nodeInfo.insecureCommonBLSPublicKeys[3].c_str() );
-        //        common_public.Z = libff::alt_bn128_Fq2::one();
-
         try {
             libff::inhibit_profiling_info = true;
             if ( !this->bls_->Verification(

--- a/libskale/SnapshotHashAgent.h
+++ b/libskale/SnapshotHashAgent.h
@@ -27,8 +27,8 @@
 
 #include <libconsensus/libBLS/bls/bls.h>
 #include <libethereum/ChainParams.h>
-#include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
 #include <boost/algorithm/string.hpp>
+#include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
 
 namespace dev {
 namespace test {
@@ -62,24 +62,25 @@ public:
 
 class SnapshotHashAgent {
 public:
-    SnapshotHashAgent( const dev::eth::ChainParams& chain_params, const std::string& common_public_key = "" )
+    SnapshotHashAgent(
+        const dev::eth::ChainParams& chain_params, const std::string& common_public_key = "" )
         : chain_params_( chain_params ), n_( chain_params.sChain.nodes.size() ) {
         this->hashes_.resize( n_ );
         this->signatures_.resize( n_ );
         this->public_keys_.resize( n_ );
         if ( common_public_key == "" ) {
-            common_public_key_.X.c0 =
-                libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[0].c_str() );
-            common_public_key_.X.c1 =
-                libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[1].c_str() );
-            common_public_key_.Y.c0 =
-                libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[2].c_str() );
-            common_public_key_.Y.c1 =
-                libff::alt_bn128_Fq( chain_params_.nodeInfo.insecureCommonBLSPublicKeys[3].c_str() );
+            common_public_key_.X.c0 = libff::alt_bn128_Fq(
+                chain_params_.nodeInfo.insecureCommonBLSPublicKeys[0].c_str() );
+            common_public_key_.X.c1 = libff::alt_bn128_Fq(
+                chain_params_.nodeInfo.insecureCommonBLSPublicKeys[1].c_str() );
+            common_public_key_.Y.c0 = libff::alt_bn128_Fq(
+                chain_params_.nodeInfo.insecureCommonBLSPublicKeys[2].c_str() );
+            common_public_key_.Y.c1 = libff::alt_bn128_Fq(
+                chain_params_.nodeInfo.insecureCommonBLSPublicKeys[3].c_str() );
             common_public_key_.Z = libff::alt_bn128_Fq2::one();
         } else {
-            std::vector<std::string> coords;
-            boost::split(coords, common_public_key, [](char c){return c == ':';});
+            std::vector< std::string > coords;
+            boost::split( coords, common_public_key, []( char c ) { return c == ':'; } );
             common_public_key_.X.c0 = libff::alt_bn128_Fq( coords[0].c_str() );
             common_public_key_.X.c1 = libff::alt_bn128_Fq( coords[1].c_str() );
             common_public_key_.Y.c0 = libff::alt_bn128_Fq( coords[2].c_str() );

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -38,6 +38,8 @@
 #include <skutils/console_colors.h>
 #include <skutils/eth_utils.h>
 
+#include <boost/algorithm/string.hpp>
+
 //#include <nlohmann/json.hpp>
 #include <json.hpp>
 
@@ -60,22 +62,6 @@ namespace dev {
 namespace rpc {
 
 std::string exceptionToErrorMessage();
-
-std::vector< std::string > SplitString( const std::string& str, const char delim ) {
-    std::vector< std::string > retVal;
-
-    auto start = 0U;
-    auto end = str.find( delim );
-    while ( end != std::string::npos ) {
-        retVal.push_back( str.substr( start, end - start ) );
-        start = end + 1;
-        end = str.find( delim, start );
-    }
-
-    retVal.push_back( str.substr( start, end ) );
-
-    return retVal;
-}
 
 Skale::Skale( Client& _client ) : m_client( _client ) {}
 
@@ -373,7 +359,9 @@ Json::Value Skale::skale_getSnapshotSignature( unsigned blockNumber ) {
         }
         std::string signature_with_helper = joResponse["signatureShare"].get< std::string >();
 
-        auto splited_string = SplitString( signature_with_helper, ':' );
+        std::vector< std::string > splited_string;
+        splited_string = boost::split(
+            splited_string, signature_with_helper, []( char c ) { return c == ':'; } );
 
         nlohmann::json joSignature = nlohmann::json::object();
 

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1116,8 +1116,11 @@ int main( int argc, char** argv ) try {
     if ( vm.count( "download-snapshot" ) ) {
         std::string commonPublicKey;
         if ( !vm.count( "public-key" ) ) {
-            throw std::runtime_error(
-                cc::error( "Missing --public-key option - cannot download snapshot" ) );
+            // for tests only!
+            commonPublicKey = "";
+            //            throw std::runtime_error(
+            //                cc::error( "Missing --public-key option - cannot download snapshot" )
+            //                );
         } else {
             commonPublicKey = vm["public-key"].as< std::string >();
         }
@@ -1133,7 +1136,7 @@ int main( int argc, char** argv ) try {
         }
 
         if ( blockNumber > 0 ) {
-            SnapshotHashAgent snapshotHashAgent( chainParams );
+            SnapshotHashAgent snapshotHashAgent( chainParams, commonPublicKey );
 
             libff::init_alt_bn128_params();
             std::pair< dev::h256, libff::alt_bn128_G1 > voted_hash;

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -490,8 +490,9 @@ int main( int argc, char** argv ) try {
         "Download snapshot from other skaled node specified by web3/json-rpc url" );
     // addClientOption( "download-target", po::value< string >()->value_name( "<port>" ),
     //    "Path of file to save downloaded snapshot to" );
-    addClientOption( "public-key", po::value< std::string >()->value_name( "<libff::alt_bn128_G2>" ),
-            "Collects old common public key from chain to verify snapshot before starts from it" );
+    addClientOption( "public-key",
+        po::value< std::string >()->value_name( "<libff::alt_bn128_G2>" ),
+        "Collects old common public key from chain to verify snapshot before starts from it" );
 
     LoggingOptions loggingOptions;
     po::options_description loggingProgramOptions(
@@ -1111,7 +1112,8 @@ int main( int argc, char** argv ) try {
     if ( vm.count( "download-snapshot" ) ) {
         std::string commonPublicKey;
         if ( !vm.count( "public-key" ) ) {
-            throw std::runtime_error( cc::error( "Missing --public-key option - cannot download snapshot" ) );
+            throw std::runtime_error(
+                cc::error( "Missing --public-key option - cannot download snapshot" ) );
         } else {
             commonPublicKey = vm["public-key"].as< std::string >();
         }

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1151,15 +1151,18 @@ int main( int argc, char** argv ) try {
 
     if ( vm.count( "download-snapshot" ) ||
          isNeededToDownloadSnapshot( chainParams, dev::getDataDir(), withExisting ) ) {
-        std::string commonPublicKey;
-        if ( !vm.count( "public-key" ) ) {
-            // for tests only!
-            commonPublicKey = "";
-            //            throw std::runtime_error(
-            //                cc::error( "Missing --public-key option - cannot download snapshot" )
-            //                );
-        } else {
-            commonPublicKey = vm["public-key"].as< std::string >();
+        std::string commonPublicKey = "";
+        if ( vm.count( "download-snapshot" ) ) {
+            if ( !vm.count( "public-key" ) ) {
+                // for tests only! remove it later
+                commonPublicKey = "";
+                //            throw std::runtime_error(
+                //                cc::error( "Missing --public-key option - cannot download
+                //                snapshot" )
+                //                );
+            } else {
+                commonPublicKey = vm["public-key"].as< std::string >();
+            }
         }
         std::string strURLWeb3 = vm["download-snapshot"].as< string >();
         unsigned blockNumber;

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -490,6 +490,8 @@ int main( int argc, char** argv ) try {
         "Download snapshot from other skaled node specified by web3/json-rpc url" );
     // addClientOption( "download-target", po::value< string >()->value_name( "<port>" ),
     //    "Path of file to save downloaded snapshot to" );
+    addClientOption( "public-key", po::value< std::string >()->value_name( "<libff::alt_bn128_G2>" ),
+            "Collects old common public key from chain to verify snapshot before starts from it" );
 
     LoggingOptions loggingOptions;
     po::options_description loggingProgramOptions(
@@ -1107,6 +1109,13 @@ int main( int argc, char** argv ) try {
                               "blocks_" + chainParams.nodeInfo.id.str() + ".db"} ) );
 
     if ( vm.count( "download-snapshot" ) ) {
+        std::string commonPublicKey;
+        if ( !vm.count( "public-key" ) ) {
+            throw std::runtime_error( cc::error( "Missing --public-key option - cannot download snapshot" ) );
+        } else {
+            commonPublicKey = vm["public-key"].as< std::string >();
+        }
+
         std::string strURLWeb3 = vm["download-snapshot"].as< string >();
         unsigned blockNumber;
         try {

--- a/test/unittests/libskale/HashSnapshot.cpp
+++ b/test/unittests/libskale/HashSnapshot.cpp
@@ -59,8 +59,7 @@ public:
             }
         }
 
-        signatures::Bls obj =
-            signatures::Bls( _chainParams.sChain.t, _chainParams.sChain.n );
+        signatures::Bls obj = signatures::Bls( _chainParams.sChain.t, _chainParams.sChain.n );
         std::vector< size_t > idx( _chainParams.sChain.t );
         for ( size_t i = 0; i < _chainParams.sChain.t; ++i ) {
             idx[i] = i + 1;
@@ -68,10 +67,14 @@ public:
         auto lagrange_coeffs = obj.LagrangeCoeffs( idx );
         auto keys = obj.KeysRecover( lagrange_coeffs, this->insecureBlsPrivateKeys_ );
         keys.second.to_affine_coordinates();
-        _chainParams.nodeInfo.insecureCommonBLSPublicKeys[0] = BLSutils::ConvertToString( keys.second.X.c0 );
-        _chainParams.nodeInfo.insecureCommonBLSPublicKeys[1] = BLSutils::ConvertToString( keys.second.X.c1 );
-        _chainParams.nodeInfo.insecureCommonBLSPublicKeys[2] = BLSutils::ConvertToString( keys.second.Y.c0 );
-        _chainParams.nodeInfo.insecureCommonBLSPublicKeys[3] = BLSutils::ConvertToString( keys.second.Y.c1 );
+        _chainParams.nodeInfo.insecureCommonBLSPublicKeys[0] =
+            BLSutils::ConvertToString( keys.second.X.c0 );
+        _chainParams.nodeInfo.insecureCommonBLSPublicKeys[1] =
+            BLSutils::ConvertToString( keys.second.X.c1 );
+        _chainParams.nodeInfo.insecureCommonBLSPublicKeys[2] =
+            BLSutils::ConvertToString( keys.second.Y.c0 );
+        _chainParams.nodeInfo.insecureCommonBLSPublicKeys[3] =
+            BLSutils::ConvertToString( keys.second.Y.c1 );
 
         this->insecure_secret = keys.first;
 


### PR DESCRIPTION
low risk
add feature related to node rotation - verify snapshot's signature by old BLS public key