### PR TITLE
SKALE-3373 now eth_getTransactionReceipt returns status as 0x string

### DIFF
--- a/libdevcore/CommonIO.h
+++ b/libdevcore/CommonIO.h
@@ -230,4 +230,26 @@ inline std::string toString< uint8_t >( uint8_t const& _u ) {
     o << static_cast< uint16_t >( _u );
     return o.str();
 }
+
+template < class T >
+inline std::string toString0x( T const& _val ) {
+    std::ostringstream o;
+    o << "0x" << std::uppercase << std::setfill( '0' ) << std::setw( 1 ) << std::hex << _val;
+    return o.str();
+}
+template <>
+inline std::string toString0x< int8_t >( int8_t const& _val ) {
+    std::ostringstream o;
+    o << "0x" << std::uppercase << std::setfill( '0' ) << std::setw( 1 ) << std::hex
+      << static_cast< int16_t >( _val );
+    return o.str();
+}
+template <>
+inline std::string toString0x< uint8_t >( uint8_t const& _val ) {
+    std::ostringstream o;
+    o << "0x" << std::uppercase << std::setfill( '0' ) << std::setw( 1 ) << std::hex
+      << static_cast< uint16_t >( _val );
+    return o.str();
+}
+
 }  // namespace dev

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -418,8 +418,10 @@ Json::Value Eth::eth_getTransactionReceipt( string const& _transactionHash ) {
         h256 h = jsToFixed< 32 >( _transactionHash );
         if ( !client()->isKnownTransaction( h ) )
             return Json::Value( Json::nullValue );
-
-        return toJson( client()->localisedTransactionReceipt( h ) );
+        auto cli = client();
+        auto rcp = cli->localisedTransactionReceipt( h );
+        auto jo = toJson( rcp );
+        return jo;
     } catch ( ... ) {
         BOOST_THROW_EXCEPTION( JsonRpcException( Errors::ERROR_RPC_INVALID_PARAMS ) );
     }

--- a/libweb3jsonrpc/JsonHelper.cpp
+++ b/libweb3jsonrpc/JsonHelper.cpp
@@ -193,7 +193,7 @@ Json::Value toJson( dev::eth::LocalisedTransactionReceipt const& _t ) {
     res["logs"] = dev::toJson( _t.localisedLogs() );
     res["logsBloom"] = toJS( _t.bloom() );
     if ( _t.hasStatusCode() )
-        res["status"] = toString( _t.statusCode() );
+        res["status"] = toString0x< uint8_t >( _t.statusCode() );  // toString( _t.statusCode() );
     else
         res["stateRoot"] = toJS( _t.stateRoot() );
     //

--- a/libweb3jsonrpc/JsonHelper.cpp
+++ b/libweb3jsonrpc/JsonHelper.cpp
@@ -153,7 +153,7 @@ Json::Value toJson( dev::eth::TransactionSkeleton const& _t ) {
 Json::Value toJson( dev::eth::TransactionReceipt const& _t ) {
     Json::Value res;
     if ( _t.hasStatusCode() )
-        res["status"] = toString( _t.statusCode() );
+        res["status"] = toString0x< uint8_t >( _t.statusCode() );  // toString( _t.statusCode() );
     else
         res["stateRoot"] = toJS( _t.stateRoot() );
     res["gasUsed"] = toJS( _t.cumulativeGasUsed() );

--- a/test/unittests/libethereum/ClientTest.cpp
+++ b/test/unittests/libethereum/ClientTest.cpp
@@ -171,7 +171,7 @@ public:
             auto txHash = m_ethereum->importTransaction(tx);
             dev::eth::mineTransaction(*(m_ethereum), 1);
             Json::Value receipt = toJson(m_ethereum->localisedTransactionReceipt(txHash));
-            return receipt["status"] == "1";
+            return receipt["status"] == "0x1";
         } catch (...) {
             return false;
         }

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -867,7 +867,7 @@ BOOST_AUTO_TEST_CASE( deploy_contract_from_owner ) {
 
     Json::Value receipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
 
-    BOOST_REQUIRE_EQUAL( receipt["status"], string( "1" ) );
+    BOOST_REQUIRE_EQUAL( receipt["status"], string( "0x1" ) );
     BOOST_REQUIRE( !receipt["contractAddress"].isNull() );
     Json::Value code =
         fixture.rpcClient->eth_getCode( receipt["contractAddress"].asString(), "latest" );
@@ -905,7 +905,7 @@ BOOST_AUTO_TEST_CASE( deploy_contract_not_from_owner ) {
     dev::eth::mineTransaction( *( fixture.client ), 1 );
 
     Json::Value receipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
-    BOOST_CHECK_EQUAL( receipt["status"], string( "0" ) );
+    BOOST_CHECK_EQUAL( receipt["status"], string( "0x0" ) );
     Json::Value code =
         fixture.rpcClient->eth_getCode( receipt["contractAddress"].asString(), "latest" );
     BOOST_REQUIRE( code.asString() == "0x" );
@@ -948,7 +948,7 @@ BOOST_AUTO_TEST_CASE( deploy_contract_true_flag ) {
     dev::eth::mineTransaction( *( fixture.client ), 1 );
 
     Json::Value receipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
-    BOOST_REQUIRE_EQUAL( receipt["status"], string( "1" ) );
+    BOOST_REQUIRE_EQUAL( receipt["status"], string( "0x1" ) );
     BOOST_REQUIRE( !receipt["contractAddress"].isNull() );
     Json::Value code =
             fixture.rpcClient->eth_getCode( receipt["contractAddress"].asString(), "latest" );
@@ -992,7 +992,7 @@ BOOST_AUTO_TEST_CASE( deploy_contract_false_flag ) {
     dev::eth::mineTransaction( *( fixture.client ), 1 );
 
     Json::Value receipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
-    BOOST_CHECK_EQUAL( receipt["status"], string( "0" ) );
+    BOOST_CHECK_EQUAL( receipt["status"], string( "0x0" ) );
     Json::Value code =
             fixture.rpcClient->eth_getCode( receipt["contractAddress"].asString(), "latest" );
     BOOST_REQUIRE( code.asString() == "0x" );
@@ -1124,7 +1124,7 @@ BOOST_AUTO_TEST_CASE( eth_sendRawTransaction_gasLimitExceeded ) {
 
     Json::Value receipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
 
-    BOOST_REQUIRE_EQUAL( receipt["status"], string( "0" ) );
+    BOOST_REQUIRE_EQUAL( receipt["status"], string( "0x0" ) );
     BOOST_REQUIRE_EQUAL( balanceBefore - balanceAfter, u256( gas ) * u256( gasPrice ) );
 }
 


### PR DESCRIPTION
- now `eth_getTransactionReceipt` returns `status` field of response JSON as `0x` string
- no new tests needed