### PR TITLE
ticket-321 snapshot downloading can wait up to 30 minutes

### DIFF
--- a/libskutils/include/skutils/rest_call.h
+++ b/libskutils/include/skutils/rest_call.h
@@ -37,6 +37,8 @@
 namespace skutils {
 namespace rest {
 
+extern long g_nClientConnectionTimeoutMS;
+
 enum class e_data_fetch_strategy {
     edfs_by_equal_json_id,
     edfs_nearest_arrived,

--- a/libskutils/src/http_pg.cpp
+++ b/libskutils/src/http_pg.cpp
@@ -5,6 +5,7 @@
 
 #include <skutils/console_colors.h>
 #include <skutils/multithreading.h>
+#include <skutils/rest_call.h>
 
 #include <glog/logging.h>
 
@@ -357,9 +358,7 @@ bool server::start() {
 
     proxygen::HTTPServerOptions options;
     options.threads = static_cast< size_t >( threads_ );
-    options.idleTimeout =
-        std::chrono::milliseconds( 1000 * 60 * 30  // 30 minutes in milliseconds, connect timeout
-        );
+    options.idleTimeout = std::chrono::milliseconds( skutils::rest::g_nClientConnectionTimeoutMS );
     // // // options.shutdownOn = {SIGINT, SIGTERM}; // experimental only, not needed in `skaled`
     // here
     options.enableContentCompression = false;

--- a/libskutils/src/http_pg.cpp
+++ b/libskutils/src/http_pg.cpp
@@ -357,7 +357,9 @@ bool server::start() {
 
     proxygen::HTTPServerOptions options;
     options.threads = static_cast< size_t >( threads_ );
-    options.idleTimeout = std::chrono::milliseconds( 60000 );
+    options.idleTimeout =
+        std::chrono::milliseconds( 1000 * 60 * 30  // 30 minutes in milliseconds, connect timeout
+        );
     // // // options.shutdownOn = {SIGINT, SIGTERM}; // experimental only, not needed in `skaled`
     // here
     options.enableContentCompression = false;

--- a/libskutils/src/rest_call.cpp
+++ b/libskutils/src/rest_call.cpp
@@ -24,6 +24,8 @@
 namespace skutils {
 namespace rest {
 
+long g_nClientConnectionTimeoutMS = 1000 * 60 * 30;  // 30 minutes in milliseconds, connect timeout
+
 data_t::data_t() {}
 data_t::data_t( const data_t& d ) {
     assign( d );

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -408,7 +408,8 @@ Json::Value Skale::skale_getSnapshotSignature( unsigned blockNumber ) {
         ssl_options.client_cert = sgx_cert_path + sgx_cert_filename;
         ssl_options.client_key = sgx_cert_path + sgx_key_filename;
 
-        skutils::rest::client cli;
+        skutils::rest::client cli( 1000 * 60 * 30  // 30 minutes in milliseconds, connect timeout
+        );
         cli.optsSSL_ = ssl_options;
         bool fl = cli.open( sgxServerURL );
         if ( !fl ) {
@@ -569,7 +570,9 @@ bool download( const std::string& strURLWeb3, unsigned& block_number, const fs::
         //
         if ( block_number == unsigned( -1 ) ) {
             // this means "latest"
-            skutils::rest::client cli;
+            skutils::rest::client cli(
+                1000 * 60 * 30  // 30 minutes in milliseconds, connect timeout
+            );
             if ( !cli.open( strURLWeb3 ) ) {
                 if ( pStrErrorDescription )
                     ( *pStrErrorDescription ) = "REST failed to connect to server(1)";
@@ -598,7 +601,8 @@ bool download( const std::string& strURLWeb3, unsigned& block_number, const fs::
         }
         //
         //
-        skutils::rest::client cli;
+        skutils::rest::client cli( 1000 * 60 * 30  // 30 minutes in milliseconds, connect timeout
+        );
         if ( !cli.open( strURLWeb3 ) ) {
             if ( pStrErrorDescription )
                 ( *pStrErrorDescription ) = "REST failed to connect to server(2)";
@@ -607,7 +611,6 @@ bool download( const std::string& strURLWeb3, unsigned& block_number, const fs::
                 << cc::error( "REST failed to connect to server(2)" ) << "\n";
             return false;
         }
-        cli.client_connection_timeout( 30 * 60 * 1000 );  // milliseconds
 
         nlohmann::json joIn = nlohmann::json::object();
         joIn["jsonrpc"] = "2.0";

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -408,8 +408,7 @@ Json::Value Skale::skale_getSnapshotSignature( unsigned blockNumber ) {
         ssl_options.client_cert = sgx_cert_path + sgx_cert_filename;
         ssl_options.client_key = sgx_cert_path + sgx_key_filename;
 
-        skutils::rest::client cli( 1000 * 60 * 30  // 30 minutes in milliseconds, connect timeout
-        );
+        skutils::rest::client cli( skutils::rest::g_nClientConnectionTimeoutMS );
         cli.optsSSL_ = ssl_options;
         bool fl = cli.open( sgxServerURL );
         if ( !fl ) {
@@ -570,9 +569,7 @@ bool download( const std::string& strURLWeb3, unsigned& block_number, const fs::
         //
         if ( block_number == unsigned( -1 ) ) {
             // this means "latest"
-            skutils::rest::client cli(
-                1000 * 60 * 30  // 30 minutes in milliseconds, connect timeout
-            );
+            skutils::rest::client cli( skutils::rest::g_nClientConnectionTimeoutMS );
             if ( !cli.open( strURLWeb3 ) ) {
                 if ( pStrErrorDescription )
                     ( *pStrErrorDescription ) = "REST failed to connect to server(1)";
@@ -601,8 +598,7 @@ bool download( const std::string& strURLWeb3, unsigned& block_number, const fs::
         }
         //
         //
-        skutils::rest::client cli( 1000 * 60 * 30  // 30 minutes in milliseconds, connect timeout
-        );
+        skutils::rest::client cli( skutils::rest::g_nClientConnectionTimeoutMS );
         if ( !cli.open( strURLWeb3 ) ) {
             if ( pStrErrorDescription )
                 ( *pStrErrorDescription ) = "REST failed to connect to server(2)";

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -630,6 +630,8 @@ int main( int argc, char** argv ) try {
         "Run informational web3 WSS(IPv6) server(s) on specified port(and next set of ports if "
         "--info-acceptors > 1)" );
 
+    addClientOption( "no-snapshot-majority", po::value< string >()->value_name( "<url>" ), "" );
+
     addClientOption( "network-idle-timeout", po::value< long >()->value_name( "<timeout>" ),
         "Idle wait timeout for JSON RPC calls in milliseconds" );
 

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -225,8 +225,7 @@ void removeEmptyOptions( po::parsed_options& parsed ) {
 }
 
 unsigned getLatestSnapshotBlockNumber( const std::string& strURLWeb3 ) {
-    skutils::rest::client cli( 1000 * 60 * 30  // 30 minutes in milliseconds, connect timeout
-    );
+    skutils::rest::client cli( skutils::rest::g_nClientConnectionTimeoutMS );
     if ( !cli.open( strURLWeb3 ) ) {
         throw std::runtime_error( "REST failed to connect to server" );
     }
@@ -631,6 +630,9 @@ int main( int argc, char** argv ) try {
         "Run informational web3 WSS(IPv6) server(s) on specified port(and next set of ports if "
         "--info-acceptors > 1)" );
 
+    addClientOption( "network-idle-timeout", po::value< long >()->value_name( "<timiout>" ),
+        "Idle wait timeout for JSON RPC calls in milliseconds" );
+
     std::string strPerformanceWarningDurationOptionDescription =
         "Specifies time margin in floating point format, in seconds, for displaying performance "
         "warning messages in log output if JSON RPC call processing exeeds it, default is " +
@@ -836,6 +838,9 @@ int main( int argc, char** argv ) try {
         return 0;
     }
 
+    if ( vm.count( "network-idle-timeout" ) )
+        skutils::rest::g_nClientConnectionTimeoutMS = vm["network-idle-timeout"].as< long >();
+
     if ( vm.count( "test-enable-crash-at" ) ) {
         std::string crash_at = vm["test-enable-crash-at"].as< string >();
         batched_io::test_enable_crash_at( crash_at );
@@ -916,7 +921,7 @@ int main( int argc, char** argv ) try {
                            cc::p( strPathKey ) + "\n" );
         }
         try {
-            skutils::rest::client cli;
+            skutils::rest::client cli( skutils::rest::g_nClientConnectionTimeoutMS );
             cli.optsSSL_ = optsSSL;
             cli.open( u );
             const bool isAutoGenJsonID = true;

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -225,7 +225,8 @@ void removeEmptyOptions( po::parsed_options& parsed ) {
 }
 
 unsigned getLatestSnapshotBlockNumber( const std::string& strURLWeb3 ) {
-    skutils::rest::client cli;
+    skutils::rest::client cli( 1000 * 60 * 30  // 30 minutes in milliseconds, connect timeout
+    );
     if ( !cli.open( strURLWeb3 ) ) {
         throw std::runtime_error( "REST failed to connect to server" );
     }

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -630,7 +630,7 @@ int main( int argc, char** argv ) try {
         "Run informational web3 WSS(IPv6) server(s) on specified port(and next set of ports if "
         "--info-acceptors > 1)" );
 
-    addClientOption( "network-idle-timeout", po::value< long >()->value_name( "<timiout>" ),
+    addClientOption( "network-idle-timeout", po::value< long >()->value_name( "<timeout>" ),
         "Idle wait timeout for JSON RPC calls in milliseconds" );
 
     std::string strPerformanceWarningDurationOptionDescription =


### PR DESCRIPTION
- `rest::client` instances configured property for snapshot downloading and can wait up to `30` minutes
- `proxygen` configured properly to handle HTTP idle states up to `30` minutes
- added `--network-idle-timeout=<milliseconds>` command line argument for waiting REST calls long time