### PR TITLE
Enhancement/skale 2126 block rotation tests

### DIFF
--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -867,32 +867,9 @@ void Block::commitToSeal(
 
     RLPStream unclesData;
     unsigned unclesCount = 0;
-    if ( m_previousBlock.number() != 0 ) {
-        // Find great-uncles (or second-cousins or whatever they are) - children of
-        // great-grandparents, great-great-grandparents... that were not already uncles in previous
-        // generations.
-        LOG( m_loggerDetailed ) << cc::debug( "Checking " ) << m_previousBlock.hash()
-                                << cc::debug( ", parent = " ) << m_previousBlock.parentHash();
-        h256Hash excluded = _bc.allKinFrom( m_currentBlock.parentHash(), 6 );
-        auto p = m_previousBlock.parentHash();
-        for ( unsigned gen = 0; gen < 6 && p != _bc.genesisHash() && unclesCount < 2;
-              ++gen, p = _bc.details( p ).parent ) {
-            auto us = _bc.details( p ).children;
-            assert( us.size() >= 1 );  // must be at least 1 child of our grandparent - it's our own
-                                       // parent!
-            for ( auto const& u : us )
-                if ( !excluded.count( u ) )  // ignore any uncles/mainline blocks that we know
-                                             // about.
-                {
-                    uncleBlockHeaders.push_back( _bc.info( u ) );
-                    unclesData.appendRaw( _bc.headerData( u ) );
-                    ++unclesCount;
-                    if ( unclesCount == 2 )
-                        break;
-                    excluded.insert( u );
-                }
-        }
-    }
+
+    // here was code to handle 6 generations of uncles
+    // it was wtiting its results in two variables above
 
     BytesMap transactionsMap;
     BytesMap receiptsMap;

--- a/libweb3jsonrpc/JsonHelper.cpp
+++ b/libweb3jsonrpc/JsonHelper.cpp
@@ -173,9 +173,9 @@ Json::Value toJson( dev::eth::LocalisedTransactionReceipt const& _t ) {
     res["to"] = toJS( _t.to() );
 
     res["transactionHash"] = toJS( _t.hash() );
-    res["transactionIndex"] = _t.transactionIndex();
+    res["transactionIndex"] = toJS( _t.transactionIndex() );
     res["blockHash"] = toJS( _t.blockHash() );
-    res["blockNumber"] = _t.blockNumber();
+    res["blockNumber"] = toJS( _t.blockNumber() );
     res["cumulativeGasUsed"] = toJS( _t.cumulativeGasUsed() );
     res["gasUsed"] = toJS( _t.gasUsed() );
     //
@@ -259,11 +259,11 @@ Json::Value toJson( dev::eth::LocalisedLogEntry const& _e ) {
         res["polarity"] = _e.polarity == BlockPolarity::Live ? true : false;
         if ( _e.mined ) {
             res["type"] = "mined";
-            res["blockNumber"] = _e.blockNumber;
+            res["blockNumber"] = toJS( _e.blockNumber );
             res["blockHash"] = toJS( _e.blockHash );
-            res["logIndex"] = _e.logIndex;
+            res["logIndex"] = toJS( _e.logIndex );
             res["transactionHash"] = toJS( _e.transactionHash );
-            res["transactionIndex"] = _e.transactionIndex;
+            res["transactionIndex"] = toJS( _e.transactionIndex );
         } else {
             res["type"] = "pending";
             res["blockNumber"] = Json::Value( Json::nullValue );

--- a/test/unittests/libweb3jsonrpc/WebThreeStubClient.cpp
+++ b/test/unittests/libweb3jsonrpc/WebThreeStubClient.cpp
@@ -279,7 +279,7 @@ Json::Value WebThreeStubClient::eth_getBlockTransactionCountByHash( const std::s
     Json::Value p;
     p.append( param1 );
     Json::Value result = this->CallMethod( "eth_getBlockTransactionCountByHash", p );
-    if ( result.isObject() )
+    if ( result.isString() )
         return result;
     else
         throw jsonrpc::JsonRpcException(
@@ -290,7 +290,7 @@ Json::Value WebThreeStubClient::eth_getBlockTransactionCountByNumber( const std:
     Json::Value p;
     p.append( param1 );
     Json::Value result = this->CallMethod( "eth_getBlockTransactionCountByNumber", p );
-    if ( result.isObject() )
+    if ( result.isString() )
         return result;
     else
         throw jsonrpc::JsonRpcException(
@@ -301,7 +301,7 @@ Json::Value WebThreeStubClient::eth_getUncleCountByBlockHash( const std::string&
     Json::Value p;
     p.append( param1 );
     Json::Value result = this->CallMethod( "eth_getUncleCountByBlockHash", p );
-    if ( result.isObject() )
+    if ( result.isString() )
         return result;
     else
         throw jsonrpc::JsonRpcException(
@@ -312,7 +312,7 @@ Json::Value WebThreeStubClient::eth_getUncleCountByBlockNumber( const std::strin
     Json::Value p;
     p.append( param1 );
     Json::Value result = this->CallMethod( "eth_getUncleCountByBlockNumber", p );
-    if ( result.isObject() )
+    if ( result.isString() )
         return result;
     else
         throw jsonrpc::JsonRpcException(


### PR DESCRIPTION
Tests AND some fixes too.
Important! Now some JSON-RPC calls (like eth_getBlockTransactionCountByNumber) return string - not number (see code changes). This is like in JSON-RPC docs.
See also https://skalelabs.atlassian.net/wiki/spaces/SKALE/pages/677019695/Blocks+Rotation