### PR TITLE
Bugfix/skale 5029 skale net browser failure 2

### DIFF
--- a/libweb3jsonrpc/SkaleNetworkBrowser.cpp
+++ b/libweb3jsonrpc/SkaleNetworkBrowser.cpp
@@ -26,7 +26,7 @@ namespace skale {
 namespace network {
 namespace browser {
 
-static bool g_bDebugVerboseSNB = false;
+static bool g_bDebugVerboseSNB = true; // false;
 
 // see: https://docs.soliditylang.org/en/develop/abi-spec.html#abi
 // see: https://docs.soliditylang.org/en/develop/internals/layout_in_memory.html

--- a/libweb3jsonrpc/SkaleNetworkBrowser.cpp
+++ b/libweb3jsonrpc/SkaleNetworkBrowser.cpp
@@ -26,7 +26,7 @@ namespace skale {
 namespace network {
 namespace browser {
 
-static bool g_bDebugVerboseSNB = true; // false;
+static bool g_bDebugVerboseSNB = false;
 
 // see: https://docs.soliditylang.org/en/develop/abi-spec.html#abi
 // see: https://docs.soliditylang.org/en/develop/internals/layout_in_memory.html


### PR DESCRIPTION
HTTP(S) client code uses `poll()` to detect socket ready states
