### PR TITLE
SKALE-2687 testeth fails on GA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,3 +229,4 @@ if ( SANITIZE )
     SET( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=${SANITIZE}" )
     SET( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=${SANITIZE}" )
 endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,4 +229,3 @@ if ( SANITIZE )
     SET( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=${SANITIZE}" )
     SET( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=${SANITIZE}" )
 endif()
-

--- a/test/unittests/libskutils/test_skutils_dispatch.cpp
+++ b/test/unittests/libskutils/test_skutils_dispatch.cpp
@@ -1,5 +1,6 @@
 #include "test_skutils_helper.h"
 #include <boost/test/unit_test.hpp>
+#include <test/tools/libtesteth/TestHelper.h>
 
 static const bool g_bShowDetailedJobLogs = false;  // useful for dispatch development only
 
@@ -64,7 +65,7 @@ static std::string thread_prefix_str() {
 
 
 BOOST_AUTO_TEST_SUITE( SkUtils )
-BOOST_AUTO_TEST_SUITE( dispatch )
+BOOST_AUTO_TEST_SUITE( dispatch, *boost::unit_test::precondition( dev::test::option_all_tests ) )
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
dispatch tests relying on time measurements do run only when testeth is invoked with --all