### PR TITLE
1558

### DIFF
--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -813,6 +813,7 @@ void SkaleHost::startWorking() {
                 m_broadcastThread.join();
             }
             ExitHandler::exitHandler( SIGABRT, ExitHandler::ec_termninated_by_signal );
+            return;
         }
 
         // comment out as this hack is in consensus now


### PR DESCRIPTION
Returned the behavior we had in 2.1.1. If the lock can not be acquired for a long time by catchup, the catchup will be skipped to avoid deadlock.

In 2.3 we will need to investigate the deadlock in more detail.