### PR TITLE
Global UnDDoS limit settings affecting all connections

### DIFF
--- a/libskutils/include/skutils/unddos.h
+++ b/libskutils/include/skutils/unddos.h
@@ -105,6 +105,7 @@ class settings {
 public:
     bool enabled_ = true;
     origin_entry_settings_t origins_;
+    origin_entry_setting global_limit_;
     settings();
     settings( const settings& other );
     settings( settings&& other );
@@ -285,8 +286,10 @@ class algorithm {
     mutable mutex_type mtx_;
     mutable settings settings_;
     tracked_origins_t tracked_origins_;
+    tracked_origin tracked_global_;
     typedef std::map< std::string, size_t > map_ws_conn_counts_t;
     map_ws_conn_counts_t map_ws_conn_counts_;
+    size_t ws_conn_count_global_ = 0;
 
 public:
     algorithm();

--- a/libskutils/src/unddos.cpp
+++ b/libskutils/src/unddos.cpp
@@ -292,12 +292,15 @@ bool settings::empty() const {
         return true;
     if ( !origins_.empty() )
         return false;
+    if ( !global_limit_.empty() )
+        return false;
     return true;
 }
 
 void settings::clear() {
     enabled_ = true;
     origins_.clear();
+    global_limit_.clear();
 }
 
 settings& settings::assign( const settings& other ) {
@@ -306,6 +309,7 @@ settings& settings::assign( const settings& other ) {
     clear();
     enabled_ = other.enabled_;
     origins_ = other.origins_;
+    global_limit_ = other.global_limit_;
     return ( *this );
 }
 
@@ -314,6 +318,7 @@ settings& settings::merge( const settings& other ) {
         return ( *this );
     for ( const origin_entry_setting& oe : other.origins_ )
         merge( oe );
+    global_limit_.merge( other.global_limit_ );
     return ( *this );
 }
 settings& settings::merge( const origin_entry_setting& oe ) {
@@ -365,6 +370,12 @@ void settings::fromJSON( const nlohmann::json& jo ) {
             }
         }
     }
+    if ( jo.find( "global" ) != jo.end() ) {
+        const nlohmann::json& joGlobalLimit = jo["global"];
+        origin_entry_setting oe;
+        oe.fromJSON( joGlobalLimit );
+        global_limit_ = oe;
+    }
     bool isEnabled = true;
     if ( jo.find( "enabled" ) != jo.end() ) {
         const nlohmann::json& joEnabled = jo["enabled"];
@@ -382,8 +393,11 @@ void settings::toJSON( nlohmann::json& jo ) const {
         oe.toJSON( joOrigin );
         joOrigins.push_back( joOrigin );
     }
+    nlohmann::json joGlobalLimit = nlohmann::json::object();
+    global_limit_.toJSON( joGlobalLimit );
     jo["enabled"] = enabled_;
     jo["origins"] = joOrigins;
+    jo["global"] = joGlobalLimit;
 }
 
 size_t settings::find_origin_entry_setting_match( const char* origin, size_t idxStart ) const {
@@ -631,6 +645,7 @@ size_t algorithm::unload_old_data_by_time_to_past(
     }
     for ( const std::string& origin : setOriginsTorRemove )
         tracked_origins_.erase( origin );
+    tracked_global_.unload_old_data_by_time_to_past( ttmNow, durationToPast );
     return cnt;
 }
 
@@ -642,6 +657,11 @@ e_high_load_detection_result_t algorithm::register_call_from_origin(
         return e_high_load_detection_result_t::ehldr_bad_origin;
     adjust_now_tick_mark( ttmNow );
     lock_type lock( mtx_ );
+    //
+    tracked_global_.time_entries_.push_back( time_entry( ttmNow ) );
+    if ( tracked_global_.check_ban( ttmNow ) )
+        return e_high_load_detection_result_t::ehldr_ban;  // still banned
+    //
     unload_old_data_by_time_to_past( ttmNow, durationToPast );  // unload first
     tracked_origins_t::iterator itFind = tracked_origins_.find( origin ),
                                 itEnd = tracked_origins_.end();
@@ -680,6 +700,8 @@ bool algorithm::is_ban_ws_conn_for_origin( const char* origin ) const {
     if ( origin == nullptr || origin[0] == '\0' )
         return true;
     lock_type lock( mtx_ );
+    if ( ws_conn_count_global_ > settings_.global_limit_.max_ws_conn_ )
+        return true;
     map_ws_conn_counts_t::const_iterator itFind = map_ws_conn_counts_.find( origin ),
                                          itEnd = map_ws_conn_counts_.end();
     if ( itFind == itEnd )
@@ -696,6 +718,9 @@ e_high_load_detection_result_t algorithm::register_ws_conn_for_origin( const cha
     if ( origin == nullptr || origin[0] == '\0' )
         return e_high_load_detection_result_t::ehldr_bad_origin;
     lock_type lock( mtx_ );
+    ++ws_conn_count_global_;
+    if ( ws_conn_count_global_ > settings_.global_limit_.max_ws_conn_ )
+        return e_high_load_detection_result_t::ehldr_peak;
     map_ws_conn_counts_t::iterator itFind = map_ws_conn_counts_.find( origin ),
                                    itEnd = map_ws_conn_counts_.end();
     if ( itFind == itEnd ) {
@@ -716,6 +741,8 @@ bool algorithm::unregister_ws_conn_for_origin( const char* origin ) {
         return false;
     }
     lock_type lock( mtx_ );
+    if ( ws_conn_count_global_ > 0 )
+        --ws_conn_count_global_;
     map_ws_conn_counts_t::iterator itFind = map_ws_conn_counts_.find( origin ),
                                    itEnd = map_ws_conn_counts_.end();
     if ( itFind == itEnd ) {
@@ -803,6 +830,13 @@ nlohmann::json algorithm::stats( time_tick_mark ttmNow, duration durationToPast 
     joStats["counts"] = joCounts;
     joStats["calls"] = joCalls;
     joStats["ws_conns"] = joWsConns;
+    //
+    joStats["global_ws_conns_count"] = ws_conn_count_global_;
+    joStats["global_cps"] = tracked_global_.count_to_past( ttmNow, 1 );
+    joStats["global_cpm"] = tracked_global_.count_to_past( ttmNow, durationToPast );
+    bool isGlobalBan = ( tracked_global_.ban_until_ != time_tick_mark( 0 ) ) ? true : false;
+    joStats["global_ban"] = isGlobalBan;
+    //
     return joStats;
 }
 

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -330,16 +330,14 @@ string Eth::eth_call( TransactionSkeleton& t, string const& /* _blockNumber */ )
     // note that lru_cache class is thread safe so there is no need to lock
 
 
-
-
     // Step 1 Look into the cache for the same request at the same block number
     // no need to lock since cache is synchronized internally
     uint64_t currentBlockNumber = client()->number();
-    auto key = t.toString().append(to_string(currentBlockNumber));
+    auto key = t.toString().append( to_string( currentBlockNumber ) );
     auto result = m_callCache.getIfExists( key );
     if ( result.has_value() ) {
         // found an identical request in cache, return
-        return any_cast<string>(result);
+        return any_cast< string >( result );
     }
 
     // Step 2. We got a cache miss. Execute the call now.
@@ -366,7 +364,7 @@ string Eth::eth_call( TransactionSkeleton& t, string const& /* _blockNumber */ )
     string callResult = toJS( er.output );
 
     // put the result into cache so it can be used by future calls
-    m_callCache.put( key, callResult);
+    m_callCache.put( key, callResult );
 
     return callResult;
 }

--- a/libweb3jsonrpc/Eth.h
+++ b/libweb3jsonrpc/Eth.h
@@ -152,8 +152,7 @@ protected:
 
     // a cache that maps the call request to the pair of response string and block number
     // for which the request has been executed
-    cache::lru_cache<string, string> m_callCache;
-
+    cache::lru_cache< string, string > m_callCache;
 };
 
 }  // namespace rpc

--- a/test/unittests/libweb3jsonrpc/genesisGeneration2Config.h
+++ b/test/unittests/libweb3jsonrpc/genesisGeneration2Config.h
@@ -27,6 +27,7 @@ static std::string const c_genesisGeneration2ConfigString = R"(
         "skaleDisableChainIdCheck": true
     },
     "unddos": {
+        "enabled": false,
         "origins": [
             {
                 "origin": [
@@ -38,7 +39,14 @@ static std::string const c_genesisGeneration2ConfigString = R"(
                 "max_calls_per_second": 1000000000,
                 "max_ws_conn": 20000
             }
-        ]
+        ],
+        "global": {
+            "ban_lengthy": 120,
+            "ban_peak": 15,
+            "max_calls_per_minute": 1000000000,
+            "max_calls_per_second": 1000000000,
+            "max_ws_conn": 20000
+        }
     },
     "genesis": {
         "nonce": "0x0000000000000042",


### PR DESCRIPTION
Implemented global UnDDoS limit settings affecting all connections on all network protocols. New UnDDoS settings example:
```    "unddos": {
        "enabled": true,
        "origins": [{
            "origin": [
                "*"
            ],
            "ban_lengthy": 120,
            "ban_peak": 15,
            "max_calls_per_minute": 5000000,
            "max_calls_per_second": 1500000,
            "max_ws_conn": 20000
        }],
        "global": {
            "ban_lengthy": 120,
            "ban_peak": 15,
            "max_calls_per_minute": 300,
            "max_calls_per_second": 20,
            "max_ws_conn": 40
        }
    },
```