### PR TITLE
Do not start skaled after forceful shutdown

### DIFF
--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -293,7 +293,7 @@ protected:
 
     /// Perform critical setup functions.
     /// Must be called in the constructor of the finally derived class.
-    void init( boost::filesystem::path const& _dbPath, WithExisting _forceAction, u256 _networkId );
+    void init( WithExisting _forceAction, u256 _networkId );
 
     /// InterfaceStub methods
     BlockChain& bc() override { return m_bc; }
@@ -464,6 +464,7 @@ protected:
     std::shared_ptr< SkaleHost > m_skaleHost;
     std::shared_ptr< SnapshotManager > m_snapshotManager;
     std::shared_ptr< InstanceMonitor > m_instanceMonitor;
+    fs::path m_dbPath;
 
 private:
     inline bool isTimeToDoSnapshot( uint64_t _timestamp ) const;

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -568,6 +568,7 @@ void SkaleHost::startWorking() {
     // TODO Should we do it at end of this func? (problem: broadcaster receives transaction and
     // recursively calls this func - so working is still false!)
     working = true;
+    m_exitedForcefully = false;
 
     try {
         m_broadcaster->startService();
@@ -619,6 +620,13 @@ void SkaleHost::stopWorking() {
                              m_consensusWorkingMutex, std::adopt_lock ) :
                          std::unique_ptr< std::lock_guard< std::timed_mutex > >();
     ( void ) lock;  // for Codacy
+
+    // if we could not lock from 1st attempt - then exit forcefully!
+    if ( !locked ) {
+        m_exitedForcefully = true;
+        clog( VerbosityWarning, "skale-host" ) << "Forcefully shutting down consensus!";
+    }
+
 
     m_exitNeeded = true;
     pauseConsensus( false );

--- a/libethereum/SkaleHost.h
+++ b/libethereum/SkaleHost.h
@@ -108,6 +108,8 @@ public:
 
     void startWorking();
     void stopWorking();
+    bool isWorking() const { return this->working; }
+    bool exitedForcefully() const { return m_exitedForcefully; }
 
     void noteNewTransactions();
     void noteNewBlocks();
@@ -137,6 +139,7 @@ public:
 
 private:
     std::atomic_bool working = false;
+    std::atomic_bool m_exitedForcefully = false;
 
     std::unique_ptr< Broadcaster > m_broadcaster;
 

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1089,12 +1089,12 @@ int main( int argc, char** argv ) try {
             cerr << err.reason_ << " line " << err.line_ << endl;
             cerr << configJSON << endl;
         } catch ( const std::exception& ex ) {
-            cerr << "provided configuration is not well formatted\n";
+            cerr << "provided configuration is incorrect\n";
             cerr << configJSON << endl;
             cerr << ex.what() << endl;
             return 0;
         } catch ( ... ) {
-            cerr << "provided configuration is not well formatted\n";
+            cerr << "provided configuration is incorrect\n";
             // cerr << "sample: \n" << genesisInfo(eth::Network::MainNetworkTest) << "\n";
             cerr << configJSON << endl;
             return 0;


### PR DESCRIPTION
If skaled was shut down by SIGKILL OR exited in the middle of consensus (i.e. if thre where less than 2/3 nodes) - then print message and refuse to start!

```
skaled, a C++ Skale client
2020-06-28 14:56:07.351128   CRITICAL Data dir unclean! Remove /home/dimalit/.ethereum/skaled.lock and continue at your own risk! ---
```

Hopefully, during testing, this will catch some errors earlier.