### PR TITLE
SIGSEGV in skale_stats

### DIFF
--- a/libskutils/include/skutils/stats.h
+++ b/libskutils/include/skutils/stats.h
@@ -220,7 +220,7 @@ public:
     element( const char* strSubSystem, const char* strProtocol, const char* strMethod,
         int /*nServerIndex*/, int /*ipVer*/ );
     virtual ~element();
-    void stop() const;
+    void stop();
     void setMethod( const char* strMethod ) const;
     void setError() const;
     double getDurationInSeconds() const;

--- a/libskutils/src/stats.cpp
+++ b/libskutils/src/stats.cpp
@@ -405,7 +405,6 @@ element::element( const char* strSubSystem, const char* strProtocol, const char*
         strProtocol_ = "N/A";
     if ( strMethod_.empty() )
         strMethod_ = g_strMethodNameUnknown;
-    do_register();
 }
 element::~element() {
     stop();
@@ -420,12 +419,13 @@ void element::do_unregister() {
     queue::getQueueForSubsystem( strSubSystem_.c_str() ).do_unregister( rttElement );
 }
 
-void element::stop() const {
+void element::stop() {
     lock_type lock( mtx() );
     if ( isStopped_ )
         return;
     isStopped_ = true;
     tpEnd_ = skutils::stats::clock::now();
+    do_register();
 }
 
 void element::setMethod( const char* strMethod ) const {


### PR DESCRIPTION
IS-256 HACK do_register() in stats::element only in stop(), to avoid race condition with queue