### PR TITLE
SKALE-2352 Fixed skaled build errors on clang and Mac OSX

### DIFF
--- a/libskutils/include/skutils/http.h
+++ b/libskutils/include/skutils/http.h
@@ -3,7 +3,8 @@
 #if ( !defined SKUTILS_HTTP_H )
 #define SKUTILS_HTTP_H 1
 
-#ifdef _WIN32
+#if ( defined _WIN32 )
+
 #ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
 #endif  //_CRT_SECURE_NO_WARNINGS
@@ -39,21 +40,15 @@
 #endif  // strcasecmp
 
 typedef SOCKET socket_t;
-#else
-#include <arpa/inet.h>
-#include <netdb.h>
-#include <netinet/in.h>
-#include <pthread.h>
-#include <signal.h>
-#include <sys/poll.h>
-#include <sys/select.h>
-#include <sys/socket.h>
-#include <unistd.h>
+
+#else  // (defined _WIN32)
+
 #include <cstring>
 
 typedef int socket_t;
 #define INVALID_SOCKET ( -1 )
-#endif  //_WIN32
+
+#endif  // else from (defined _WIN32)
 
 #include <assert.h>
 #include <fcntl.h>

--- a/libskutils/src/http.cpp
+++ b/libskutils/src/http.cpp
@@ -1,5 +1,19 @@
 #include <skutils/http.h>
 
+#if (!defined _WIN32)
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <signal.h>
+#include <sys/poll.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#endif // (!defined _WIN32)
+
 //#define __SKUTILS_HTTP_DEBUG_CONSOLE_TRACE_HTTP_TASK_STATES__ 1
 
 namespace skutils {

--- a/libskutils/src/http.cpp
+++ b/libskutils/src/http.cpp
@@ -1,6 +1,6 @@
 #include <skutils/http.h>
 
-#if (!defined _WIN32)
+#if ( !defined _WIN32 )
 
 #include <arpa/inet.h>
 #include <netdb.h>
@@ -12,7 +12,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-#endif // (!defined _WIN32)
+#endif  // (!defined _WIN32)
 
 //#define __SKUTILS_HTTP_DEBUG_CONSOLE_TRACE_HTTP_TASK_STATES__ 1
 

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1864,7 +1864,7 @@ int main( int argc, char** argv ) try {
             clog( VerbosityInfo, "main" )
                 << cc::debug( "...." ) << cc::info( "Performance timeline tracker" )
                 << cc::debug( "............. " )
-                << ( pTracker->is_enabled() ? cc::num10( pTracker->get_safe_max_item_count() ) :
+                << ( pTracker->is_enabled() ? cc::size10( pTracker->get_safe_max_item_count() ) :
                                               cc::error( "off" ) );
 
             if ( !bHaveSSL )

--- a/test/unittests/libskutils/test_skutils_helper.cpp
+++ b/test/unittests/libskutils/test_skutils_helper.cpp
@@ -1,5 +1,4 @@
 #include "test_skutils_helper.h"
-#include <test/tools/libtestutils/Common.h>
 #include <boost/test/unit_test.hpp>
 #include <mutex>
 
@@ -1515,7 +1514,7 @@ void test_protocol_busy_port( const char* strProto, int nPort ) {
 BOOST_AUTO_TEST_SUITE( SkUtils )
 BOOST_AUTO_TEST_SUITE( helper )
 
-BOOST_AUTO_TEST_CASE( simple, *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
+BOOST_AUTO_TEST_CASE( simple ) {}
 
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libskutils/test_skutils_http.cpp
+++ b/test/unittests/libskutils/test_skutils_http.cpp
@@ -1,17 +1,14 @@
 #include "test_skutils_helper.h"
-#include <test/tools/libtestutils/Common.h>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE( SkUtils )
 BOOST_AUTO_TEST_SUITE( http )
 
-BOOST_AUTO_TEST_CASE( http_server_startup, 
-    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+BOOST_AUTO_TEST_CASE( http_server_startup ) {
     skutils::test::test_print_header_name( "SkUtils/http/http_server_startup" );
     skutils::test::test_protocol_server_startup( "http_async", skutils::test::g_nDefaultPort );
 }
-BOOST_AUTO_TEST_CASE( http_server_startup_sync, 
-    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+BOOST_AUTO_TEST_CASE( http_server_startup_sync ) {
     skutils::test::test_print_header_name( "SkUtils/http/http_server_startup_sync" );
     skutils::test::test_protocol_server_startup( "http_sync", skutils::test::g_nDefaultPort );
 }
@@ -20,20 +17,17 @@ BOOST_AUTO_TEST_CASE( http_single_call ) {
     skutils::test::test_print_header_name( "SkUtils/http/http_single_call" );
     skutils::test::test_protocol_single_call( "http_async", skutils::test::g_nDefaultPort );
 }
-BOOST_AUTO_TEST_CASE( http_single_call_sync, 
-    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+BOOST_AUTO_TEST_CASE( http_single_call_sync ) {
     skutils::test::test_print_header_name( "SkUtils/http/http_single_call_sync" );
     skutils::test::test_protocol_single_call( "http_sync", skutils::test::g_nDefaultPort );
 }
 
-BOOST_AUTO_TEST_CASE( http_serial_calls, 
-    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+BOOST_AUTO_TEST_CASE( http_serial_calls ) {
     skutils::test::test_print_header_name( "SkUtils/http/http_serial_calls" );
     skutils::test::test_protocol_serial_calls(
         "http_async", skutils::test::g_nDefaultPort, skutils::test::g_vecTestClientNamesA );
 }
-BOOST_AUTO_TEST_CASE( http_serial_calls_sync, 
-    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+BOOST_AUTO_TEST_CASE( http_serial_calls_sync ) {
     skutils::test::test_print_header_name( "SkUtils/http/http_serial_calls_sync" );
     skutils::test::test_protocol_serial_calls(
         "http_sync", skutils::test::g_nDefaultPort, skutils::test::g_vecTestClientNamesA );
@@ -56,13 +50,11 @@ BOOST_AUTO_TEST_CASE( http_busy_port ) {
 }
 
 
-BOOST_AUTO_TEST_CASE( https_server_startup, 
-    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+BOOST_AUTO_TEST_CASE( https_server_startup ) {
     skutils::test::test_print_header_name( "SkUtils/http/https_server_startup" );
     skutils::test::test_protocol_server_startup( "https_async", skutils::test::g_nDefaultPort );
 }
-BOOST_AUTO_TEST_CASE( https_server_startup_sync, 
-    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+BOOST_AUTO_TEST_CASE( https_server_startup_sync ) {
     skutils::test::test_print_header_name( "SkUtils/http/https_server_startup_sync" );
     skutils::test::test_protocol_server_startup( "https_sync", skutils::test::g_nDefaultPort );
 }
@@ -71,8 +63,7 @@ BOOST_AUTO_TEST_CASE( https_single_call ) {
     skutils::test::test_print_header_name( "SkUtils/http/https_single_call" );
     skutils::test::test_protocol_single_call( "https_async", skutils::test::g_nDefaultPort );
 }
-BOOST_AUTO_TEST_CASE( https_single_call_sync, 
-    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+BOOST_AUTO_TEST_CASE( https_single_call_sync ) {
     skutils::test::test_print_header_name( "SkUtils/http/https_single_call_sync" );
     skutils::test::test_protocol_single_call( "https_sync", skutils::test::g_nDefaultPort );
 }
@@ -82,8 +73,7 @@ BOOST_AUTO_TEST_CASE( https_serial_calls ) {
     skutils::test::test_protocol_serial_calls(
         "https_async", skutils::test::g_nDefaultPort, skutils::test::g_vecTestClientNamesA );
 }
-BOOST_AUTO_TEST_CASE( https_serial_calls_sync, 
-    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+BOOST_AUTO_TEST_CASE( https_serial_calls_sync ) {
     skutils::test::test_print_header_name( "SkUtils/http/https_serial_calls_sync" );
     skutils::test::test_protocol_serial_calls(
         "https_sync", skutils::test::g_nDefaultPort, skutils::test::g_vecTestClientNamesA );
@@ -94,8 +84,7 @@ BOOST_AUTO_TEST_CASE( https_parallel_calls ) {
     skutils::test::test_protocol_parallel_calls(
         "https_async", skutils::test::g_nDefaultPort, skutils::test::g_vecTestClientNamesA );
 }
-BOOST_AUTO_TEST_CASE( https_parallel_calls_sync, 
-    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+BOOST_AUTO_TEST_CASE( https_parallel_calls_sync ) {
     skutils::test::test_print_header_name( "SkUtils/http/https_parallel_calls_sync" );
     skutils::test::test_protocol_parallel_calls(
         "https_sync", skutils::test::g_nDefaultPort, skutils::test::g_vecTestClientNamesA );

--- a/test/unittests/libskutils/test_skutils_ws.cpp
+++ b/test/unittests/libskutils/test_skutils_ws.cpp
@@ -1,5 +1,4 @@
 #include "test_skutils_helper.h"
-#include <test/tools/libtestutils/Common.h>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE( SkUtils )
@@ -15,8 +14,7 @@ BOOST_AUTO_TEST_CASE( ws_single_call ) {
     skutils::test::test_protocol_single_call( "ws", skutils::test::g_nDefaultPort );
 }
 
-BOOST_AUTO_TEST_CASE( ws_serial_calls, 
-    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+BOOST_AUTO_TEST_CASE( ws_serial_calls ) {
     skutils::test::test_print_header_name( "SkUtils/ws/ws_serial_calls" );
     skutils::test::test_protocol_serial_calls(
         "ws", skutils::test::g_nDefaultPort, skutils::test::g_vecTestClientNamesA );
@@ -43,15 +41,13 @@ BOOST_AUTO_TEST_CASE( wss_single_call ) {
     skutils::test::test_protocol_single_call( "wss", skutils::test::g_nDefaultPort );
 }
 
-BOOST_AUTO_TEST_CASE( wss_serial_calls, 
-    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+BOOST_AUTO_TEST_CASE( wss_serial_calls ) {
     skutils::test::test_print_header_name( "SkUtils/ws/wss_serial_calls" );
     skutils::test::test_protocol_serial_calls(
         "wss", skutils::test::g_nDefaultPort, skutils::test::g_vecTestClientNamesA );
 }
 
-BOOST_AUTO_TEST_CASE( wss_parallel_calls, 
-    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+BOOST_AUTO_TEST_CASE( wss_parallel_calls ) {
     skutils::test::test_print_header_name( "SkUtils/ws/wss_parallel_calls" );
     skutils::test::test_protocol_parallel_calls(
         "wss", skutils::test::g_nDefaultPort, skutils::test::g_vecTestClientNamesB );


### PR DESCRIPTION
There were build errors on latest Apple's **clang** and Mac OSX. Once upon a time, a very early morning I was in a good mood to fix this. No new functions/classes added. No new tests required.
In details, the **MSIZE** symbol is defined somewhere in **EVM** code and names some instruction. The same **MSIZE** symbol is defined as integer code in network related headers of Apple SDK. I would recommend to rename **MSIZE** in **EVM** to avoid same problems in the future.