### PR TITLE
SKALE-2188 fixed build problem with unused variable warnings treated …

### DIFF
--- a/libskutils/src/dispatch.cpp
+++ b/libskutils/src/dispatch.cpp
@@ -527,7 +527,7 @@ void loop::job_data_t::init() {
 #endif
     if ( !pLoop_ )
         return;
-    uv_loop_t* p_uvLoop = ( uv_loop_t* ) ( void* ) pLoop_->p_uvLoop_;
+    // uv_loop_t* p_uvLoop = ( uv_loop_t* ) ( void* ) pLoop_->p_uvLoop_;
     needsCancel_ = true;
     // nanoseconds
     uint64_t ns_timeout = timeout_.count(), ns_interval = interval_.count();

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -292,6 +292,9 @@ void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >
 
 bool isNeededToDownloadSnapshot( const ChainParams& _chainParams,
     const boost::filesystem::path& _dbPath, WithExisting _forceAction ) {
+    if ( _chainParams.nodeInfo.snapshotIntervalMs <= 0 ) {
+        return false;
+    }
     BlockChain bc( _chainParams, _dbPath, _forceAction );
     unsigned currentNumber = bc.number();
 

--- a/test/unittests/libskutils/test_skutils_helper.cpp
+++ b/test/unittests/libskutils/test_skutils_helper.cpp
@@ -1226,8 +1226,8 @@ void test_protocol_serial_calls(
             strProto, nPort );
     } );
     size_t idxWaitAttempt, cntWaitAttempts = size_t( cnt_clients ) + 1;
-    for ( size_t idxWaitAttempt = 0; size_t( idxWaitAttempt ) < size_t( cntWaitAttempts ) &&
-                                     size_t( cnt_actions_performed ) < size_t( cnt_clients );
+    for ( idxWaitAttempt = 0; size_t( idxWaitAttempt ) < size_t( cntWaitAttempts ) &&
+                              size_t( cnt_actions_performed ) < size_t( cnt_clients );
           ++idxWaitAttempt ) {
         skutils::test::test_log_e(
             cc::debug( "Waiting for test to complete, step " ) +
@@ -1294,8 +1294,8 @@ void test_protocol_parallel_calls(
         skutils::test::test_log_e( cc::sunny( "Server finish" ) );
     } );
     size_t idxWaitAttempt, cntWaitAttempts = size_t( cnt_clients ) + 1;
-    for ( size_t idxWaitAttempt = 0; size_t( idxWaitAttempt ) < size_t( cntWaitAttempts ) &&
-                                     size_t( cnt_actions_performed ) < size_t( cnt_clients );
+    for ( idxWaitAttempt = 0; size_t( idxWaitAttempt ) < size_t( cntWaitAttempts ) &&
+                              size_t( cnt_actions_performed ) < size_t( cnt_clients );
           ++idxWaitAttempt ) {
         skutils::test::test_log_e(
             cc::debug( "Waiting for test to complete, step " ) +


### PR DESCRIPTION
…as errors

- this is only a build fix
- due to some reasons these build errors are not detected by travis build
- all the fixed errors are unused variable warnings treated as errors
- fixed skaled startup error with Oleg
- no new features, classes, functions added
- no new tests required