### PR TITLE
Enhancement/sync catchup flag

### DIFF
--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -85,6 +85,7 @@ public:
     std::array< std::string, 4 > commonBLSPublicKeys;
     bool syncNode;
     bool archiveMode;
+    bool syncFromCatchup;
 
     NodeInfo( std::string _name = "TestNode", u256 _id = 1, std::string _ip = "127.0.0.11",
         uint16_t _port = 11111, std::string _ip6 = "::1", uint16_t _port6 = 11111,
@@ -100,7 +101,7 @@ public:
                 "11559732032986387107991004021392285783925812861821192530917403151452391805634",
                 "8495653923123431417604973247489272438418190587263600148770280649306958101930",
                 "4082367875863433681332203403145435568316851327593401208105741076214120093531" },
-        bool _syncNode = false, bool _archiveMode = false ) {
+        bool _syncNode = false, bool _archiveMode = false, bool _syncFromCatchup = false ) {
         name = _name;
         id = _id;
         ip = _ip;
@@ -114,6 +115,7 @@ public:
         commonBLSPublicKeys = _commonBLSPublicKeys;
         syncNode = _syncNode;
         archiveMode = _archiveMode;
+        syncFromCatchup = _syncFromCatchup;
     }
 };
 

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -114,6 +114,7 @@ ChainParams ChainParams::loadConfig(
         auto nodeID = infoObj.at( "nodeID" ).get_uint64();
         bool syncNode = false;
         bool archiveMode = false;
+        bool syncFromCatchup = false;
         std::string ip, ip6, keyShareName, sgxServerUrl;
         size_t t = 0;
         uint64_t port = 0, port6 = 0;
@@ -139,6 +140,10 @@ ChainParams ChainParams::loadConfig(
         }
         try {
             archiveMode = infoObj.at( "archiveMode" ).get_bool();
+        } catch ( ... ) {
+        }
+        try {
+            syncFromCatchup = infoObj.at( "syncFromCatchup" ).get_bool();
         } catch ( ... ) {
         }
 
@@ -182,7 +187,7 @@ ChainParams ChainParams::loadConfig(
 
         cp.nodeInfo = { nodeName, nodeID, ip, static_cast< uint16_t >( port ), ip6,
             static_cast< uint16_t >( port6 ), sgxServerUrl, ecdsaKeyName, keyShareName,
-            BLSPublicKeys, commonBLSPublicKeys, syncNode, archiveMode };
+            BLSPublicKeys, commonBLSPublicKeys, syncNode, archiveMode, syncFromCatchup };
 
         auto sChainObj = skaleObj.at( "sChain" ).get_obj();
         SChain s{};

--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -206,6 +206,7 @@ void validateConfigJson( js::mObject const& _obj ) {
             { "imaCallerAddressMainNet", { { js::str_type }, JsonFieldPresence::Optional } },
             { "syncNode", { { js::bool_type }, JsonFieldPresence::Optional } },
             { "archiveMode", { { js::bool_type }, JsonFieldPresence::Optional } },
+            { "syncFromCatchup", { { js::bool_type }, JsonFieldPresence::Optional } },
             { "wallets", { { js::obj_type }, JsonFieldPresence::Optional } } } );
 
     std::string keyShareName = "";

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1498,7 +1498,7 @@ int main( int argc, char** argv ) try {
             shared_space ? shared_space->getPath() : std::string() ) );
     }
     
-    if ( chainParams.nodeInfo.syncNode ) {
+    if ( chainParams.nodeInfo.syncNode && !chainParams.nodeInfo.syncFromCatchup ) {
         auto bc = BlockChain(chainParams, getDataDir());
         if ( bc.number() == 0 ) {
             downloadSnapshotFlag = true;


### PR DESCRIPTION
Add syncFromCatchup flag. By default, the archive node starting from the snapshot. But in the case of cryptoblades issue, need to start from the catchup from the 0 block.

Added flag enables sync from catchup
```
{ 
...
     "syncFromCatchup" : true
...
}
```
Closes skalenetwork/internal-support#532