### PR TITLE
feature/SKALE-2814 partial catch up

### DIFF
--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -43,46 +43,6 @@
 
 #include <skutils/console_colors.h>
 
-//
-// The following variable allows to emulate skaled crash after some but not all block transactions
-// were executed and their state data were saved into level DB.
-//
-// Based on https://stackoverflow.com/questions/3649874/how-can-i-get-the-keyboard-state-in-linux
-//
-// #define __DEBUG_EMULATE_CRASH_IN_THE_MIDDLE_OF_BLOCK_TRANSACTIONS_EXECUTION__ 1
-
-#if ( defined __DEBUG_EMULATE_CRASH_IN_THE_MIDDLE_OF_BLOCK_TRANSACTIONS_EXECUTION__ )
-
-#include <linux/input.h>
-#include <stdio.h>
-#include <sys/ioctl.h>
-#include <sysexits.h>
-#include <unistd.h>
-
-static int g_key_to_crash_if_pressed =
-    KEY_RIGHTALT;  // value examples KEY_LEFTSHIFT KEY_RIGHTSHIFT, KEY_LEFTALT, KEY_RIGHTALT,
-                   // KEY_LEFTCTRL, KEY_RIGHTCTRL
-
-static bool check_if_key_is_pressed( int key ) {
-    FILE* kbd = fopen( "/dev/input/by-path/platform-i8042-serio-0-event-kbd", "r" );
-    char key_map[KEY_MAX / 8 + 1];            // create a byte array the size of the number of keys
-    memset( key_map, 0, sizeof( key_map ) );  // initate the array to zero's
-    ioctl( fileno( kbd ), EVIOCGKEY( sizeof( key_map ) ), key_map );  // fill the keymap with the
-                                                                      // current keyboard state
-    int keyb = key_map[key / 8];  // the key we want (and the seven others arround it)
-    int mask = 1 << ( key % 8 );  // put a one in the same column as out key state will be in;
-    bool bIsPressed = ( !( keyb & mask ) ) ? true : false;
-    return bIsPressed;
-}
-
-static void exit_immedeately_if_key_is_pressed( int key ) {
-    if ( check_if_key_is_pressed( key ) ) {
-        _exit( 66 );
-    }
-}
-
-#endif  /// (defined __DEBUG_EMULATE_CRASH_IN_THE_MIDDLE_OF_BLOCK_TRANSACTIONS_EXECUTION__)
-
 using namespace std;
 using namespace dev;
 using namespace dev::eth;
@@ -516,9 +476,19 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
             if ( res.excepted == TransactionException::WouldNotBeInBlock )
                 ++count_bad;
 
-#if ( defined __DEBUG_EMULATE_CRASH_IN_THE_MIDDLE_OF_BLOCK_TRANSACTIONS_EXECUTION__ )
-            exit_immedeately_if_key_is_pressed( g_key_to_crash_if_pressed );
-#endif  /// (defined __DEBUG_EMULATE_CRASH_IN_THE_MIDDLE_OF_BLOCK_TRANSACTIONS_EXECUTION__)
+            //
+            // Debug only, related SKALE-2814 partial catchup testing
+            //
+            // if ( i == 3 ) {
+            //    std::cout << "\n\n"
+            //              << cc::warn( "--- EXITING AS CRASH EMULATION AT TX# " ) <<
+            //              cc::num10( i )
+            //              << cc::warn( " with hash " ) << cc::info( tr.sha3().hex() )
+            //              << "\n\n\n";
+            //    std::cout.flush();
+            //    _exit( 200 );
+            //}
+
 
         } catch ( Exception& ex ) {
             ex << errinfo_transactionIndex( i );

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -480,13 +480,11 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
             // Debug only, related SKALE-2814 partial catchup testing
             //
             // if ( i == 3 ) {
-            //    std::cout << "\n\n"
-            //              << cc::warn( "--- EXITING AS CRASH EMULATION AT TX# " ) <<
-            //              cc::num10( i )
-            //              << cc::warn( " with hash " ) << cc::info( tr.sha3().hex() )
-            //              << "\n\n\n";
-            //    std::cout.flush();
-            //    _exit( 200 );
+            // std::cout << "\n\n"
+            //          << cc::warn( "--- EXITING AS CRASH EMULATION AT TX# " ) << cc::num10( i )
+            //          << cc::warn( " with hash " ) << cc::info( tr.sha3().hex() ) << "\n\n\n";
+            // std::cout.flush();
+            //_exit( 200 );
             //}
 
 

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -464,7 +464,8 @@ pair< TransactionReceipts, bool > Block::sync(
 }
 
 tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _bc,
-    const Transactions _transactions, uint64_t _timestamp, u256 _gasPrice, bool isSaveLastTxHash ) {
+    const Transactions& _transactions, uint64_t _timestamp, u256 _gasPrice,
+    bool isSaveLastTxHash ) {
     if ( isSealed() )
         BOOST_THROW_EXCEPTION( InvalidOperationOnSealedBlock() );
 

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -210,7 +210,8 @@ public:
     /// Execute a given transaction.
     /// This will append @a _t to the transaction list and change the state accordingly.
     ExecutionResult execute( LastBlockHashesFace const& _lh, Transaction const& _t,
-        skale::Permanence _p = skale::Permanence::Committed, OnOpFunc const& _onOp = OnOpFunc() );
+        skale::Permanence _p = skale::Permanence::Committed, OnOpFunc const& _onOp = OnOpFunc(),
+        bool isSaveLastTxHash = false );
 
     /// Sync our transactions, killing those from the queue that we have and assimilating those that
     /// we don't.
@@ -233,7 +234,8 @@ public:
 
     /// Sync all transactions unconditionally
     std::tuple< TransactionReceipts, unsigned > syncEveryone( BlockChain const& _bc,
-        const Transactions _transactions, uint64_t _timestamp, u256 _gasPrice );
+        const Transactions _transactions, uint64_t _timestamp, u256 _gasPrice,
+        bool isSaveLastTxHash = false );
 
     /// Execute all transactions within a given block.
     /// @returns the additional total difficulty.

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -211,7 +211,8 @@ public:
     /// This will append @a _t to the transaction list and change the state accordingly.
     ExecutionResult execute( LastBlockHashesFace const& _lh, Transaction const& _t,
         skale::Permanence _p = skale::Permanence::Committed, OnOpFunc const& _onOp = OnOpFunc(),
-        bool isSaveLastTxHash = false );
+        bool isSaveLastTxHash = false,
+        TransactionReceipts* accumulatedTransactionReceipts = nullptr );
 
     /// Sync our transactions, killing those from the queue that we have and assimilating those that
     /// we don't.
@@ -235,7 +236,8 @@ public:
     /// Sync all transactions unconditionally
     std::tuple< TransactionReceipts, unsigned > syncEveryone( BlockChain const& _bc,
         const Transactions& _transactions, uint64_t _timestamp, u256 _gasPrice,
-        bool isSaveLastTxHash = false );
+        bool isSaveLastTxHash = false,
+        TransactionReceipts* accumulatedTransactionReceipts = nullptr );
 
     /// Execute all transactions within a given block.
     /// @returns the additional total difficulty.

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -234,7 +234,7 @@ public:
 
     /// Sync all transactions unconditionally
     std::tuple< TransactionReceipts, unsigned > syncEveryone( BlockChain const& _bc,
-        const Transactions _transactions, uint64_t _timestamp, u256 _gasPrice,
+        const Transactions& _transactions, uint64_t _timestamp, u256 _gasPrice,
         bool isSaveLastTxHash = false );
 
     /// Execute all transactions within a given block.

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -597,7 +597,8 @@ ImportRoute BlockChain::import( VerifiedBlockRef const& _block, State& _state, b
     return insertBlockAndExtras( _block, ref( receipts ), totalDifficulty, performanceLogger );
 }
 
-ImportRoute BlockChain::import( const Block& _block ) {
+ImportRoute BlockChain::import(
+    const Block& _block, TransactionReceipts* partialTransactionReceipts ) {
     assert( _block.isSealed() );
 
     VerifiedBlockRef verifiedBlock;
@@ -607,6 +608,10 @@ ImportRoute BlockChain::import( const Block& _block ) {
     //    verifyBlock( ref( _block.blockData() ), m_onBad, ImportRequirements::OutOfOrderChecks );
 
     BlockReceipts blockReceipts;
+    if ( partialTransactionReceipts ) {
+        for ( unsigned i = 0; i < partialTransactionReceipts->size(); ++i )
+            blockReceipts.receipts.push_back( ( *partialTransactionReceipts )[i] );
+    }
     for ( unsigned i = 0; i < _block.pending().size(); ++i )
         blockReceipts.receipts.push_back( _block.receipt( i ) );
     bytes const receipts = blockReceipts.rlp();

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -674,6 +674,11 @@ ImportRoute BlockChain::insertBlockAndExtras( VerifiedBlockRef const& _block,
 
     rotateDBIfNeeded();
 
+    // get "safeLastExecutedTransactionHash" value from state, for debug reasons only
+    // dev::h256 shaLastTx = skale::OverlayDB::stat_safeLastExecutedTransactionHash( m_stateDB.get()
+    // ); std::cout << "--- got \"safeLastExecutedTransactionHash\" = " << shaLastTx.hex() << "\n";
+    // std::cout.flush();
+
     std::unique_ptr< db::WriteBatchFace > blocksWriteBatch = m_blocksDB->createWriteBatch();
     std::unique_ptr< db::WriteBatchFace > extrasWriteBatch = m_extrasDB->createWriteBatch();
     h256 newLastBlockHash = currentHash();

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -536,6 +536,10 @@ private:
     db::DatabaseFace* m_blocksDB;
     db::DatabaseFace* m_extrasDB;
 
+public:
+    std::shared_ptr< dev::db::DatabaseFace > m_stateDB;  // initialized in Client class, than
+                                                         // assigned here later in Client::init()
+private:
     /// Hash of the last (valid) block on the longest chain.
     mutable boost::shared_mutex x_lastBlockHash;  // should protect both m_lastBlockHash and
                                                   // m_lastBlockNumber

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -148,7 +148,8 @@ public:
     ImportRoute import( bytes const& _block, skale::State& _state, bool _mustBeNew = true );
     ImportRoute import(
         VerifiedBlockRef const& _block, skale::State& _state, bool _mustBeNew = true );
-    ImportRoute import( Block const& _block );
+    ImportRoute import(
+        Block const& _block, TransactionReceipts* partialTransactionReceipts = nullptr );
 
     /// Import data into disk-backed DB.
     /// This will not execute the block and populate the state trie, but rather will simply add the

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -460,7 +460,8 @@ private:
     void rotateDBIfNeeded();
 
     ImportRoute insertBlockAndExtras( VerifiedBlockRef const& _block, bytesConstRef _receipts,
-        u256 const& _totalDifficulty, ImportPerformanceLogger& _performanceLogger );
+        LogBloom* pLogBloomFull, u256 const& _totalDifficulty,
+        ImportPerformanceLogger& _performanceLogger );
     void checkBlockIsNew( VerifiedBlockRef const& _block ) const;
     void checkBlockTimestamp( BlockHeader const& _header ) const;
 

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -487,12 +487,12 @@ size_t Client::importTransactionsAsBlock(
         dev::h256 shaLastTx = m_state.safeLastExecutedTransactionHash();
         for ( const Transaction& txWalk : _transactions ) {
             const h256 shaWalk = txWalk.sha3();
-            if ( !bIsPartial )
-                vecPassed.push_back( txWalk );
+            if ( bIsPartial )
+                vecMissing.push_back( txWalk );
             else {
+                vecPassed.push_back( txWalk );
                 if ( shaWalk == shaLastTx ) {
                     bIsPartial = true;
-                    vecPassed.push_back( txWalk );
                     size_t cntPassed = vecPassed.size();
                     size_t cntMissing = cntAll - cntPassed;
                     cntEpected = cntMissing;
@@ -501,8 +501,6 @@ size_t Client::importTransactionsAsBlock(
                                     << cc::size10( cntPassed ) << cc::error( "passed, " )
                                     << cc::size10( cntMissing ) << cc::error( " missing" );
                     LOG( m_logger ).flush();
-                } else {
-                    vecMissing.push_back( txWalk );
                 }
             }
         }

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -526,7 +526,7 @@ size_t Client::importTransactionsAsBlock(
                 vecMissing.push_back( txWalk );
             else {
                 vecPassed.push_back( txWalk );
-                if ( ( !bIsPartial ) && shaWalk == shaLastTx ) {
+                if ( shaWalk == shaLastTx ) {
                     bIsPartial = true;
                 }
             }

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -69,6 +69,7 @@ std::string filtersToString( h256Hash const& _fs ) {
     return str.str();
 }
 
+#if ( defined __HAVE_SKALED_LOCK_FILE_INDICATING_CRITICAL_STOP__ )
 void create_lock_file_or_fail( const fs::path& dir ) {
     fs::path p = dir / "skaled.lock";
     if ( fs::exists( p ) )
@@ -80,12 +81,12 @@ void create_lock_file_or_fail( const fs::path& dir ) {
             string( "Cannot create lock file " ) + p.string() + ": " + strerror( errno ) );
     fclose( fp );
 }
-
 void delete_lock_file( const fs::path& dir ) {
     fs::path p = dir / "skaled.lock";
     if ( fs::exists( p ) )
         fs::remove( p );
 }
+#endif  /// (defined __HAVE_SKALED_LOCK_FILE_INDICATING_CRITICAL_STOP__)
 
 }  // namespace
 
@@ -114,7 +115,9 @@ Client::Client( ChainParams const& _params, int _networkID,
       m_instanceMonitor( _instanceMonitor ),
       m_dbPath( _dbPath ),
       is_started_from_snapshot( isStartedFromSnapshot ) {
+#if ( defined __HAVE_SKALED_LOCK_FILE_INDICATING_CRITICAL_STOP__ )
     create_lock_file_or_fail( m_dbPath );
+#endif  /// (defined __HAVE_SKALED_LOCK_FILE_INDICATING_CRITICAL_STOP__)
     init( _forceAction, _networkID );
 }
 
@@ -150,6 +153,7 @@ void Client::stopWorking() {
     m_bc.close();
     LOG( m_logger ) << cc::success( "Blockchain is closed" );
 
+#if ( defined __HAVE_SKALED_LOCK_FILE_INDICATING_CRITICAL_STOP__ )
     bool isForcefulExit =
         ( !m_skaleHost || m_skaleHost->exitedForcefully() == false ) ? false : true;
     if ( !isForcefulExit ) {
@@ -164,6 +168,7 @@ void Client::stopWorking() {
                         << cc::error( " after foreceful exit" );
     }
     LOG( m_logger ).flush();
+#endif  /// (defined __HAVE_SKALED_LOCK_FILE_INDICATING_CRITICAL_STOP__)
 
     terminate();
 }

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -472,7 +472,9 @@ size_t Client::importTransactionsAsBlock(
             m_snapshotManager->leaveNLastSnapshots( 2 );
         }  // if snapshot
 
-        size_t n_succeeded = syncTransactions( _transactions, _gasPrice, _timestamp );
+        bool isSaveLastTxHash = true;
+        size_t n_succeeded =
+            syncTransactions( _transactions, _gasPrice, _timestamp, isSaveLastTxHash );
         sealUnconditionally( false );
         importWorkingBlock();
 
@@ -485,8 +487,8 @@ size_t Client::importTransactionsAsBlock(
     return 0;
 }
 
-size_t Client::syncTransactions(
-    const Transactions& _transactions, u256 _gasPrice, uint64_t _timestamp ) {
+size_t Client::syncTransactions( const Transactions& _transactions, u256 _gasPrice,
+    uint64_t _timestamp, bool isSaveLastTxHash ) {
     assert( m_skaleHost );
 
     // HACK remove block verification and put it directly in blockchain!!
@@ -511,7 +513,7 @@ size_t Client::syncTransactions(
 
         //        assert(m_state.m_db_write_lock.has_value());
         tie( newPendingReceipts, goodReceipts ) =
-            m_working.syncEveryone( bc(), _transactions, _timestamp, _gasPrice );
+            m_working.syncEveryone( bc(), _transactions, _timestamp, _gasPrice, isSaveLastTxHash );
         m_state = m_state.startNew();
     }
 

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -467,6 +467,13 @@ size_t Client::importTransactionsAsBlock(
             m_snapshotManager->leaveNLastSnapshots( 2 );
         }  // if snapshot
 
+        dev::h256 shaLastTx = m_state.safeLastExecutedTransactionHash();
+        for ( const Transaction& txWalk : _transactions ) {
+            const h256 shaWalk = txWalk.sha3();
+            if ( shaWalk == shaLastTx )
+                std::cout << "--- found partially executed block\n";
+        }
+
         bool isSaveLastTxHash = true;
         size_t n_succeeded =
             syncTransactions( _transactions, _gasPrice, _timestamp, isSaveLastTxHash );

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -558,7 +558,7 @@ size_t Client::syncTransactions( const Transactions& _transactions, u256 _gasPri
     DEV_WRITE_GUARDED( x_working ) {
         assert( !m_working.isSealed() );
 
-        //        assert(m_state.m_db_write_lock.has_value());
+        // assert(m_state.m_db_write_lock.has_value());
         tie( newPendingReceipts, goodReceipts ) =
             m_working.syncEveryone( bc(), _transactions, _timestamp, _gasPrice, isSaveLastTxHash );
         m_state = m_state.startNew();

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -551,6 +551,10 @@ size_t Client::importTransactionsAsBlock(
             LOG( m_logger ).flush();
             LOG( m_logger ) << cc::info( "PARTIAL CATCHUP:" )
                             << stat_transactions2str( vecMissing, cc::notice( " Missing " ) );
+            LOG( m_logger ) << cc::info( "PARTIAL CATCHUP:" ) << cc::attention( " Found " )
+                            << cc::size10( partialTransactionReceipts.size() )
+                            << cc::attention( " partial transaction receipt(s) inside " )
+                            << cc::notice( "SAFETY CACHE" );
             LOG( m_logger ).flush();
         }
         // end, detect partially executed block

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -226,6 +226,8 @@ void Client::init( WithExisting _forceAction, u256 _networkId ) {
     if ( m_dbPath.size() )
         Defaults::setDBPath( m_dbPath );
 
+    bc().m_stateDB = m_state.db();
+
     if ( chainParams().sChain.snapshotIntervalMs > 0 ) {
         LOG( m_logger ) << "Snapshots enabled, snapshotInterval is: "
                         << chainParams().sChain.snapshotIntervalMs;

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -284,7 +284,7 @@ protected:
     /// returns number of successfullty executed transactions
     /// thread unsafe!!
     size_t syncTransactions( const Transactions& _transactions, u256 _gasPrice,
-        uint64_t _timestamp = ( uint64_t ) utcTime() );
+        uint64_t _timestamp = ( uint64_t ) utcTime(), bool isSaveLastTxHash = false );
 
     /// As rejigSealing - but stub
     /// thread unsafe!!

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -286,14 +286,15 @@ protected:
     /// returns number of successfullty executed transactions
     /// thread unsafe!!
     size_t syncTransactions( const Transactions& _transactions, u256 _gasPrice,
-        uint64_t _timestamp = ( uint64_t ) utcTime(), bool isSaveLastTxHash = false );
+        uint64_t _timestamp = ( uint64_t ) utcTime(), bool isSaveLastTxHash = false,
+        TransactionReceipts* accumulatedTransactionReceipts = nullptr );
 
     /// As rejigSealing - but stub
     /// thread unsafe!!
     void sealUnconditionally( bool submitToBlockChain = true );
 
     /// thread unsafe!!
-    void importWorkingBlock();
+    void importWorkingBlock( TransactionReceipts* partialTransactionReceipts = nullptr );
 
     /// Perform critical setup functions.
     /// Must be called in the constructor of the finally derived class.

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -208,6 +208,10 @@ void Executive::verifyTransaction( Transaction const& _transaction, BlockHeader 
             u256 nonceReq;
             nonceReq = _state.getNonce( _transaction.sender() );
             if ( _transaction.nonce() != nonceReq ) {
+                std::cout << "WARNING: Transaction " << _transaction.sha3() << " nonce "
+                          << _transaction.nonce() << " is not equal to required nonce " << nonceReq
+                          << "\n";
+                std::cout.flush();
                 BOOST_THROW_EXCEPTION(
                     InvalidNonce() << RequirementError( static_cast< bigint >( nonceReq ),
                         static_cast< bigint >( _transaction.nonce() ) ) );
@@ -220,7 +224,12 @@ void Executive::verifyTransaction( Transaction const& _transaction, BlockHeader 
             gasCost = 0;
         }
         bigint totalCost = _transaction.value() + gasCost;
-        if ( _state.balance( _transaction.sender() ) < totalCost ) {
+        auto sender_ballance = _state.balance( _transaction.sender() );
+        if ( sender_ballance < totalCost ) {
+            std::cout << "WARNING: Transaction " << _transaction.sha3() << " total cost "
+                      << totalCost << " is less than sender " << _transaction.sender()
+                      << " ballance " << sender_ballance << "\n";
+            std::cout.flush();
             BOOST_THROW_EXCEPTION( NotEnoughCash()
                                    << RequirementError(
                                           totalCost, static_cast< bigint >(

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -68,6 +68,11 @@ std::unique_ptr< ConsensusInterface > DefaultConsensusFactory::create(
     ConsensusExtFace& _extFace ) const {
 #if CONSENSUS
     const auto& nfo = static_cast< const Interface& >( m_client ).blockInfo( LatestBlock );
+    //
+    std::cout << cc::note( "NOTE: Block number at startup is " ) << cc::size10( nfo.number() )
+              << "\n";
+    std::cout.flush();
+    //
     auto ts = nfo.timestamp();
     auto consensus_engine_ptr = make_unique< ConsensusEngine >( _extFace, m_client.number(), ts );
 

--- a/libskale/OverlayDB.cpp
+++ b/libskale/OverlayDB.cpp
@@ -80,6 +80,16 @@ const OverlayDB::fn_pre_commit_t OverlayDB::g_fn_pre_commit_empty =
     []( std::shared_ptr< dev::db::DatabaseFace > /*db*/,
         std::unique_ptr< dev::db::WriteBatchFace >& /*writeBatch*/ ) {};
 
+dev::h256 OverlayDB::safeLastExecutedTransactionHash() {
+    dev::h256 shaLastTx;
+    if ( m_db ) {
+        const std::string l =
+            m_db->lookup( skale::slicing::toSlice( "safeLastExecutedTransactionHash" ) );
+        if ( !l.empty() )
+            shaLastTx = dev::h256( l, dev::h256::FromBinary );
+    }
+    return shaLastTx;
+}
 
 void OverlayDB::commit() {
     commit( g_fn_pre_commit_empty );

--- a/libskale/OverlayDB.cpp
+++ b/libskale/OverlayDB.cpp
@@ -95,6 +95,22 @@ dev::h256 OverlayDB::safeLastExecutedTransactionHash() {
     return stat_safeLastExecutedTransactionHash( m_db.get() );
 }
 
+dev::bytes OverlayDB::stat_safePartialTransactionReceipts( dev::db::DatabaseFace* pDB ) {
+    dev::bytes partialTransactionReceipts;
+    if ( pDB ) {
+        const std::string l =
+            pDB->lookup( skale::slicing::toSlice( "safeLastTransactionReceipts" ) );
+        if ( !l.empty() )
+            partialTransactionReceipts.insert(
+                partialTransactionReceipts.end(), l.begin(), l.end() );
+    }
+    return partialTransactionReceipts;
+}
+
+dev::bytes OverlayDB::safePartialTransactionReceipts() {
+    return stat_safePartialTransactionReceipts( m_db.get() );
+}
+
 void OverlayDB::commit() {
     commit( g_fn_pre_commit_empty );
 }

--- a/libskale/OverlayDB.cpp
+++ b/libskale/OverlayDB.cpp
@@ -80,15 +80,19 @@ const OverlayDB::fn_pre_commit_t OverlayDB::g_fn_pre_commit_empty =
     []( std::shared_ptr< dev::db::DatabaseFace > /*db*/,
         std::unique_ptr< dev::db::WriteBatchFace >& /*writeBatch*/ ) {};
 
-dev::h256 OverlayDB::safeLastExecutedTransactionHash() {
+dev::h256 OverlayDB::stat_safeLastExecutedTransactionHash( dev::db::DatabaseFace* pDB ) {
     dev::h256 shaLastTx;
-    if ( m_db ) {
+    if ( pDB ) {
         const std::string l =
-            m_db->lookup( skale::slicing::toSlice( "safeLastExecutedTransactionHash" ) );
+            pDB->lookup( skale::slicing::toSlice( "safeLastExecutedTransactionHash" ) );
         if ( !l.empty() )
             shaLastTx = dev::h256( l, dev::h256::FromBinary );
     }
     return shaLastTx;
+}
+
+dev::h256 OverlayDB::safeLastExecutedTransactionHash() {
+    return stat_safeLastExecutedTransactionHash( m_db.get() );
 }
 
 void OverlayDB::commit() {

--- a/libskale/OverlayDB.h
+++ b/libskale/OverlayDB.h
@@ -56,6 +56,8 @@ public:
     OverlayDB( OverlayDB&& ) = default;
     OverlayDB& operator=( OverlayDB&& ) = default;
 
+    dev::h256 safeLastExecutedTransactionHash();
+
     typedef std::function< void( std::shared_ptr< dev::db::DatabaseFace > db,
         std::unique_ptr< dev::db::WriteBatchFace >& writeBatch ) >
         fn_pre_commit_t;

--- a/libskale/OverlayDB.h
+++ b/libskale/OverlayDB.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 
 #include <libdevcore/Common.h>
@@ -32,6 +33,16 @@
 
 
 namespace skale {
+
+namespace slicing {
+
+dev::db::Slice toSlice( dev::h256 const& _h );
+dev::db::Slice toSlice( dev::bytes const& _b );
+dev::db::Slice toSlice( dev::h160 const& _h );
+dev::db::Slice toSlice( std::string const& _s );
+
+};  // namespace slicing
+
 class OverlayDB {
 public:
     explicit OverlayDB( std::unique_ptr< dev::db::DatabaseFace > _db = nullptr );
@@ -45,7 +56,14 @@ public:
     OverlayDB( OverlayDB&& ) = default;
     OverlayDB& operator=( OverlayDB&& ) = default;
 
+    typedef std::function< void( std::shared_ptr< dev::db::DatabaseFace > db,
+        std::unique_ptr< dev::db::WriteBatchFace >& writeBatch ) >
+        fn_pre_commit_t;
+
+    static const fn_pre_commit_t g_fn_pre_commit_empty;
+
     void commit();
+    void commit( fn_pre_commit_t fn_pre_commit );
     void rollback();
     void clearDB();
     bool connected() const;

--- a/libskale/OverlayDB.h
+++ b/libskale/OverlayDB.h
@@ -56,6 +56,7 @@ public:
     OverlayDB( OverlayDB&& ) = default;
     OverlayDB& operator=( OverlayDB&& ) = default;
 
+    static dev::h256 stat_safeLastExecutedTransactionHash( dev::db::DatabaseFace* pDB );
     dev::h256 safeLastExecutedTransactionHash();
 
     typedef std::function< void( std::shared_ptr< dev::db::DatabaseFace > db,
@@ -108,6 +109,9 @@ private:
 
     dev::bytes getAuxiliaryKey( dev::h160 const& _address, _byte_ space ) const;
     dev::bytes getStorageKey( dev::h160 const& _address, dev::h256 const& _storageAddress ) const;
+
+public:
+    std::shared_ptr< dev::db::DatabaseFace > db() { return m_db; }
 };
 
 }  // namespace skale

--- a/libskale/OverlayDB.h
+++ b/libskale/OverlayDB.h
@@ -58,6 +58,8 @@ public:
 
     static dev::h256 stat_safeLastExecutedTransactionHash( dev::db::DatabaseFace* pDB );
     dev::h256 safeLastExecutedTransactionHash();
+    static dev::bytes stat_safePartialTransactionReceipts( dev::db::DatabaseFace* pDB );
+    dev::bytes safePartialTransactionReceipts();
 
     typedef std::function< void( std::shared_ptr< dev::db::DatabaseFace > db,
         std::unique_ptr< dev::db::WriteBatchFace >& writeBatch ) >

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -144,6 +144,13 @@ State& State::operator=( const State& _s ) {
     return *this;
 }
 
+dev::h256 State::safeLastExecutedTransactionHash() {
+    dev::h256 shaLastTx;
+    if ( m_db_ptr )
+        shaLastTx = m_db_ptr->safeLastExecutedTransactionHash();
+    return shaLastTx;
+}
+
 void State::populateFrom( eth::AccountMap const& _map ) {
     for ( auto const& addressAccountPair : _map ) {
         const Address& address = addressAccountPair.first;
@@ -821,10 +828,10 @@ std::pair< ExecutionResult, TransactionReceipt > State::execute( EnvInfo const& 
             [&]( std::shared_ptr< dev::db::DatabaseFace > /*db*/,
                 std::unique_ptr< dev::db::WriteBatchFace >& writeBatch ) {
                 if ( isSaveLastTxHash ) {
-                    h256 sha =
-                        _t.hasSignature() ? _t.sha3() : _t.sha3( dev::eth::WithoutSignature );
-                    // std::cout << "--- saving safeLastExecutedTransactionHash = " << sha.hex() <<
-                    // "\n";
+                    h256 sha = _t.sha3();  // _t.hasSignature() ? _t.sha3() : _t.sha3(
+                                           // dev::eth::WithoutSignature );
+                    std::cout << "--- saving safeLastExecutedTransactionHash = " << sha.hex()
+                              << "\n";
                     writeBatch->insert(
                         skale::slicing::toSlice( "safeLastExecutedTransactionHash" ),
                         skale::slicing::toSlice( sha ) );

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -828,13 +828,13 @@ std::pair< ExecutionResult, TransactionReceipt > State::execute( EnvInfo const& 
             [&]( std::shared_ptr< dev::db::DatabaseFace > /*db*/,
                 std::unique_ptr< dev::db::WriteBatchFace >& writeBatch ) {
                 if ( isSaveLastTxHash ) {
-                    h256 sha = _t.sha3();  // _t.hasSignature() ? _t.sha3() : _t.sha3(
-                                           // dev::eth::WithoutSignature );
-                    std::cout << "--- saving safeLastExecutedTransactionHash = " << sha.hex()
-                              << "\n";
+                    h256 shaLastTx = _t.sha3();  // _t.hasSignature() ? _t.sha3() : _t.sha3(
+                                                 // dev::eth::WithoutSignature );
+                    // std::cout << "--- saving \"safeLastExecutedTransactionHash\" = " <<
+                    // shaLastTx.hex() << "\n";
                     writeBatch->insert(
                         skale::slicing::toSlice( "safeLastExecutedTransactionHash" ),
-                        skale::slicing::toSlice( sha ) );
+                        skale::slicing::toSlice( shaLastTx ) );
                 }
             } );
         break;

--- a/libskale/State.h
+++ b/libskale/State.h
@@ -198,6 +198,7 @@ public:
     State& operator=( State&& ) = default;
 
     dev::h256 safeLastExecutedTransactionHash();
+    dev::eth::TransactionReceipts safePartialTransactionReceipts();
 
     /// Populate the state from the given AccountMap. Just uses dev::eth::commit().
     void populateFrom( dev::eth::AccountMap const& _map );
@@ -326,7 +327,8 @@ public:
     std::pair< dev::eth::ExecutionResult, dev::eth::TransactionReceipt > execute(
         dev::eth::EnvInfo const& _envInfo, dev::eth::SealEngineFace const& _sealEngine,
         dev::eth::Transaction const& _t, Permanence _p = Permanence::Committed,
-        dev::eth::OnOpFunc const& _onOp = dev::eth::OnOpFunc(), bool isSaveLastTxHash = false );
+        dev::eth::OnOpFunc const& _onOp = dev::eth::OnOpFunc(), bool isSaveLastTxHash = false,
+        dev::eth::TransactionReceipts* accumulatedTransactionReceipts = nullptr );
 
     /// Get the account start nonce. May be required.
     dev::u256 const& accountStartNonce() const { return m_accountStartNonce; }

--- a/libskale/State.h
+++ b/libskale/State.h
@@ -197,6 +197,8 @@ public:
 
     State& operator=( State&& ) = default;
 
+    dev::h256 safeLastExecutedTransactionHash();
+
     /// Populate the state from the given AccountMap. Just uses dev::eth::commit().
     void populateFrom( dev::eth::AccountMap const& _map );
 

--- a/libskale/State.h
+++ b/libskale/State.h
@@ -316,14 +316,15 @@ public:
 
     /// Commit all changes waiting in the address cache to the DB.
     /// @param _commitBehaviour whether or not to remove empty accounts during commit.
-    void commit( CommitBehaviour _commitBehaviour = CommitBehaviour::RemoveEmptyAccounts );
+    void commit( CommitBehaviour _commitBehaviour = CommitBehaviour::RemoveEmptyAccounts,
+        OverlayDB::fn_pre_commit_t fn_pre_commit = OverlayDB::g_fn_pre_commit_empty );
 
     /// Execute a given transaction.
     /// This will change the state accordingly.
     std::pair< dev::eth::ExecutionResult, dev::eth::TransactionReceipt > execute(
         dev::eth::EnvInfo const& _envInfo, dev::eth::SealEngineFace const& _sealEngine,
         dev::eth::Transaction const& _t, Permanence _p = Permanence::Committed,
-        dev::eth::OnOpFunc const& _onOp = dev::eth::OnOpFunc() );
+        dev::eth::OnOpFunc const& _onOp = dev::eth::OnOpFunc(), bool isSaveLastTxHash = false );
 
     /// Get the account start nonce. May be required.
     dev::u256 const& accountStartNonce() const { return m_accountStartNonce; }

--- a/libskale/State.h
+++ b/libskale/State.h
@@ -454,6 +454,14 @@ private:
     std::map< dev::Address, dev::s256 > storageUsage;
     dev::s256 totalStorageUsed_ = 0;
     dev::s256 currentStorageUsed_ = 0;
+
+public:
+    std::shared_ptr< dev::db::DatabaseFace > db() {
+        std::shared_ptr< dev::db::DatabaseFace > pDB;
+        if ( m_db_ptr )
+            pDB = m_db_ptr->db();
+        return pDB;
+    }
 };
 
 std::ostream& operator<<( std::ostream& _out, State const& _s );

--- a/test/unittests/libskutils/test_skutils_http.cpp
+++ b/test/unittests/libskutils/test_skutils_http.cpp
@@ -1,8 +1,9 @@
 #include "test_skutils_helper.h"
 #include <boost/test/unit_test.hpp>
+#include <test/tools/libtesteth/TestHelper.h>
 
 BOOST_AUTO_TEST_SUITE( SkUtils )
-BOOST_AUTO_TEST_SUITE( http )
+BOOST_AUTO_TEST_SUITE( http, *boost::unit_test::precondition( dev::test::option_all_tests ) )
 
 BOOST_AUTO_TEST_CASE( http_server_startup ) {
     skutils::test::test_print_header_name( "SkUtils/http/http_server_startup" );

--- a/test/unittests/libskutils/test_skutils_unddos.cpp
+++ b/test/unittests/libskutils/test_skutils_unddos.cpp
@@ -1,8 +1,9 @@
 #include "test_skutils_helper.h"
 #include <boost/test/unit_test.hpp>
+#include <test/tools/libtesteth/TestHelper.h>
 
 BOOST_AUTO_TEST_SUITE( SkUtils )
-BOOST_AUTO_TEST_SUITE( unddos )
+BOOST_AUTO_TEST_SUITE( unddos, *boost::unit_test::precondition( dev::test::option_all_tests ) )
 
 static skutils::unddos::settings compose_test_unddos_settings() {
     skutils::unddos::settings settings;

--- a/test/unittests/libskutils/test_skutils_ws.cpp
+++ b/test/unittests/libskutils/test_skutils_ws.cpp
@@ -1,8 +1,9 @@
 #include "test_skutils_helper.h"
 #include <boost/test/unit_test.hpp>
+#include <test/tools/libtesteth/TestHelper.h>
 
 BOOST_AUTO_TEST_SUITE( SkUtils )
-BOOST_AUTO_TEST_SUITE( ws )
+BOOST_AUTO_TEST_SUITE( ws, *boost::unit_test::precondition( dev::test::option_all_tests ) )
 
 BOOST_AUTO_TEST_CASE( ws_server_startup ) {
     skutils::test::test_print_header_name( "SkUtils/ws/ws_server_startup" );


### PR DESCRIPTION
Partial catch up, DB safety issues.
If **skaled** crashes after some transactions executed and their **state data** was saved into **level DB** (i.e. block was not finished) then next startup these transactions are skipped and only rest of transactions are executed to finish block mining.

**NOTICE:** the new `Contract Events Integrity Test` was used to verify partial catch-up data, you can find it here:
https://github.com/skalenetwork/SkaleExperimental/tree/master/skaled-tests/test-event-integrity
