### PR TITLE
Bug/skale 2249 improve dispatch unit tests

### DIFF
--- a/test/unittests/libskutils/test_skutils_dispatch.cpp
+++ b/test/unittests/libskutils/test_skutils_dispatch.cpp
@@ -727,13 +727,23 @@ BOOST_AUTO_TEST_CASE( simple_api ) {
         );
         //
         //
-        static const size_t nSleepSeconds = 5;
-        skutils::test::test_log_e( thread_prefix_str() + cc::warn( "will sleep " ) +
-                                   cc::size10( nSleepSeconds ) + cc::warn( " second(s)..." ) );
-        sleep( nSleepSeconds );
-        skutils::test::test_log_e( thread_prefix_str() + cc::warn( "done sleeping " ) +
-                                   cc::size10( nSleepSeconds ) +
-                                   cc::warn( " second(s), end of domain life time..." ) );
+        static const size_t nSleepSeconds = 5, nWaitRoundCount = 5;
+        for( size_t nWaitRound = 0; nWaitRound < nWaitRoundCount; ++ nWaitRound ) {
+          skutils::test::test_log_e( thread_prefix_str()
+              + cc::warn( "waiting for test to complete in round " ) + cc::size10( nWaitRound+1 )
+              + cc::warn( " of " ) + cc::size10( nWaitRoundCount )
+              + cc::warn( ", will sleep " ) + cc::size10( nSleepSeconds ) + cc::warn( " second(s)..." ) );
+          sleep( nSleepSeconds );
+          skutils::test::test_log_e( thread_prefix_str() + cc::warn( "done sleeping " ) +
+                                     cc::size10( nSleepSeconds ) +
+                                     cc::warn( " second(s), end of domain life time..." ) );
+          if( size_t( nCallCounterOnce ) == 1
+              && size_t( nCallCounterPeriodic ) >= size_t( nCallCounterPeriodicExpected )
+              && size_t( nCallCounterAsync ) >= size_t( nCallCounterAsyncExpected )
+              && size_t( nCallCounterSync ) >= size_t( nCallCounterSyncExpected )
+              )
+              break;
+        } // for( size_t nWaitRound = 0; nWaitRound < nWaitRoundCount; ++ nWaitRound )
         skutils::test::test_log_e(
             thread_prefix_str() + cc::warn( "shutting down default domain..." ) );
         skutils::dispatch::shutdown();

--- a/test/unittests/libskutils/test_skutils_dispatch.cpp
+++ b/test/unittests/libskutils/test_skutils_dispatch.cpp
@@ -585,13 +585,26 @@ BOOST_AUTO_TEST_CASE( domain_timing_functionality_alive ) {
                 skutils::dispatch::duration_from_milliseconds( 1500 )  // 1.5 seconds
             );
             //
-            static const size_t nSleepSeconds = 5;
-            skutils::test::test_log_e( thread_prefix_str() + cc::warn( "will sleep " ) +
-                                       cc::size10( nSleepSeconds ) + cc::warn( " second(s)..." ) );
-            sleep( nSleepSeconds );
-            skutils::test::test_log_e( thread_prefix_str() + cc::warn( "done sleeping " ) +
-                                       cc::size10( nSleepSeconds ) +
-                                       cc::warn( " second(s), end of domain life time..." ) );
+            //
+            static const size_t nSleepSeconds = 5, nWaitRoundCount = 5;
+            for( size_t nWaitRound = 0; nWaitRound < nWaitRoundCount; ++ nWaitRound ) {
+              skutils::test::test_log_e( thread_prefix_str()
+                                        + cc::warn( "waiting for test to complete in round " ) + cc::size10( nWaitRound+1 )
+                                        + cc::warn( " of " ) + cc::size10( nWaitRoundCount )
+                                        + cc::warn( ", will sleep " ) + cc::size10( nSleepSeconds ) + cc::warn( " second(s)..." ) );
+              sleep( nSleepSeconds );
+              skutils::test::test_log_e( thread_prefix_str() + cc::warn( "done sleeping " ) +
+                                        cc::size10( nSleepSeconds ) +
+                                        cc::warn( " second(s), end of domain life time..." ) );
+              if( size_t( nCallCounterOnce ) >= 1
+                  && size_t( nCallCounterPeriodic ) >= size_t( nCallCounterPeriodicExpected )
+                  && size_t( nCallCounterAsync ) >= size_t( nCallCounterAsyncExpected )
+                  && size_t( nCallCounterSync ) >= size_t( nCallCounterSyncExpected )
+                  )
+                break;
+            } // for( size_t nWaitRound = 0; nWaitRound < nWaitRoundCount; ++ nWaitRound )
+            //
+            //
             skutils::test::test_log_e(
                 thread_prefix_str() + cc::warn( "shutting down domain..." ) );
             pDomain->shutdown();

--- a/test/unittests/libskutils/test_skutils_dispatch.cpp
+++ b/test/unittests/libskutils/test_skutils_dispatch.cpp
@@ -744,9 +744,12 @@ BOOST_AUTO_TEST_CASE( simple_api ) {
               )
               break;
         } // for( size_t nWaitRound = 0; nWaitRound < nWaitRoundCount; ++ nWaitRound )
+        //
+        //
         skutils::test::test_log_e(
             thread_prefix_str() + cc::warn( "shutting down default domain..." ) );
         skutils::dispatch::shutdown();
+        //
         //
         skutils::test::test_log_e(
             cc::notice( "once job" ) + cc::debug( "     expected exactly one call" ) +
@@ -855,13 +858,25 @@ BOOST_AUTO_TEST_CASE( auto_queues ) {
                                    cc::bright( async_job_id2 ) );
         //
         //
-        static const size_t nSleepSeconds = 5;
-        skutils::test::test_log_e( thread_prefix_str() + cc::warn( "will sleep " ) +
-                                   cc::size10( nSleepSeconds ) + cc::warn( " second(s)..." ) );
-        sleep( nSleepSeconds );
-        skutils::test::test_log_e( thread_prefix_str() + cc::warn( "done sleeping " ) +
-                                   cc::size10( nSleepSeconds ) +
-                                   cc::warn( " second(s), end of domain life time..." ) );
+        static const size_t nSleepSeconds = 5, nWaitRoundCount = 5;
+        for( size_t nWaitRound = 0; nWaitRound < nWaitRoundCount; ++ nWaitRound ) {
+          skutils::test::test_log_e( thread_prefix_str()
+                                    + cc::warn( "waiting for test to complete in round " ) + cc::size10( nWaitRound+1 )
+                                    + cc::warn( " of " ) + cc::size10( nWaitRoundCount )
+                                    + cc::warn( ", will sleep " ) + cc::size10( nSleepSeconds ) + cc::warn( " second(s)..." ) );
+          sleep( nSleepSeconds );
+          skutils::test::test_log_e( thread_prefix_str() + cc::warn( "done sleeping " ) +
+                                    cc::size10( nSleepSeconds ) +
+                                    cc::warn( " second(s), end of domain life time..." ) );
+          if( size_t( nCallCounterAsync ) >= size_t( nCallCounterAsyncExpected )
+              && size_t( nCallCounterSync ) >= size_t( nCallCounterSyncExpected )
+              && size_t( nCallCounterAsync ) >= size_t( nCallCounterAsyncExpected )
+              && size_t( nCallCounterSync ) >= size_t( nCallCounterSyncExpected )
+              && size_t( nCallCounterSync ) >= size_t( nCallCounterAsync )
+              )
+              break;
+        } // for( size_t nWaitRound = 0; nWaitRound < nWaitRoundCount; ++ nWaitRound )
+        //
         //
         skutils::test::test_log_e( thread_prefix_str() +
                                    cc::warn( "stopping async periodical job " ) +
@@ -903,9 +918,9 @@ BOOST_AUTO_TEST_CASE( auto_queues ) {
             ( ( size_t( nCallCounterSync ) >= size_t( nCallCounterSyncExpected ) ) ?
                     cc::success( "success" ) :
                     cc::fatal( "fail" ) ) );
-        BOOST_REQUIRE( size_t( nCallCounterAsync ) == size_t( nCallCounterAsyncExpected ) );
-        BOOST_REQUIRE( size_t( nCallCounterSync ) == size_t( nCallCounterSyncExpected ) );
-        BOOST_REQUIRE( size_t( nCallCounterSync ) == size_t( nCallCounterAsync ) );
+        BOOST_REQUIRE( size_t( nCallCounterAsync ) >= size_t( nCallCounterAsyncExpected ) );
+        BOOST_REQUIRE( size_t( nCallCounterSync ) >= size_t( nCallCounterSyncExpected ) );
+        BOOST_REQUIRE( size_t( nCallCounterSync ) >= size_t( nCallCounterAsync ) );
         //
         skutils::test::test_log_e( thread_prefix_str() + cc::info( "end of auto_queues test" ) );
     } );

--- a/test/unittests/libskutils/test_skutils_dispatch.cpp
+++ b/test/unittests/libskutils/test_skutils_dispatch.cpp
@@ -993,28 +993,34 @@ BOOST_AUTO_TEST_CASE( cross_jobs ) {
                 BOOST_REQUIRE( !bool( vecInside[i] ) );
             } );
         }
-        static const size_t nSleepSecondsNormalAttempt = 5;
-        skutils::test::test_log_e( thread_prefix_str() + cc::warn( "will sleep " ) +
-                                   cc::size10( nSleepSecondsNormalAttempt ) +
-                                   cc::warn( " second(s)..." ) );
-        sleep( nSleepSecondsNormalAttempt );
-        skutils::test::test_log_e( thread_prefix_str() + cc::warn( "done sleeping " ) +
-                                   cc::size10( nSleepSecondsNormalAttempt ) +
-                                   cc::warn( " second(s), end of domain life time..." ) );
         //
-        // pre-liminary attempt to find out everything is OKay
-        skutils::test::test_log_e(
-            thread_prefix_str() + cc::info( "performing preliminary state test..." ) );
-        bool isEverythingOKay = true;
-        for ( i = 0; i < nQueueCount; ++i ) {
+        //
+        bool isEverythingOKay = true; // assume good thing
+        static const size_t nSleepSeconds = 5, nWaitRoundCount = 5;
+        for( size_t nWaitRound = 0; nWaitRound < nWaitRoundCount; ++ nWaitRound ) {
+          skutils::test::test_log_e( thread_prefix_str()
+                                    + cc::warn( "waiting for test to complete in round " ) + cc::size10( nWaitRound+1 )
+                                    + cc::warn( " of " ) + cc::size10( nWaitRoundCount )
+                                    + cc::warn( ", will sleep " ) + cc::size10( nSleepSeconds ) + cc::warn( " second(s)..." ) );
+          sleep( nSleepSeconds );
+          skutils::test::test_log_e( thread_prefix_str() + cc::warn( "done sleeping " ) +
+                                    cc::size10( nSleepSeconds ) +
+                                    cc::warn( " second(s), end of domain life time..." ) );
+          //
+          //
+          // pre-liminary attempt to find out everything is OKay
+          skutils::test::test_log_e(
+              thread_prefix_str() + cc::info( "performing preliminary state test..." ) );
+          isEverythingOKay = true; // assume good thing
+          for ( i = 0; i < nQueueCount; ++i ) {
             bool bInside = bool( vecInside[i] );
             skutils::test::test_log_e(
                 thread_prefix_str() + cc::debug( "queue " ) + cc::size10( i ) +
                 cc::debug( " is " ) +
                 ( ( !bInside ) ? cc::success( "OKay" ) : cc::fatal( "STILL WORKING - FAIL" ) ) );
             if ( bInside ) {
-                isEverythingOKay = false;
-                break;
+              isEverythingOKay = false;
+              break;
             }
             skutils::dispatch::queue_id_t id_queue_current =
                 skutils::tools::format( "queue_%zu", i );
@@ -1027,11 +1033,14 @@ BOOST_AUTO_TEST_CASE( cross_jobs ) {
                 cc::debug( " has " ) + cc::size10( nQueueJobCount ) +
                 cc::debug( " job(s) unfinished " ) +
                 ( ( nQueueJobCount == 0 ) ? cc::success( "OKay" ) :
-                                            cc::fatal( "FAIL, MUST BE ZERO" ) ) );
-        }
-        skutils::test::test_log_e(
-            thread_prefix_str() + cc::info( "done preliminary state test - " ) +
-            ( isEverythingOKay ? cc::success( "PASSED" ) : cc::fatal( "FAILED" ) ) );
+                                       cc::fatal( "FAIL, MUST BE ZERO" ) ) );
+          }
+          skutils::test::test_log_e(
+              thread_prefix_str() + cc::info( "done preliminary state test - " ) +
+              ( isEverythingOKay ? cc::success( "PASSED" ) : cc::fatal( "FAILED" ) ) );
+          if( isEverythingOKay )
+            break;
+        } // for( size_t nWaitRound = 0; nWaitRound < nWaitRoundCount; ++ nWaitRound )
         //
         //
         if ( !isEverythingOKay ) {

--- a/test/unittests/libskutils/test_skutils_dispatch.cpp
+++ b/test/unittests/libskutils/test_skutils_dispatch.cpp
@@ -225,13 +225,21 @@ BOOST_AUTO_TEST_CASE( domain_functionality_alive ) {
             }
             //
             //
-            static const size_t nSleepSeconds = 3;
-            skutils::test::test_log_e( thread_prefix_str() + cc::warn( "will sleep " ) +
-                                       cc::size10( nSleepSeconds ) + cc::warn( " second(s)..." ) );
-            sleep( nSleepSeconds );
-            skutils::test::test_log_e( thread_prefix_str() + cc::warn( "done sleeping " ) +
-                                       cc::size10( nSleepSeconds ) +
-                                       cc::warn( " second(s), end of domain life time..." ) );
+            static const size_t nSleepSeconds = 5, nWaitRoundCount = 5;
+            for( size_t nWaitRound = 0; nWaitRound < nWaitRoundCount; ++ nWaitRound ) {
+              skutils::test::test_log_e( thread_prefix_str()
+                                        + cc::warn( "waiting for test to complete in round " ) + cc::size10( nWaitRound+1 )
+                                        + cc::warn( " of " ) + cc::size10( nWaitRoundCount )
+                                        + cc::warn( ", will sleep " ) + cc::size10( nSleepSeconds ) + cc::warn( " second(s)..." ) );
+              sleep( nSleepSeconds );
+              skutils::test::test_log_e( thread_prefix_str() + cc::warn( "done sleeping " ) +
+                                        cc::size10( nSleepSeconds ) +
+                                        cc::warn( " second(s), end of domain life time..." ) );
+              if( size_t( nExpectedCallCount ) == size_t( nCallCounter ) )
+                break;
+            } // for( size_t nWaitRound = 0; nWaitRound < nWaitRoundCount; ++ nWaitRound )
+            //
+            //
             skutils::test::test_log_e(
                 thread_prefix_str() + cc::warn( "shutting down domain..." ) );
             pDomain->shutdown();


### PR DESCRIPTION
I used `stress -c 128` and and `stress-ng` to make Linux as slow as possible but still reacting mouse and keyboard input. All the failed tests were improved and now passing under stress load.