### PR TITLE
SKALE-3396 more flexible Un-DDOS subsystem

### DIFF
--- a/libskale/httpserveroverride.cpp
+++ b/libskale/httpserveroverride.cpp
@@ -820,7 +820,7 @@ void SkaleWsPeer::onMessage( const std::string& msg, skutils::ws::opcv eOpCode )
     //
     // unddos
     skutils::unddos::e_high_load_detection_result_t ehldr =
-        pSO->unddos_.register_call_from_origin( m_strUnDdosOrigin );
+        pSO->unddos_.register_call_from_origin( m_strUnDdosOrigin, strMethod );
     switch ( ehldr ) {
     case skutils::unddos::e_high_load_detection_result_t::ehldr_peak:  // ban by too high load per
                                                                        // minute
@@ -2281,7 +2281,7 @@ bool SkaleServerOverride::implStartListening( std::shared_ptr< SkaleRelayHTTP >&
             skutils::url url_unddos_origin( req.origin_ );
             const std::string str_unddos_origin = url_unddos_origin.host();
             skutils::unddos::e_high_load_detection_result_t ehldr =
-                pSO->unddos_.register_call_from_origin( str_unddos_origin );
+                pSO->unddos_.register_call_from_origin( str_unddos_origin, strMethod );
             switch ( ehldr ) {
             case skutils::unddos::e_high_load_detection_result_t::ehldr_peak:     // ban by too high
                                                                                   // load per minute

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -2087,7 +2087,8 @@ int main( int argc, char** argv ) try {
             if ( joConfig.count( "unddos" ) > 0 ) {
                 nlohmann::json joUnDdosSettings = joConfig["unddos"];
                 skale_server_connector->unddos_.load_settings_from_json( joUnDdosSettings );
-            }
+            } else
+                skale_server_connector->unddos_.get_settings();  // auto-init
             //
             clog( VerbosityInfo, "main" )
                 << cc::attention( "UN-DDOS" ) + cc::debug( " is using configuration" )


### PR DESCRIPTION
- Un-DDOS configuration is available per-JSON-RPC-method
- changed default Un-DDOS settings to more friendly, especially for read-only often-used methods like "web3_clientVersion", "web3_sha3", "net_version", "eth_syncing", "eth_protocolVersion", "eth_gasPrice", "eth_blockNumber", "eth_getBalance", "eth_getBlockByHash", "eth_getBlockByNumber", "eth_getTransactionCount", "eth_getTransactionReceipt", "eth_getTransactionByHash", "eth_getTransactionByBlockHashAndIndex", "eth_getTransactionByBlockNumberAndIndex"
- no new tests needed