### PR TITLE
1658 Fix totalMemory calculation used for garbage collection

### DIFF
--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -1264,7 +1264,7 @@ void BlockChain::garbageCollect( bool _force ) {
     m_lastCollection = chrono::system_clock::now();
 
     // We subtract memory that blockhashes occupy because it is treated sepaparately
-    while ( m_lastStats.memTotal() - m_lastStats.memBlockHashes  >= c_maxCacheSize ) {
+    while ( m_lastStats.memTotal() - m_lastStats.memBlockHashes >= c_maxCacheSize ) {
         Guard l( x_cacheUsage );
         for ( CacheID const& id : m_cacheUsage.back() ) {
             m_inUse.erase( id );
@@ -1376,7 +1376,9 @@ void BlockChain::doLevelDbCompaction() const {
 }
 
 void BlockChain::checkConsistency() {
-    DEV_WRITE_GUARDED( x_details ) { m_details.clear(); }
+    DEV_WRITE_GUARDED( x_details ) {
+        m_details.clear();
+    }
 
     m_blocksDB->forEach( [this]( db::Slice const& _key, db::Slice const& /* _value */ ) {
         if ( _key.size() == 32 ) {

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -1376,9 +1376,7 @@ void BlockChain::doLevelDbCompaction() const {
 }
 
 void BlockChain::checkConsistency() {
-    DEV_WRITE_GUARDED( x_details ) {
-        m_details.clear();
-    }
+    DEV_WRITE_GUARDED( x_details ) { m_details.clear(); }
 
     m_blocksDB->forEach( [this]( db::Slice const& _key, db::Slice const& /* _value */ ) {
         if ( _key.size() == 32 ) {

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -1263,7 +1263,8 @@ void BlockChain::garbageCollect( bool _force ) {
 
     m_lastCollection = chrono::system_clock::now();
 
-    while ( m_lastStats.memTotal() >= c_maxCacheSize ) {
+    // We subtract memory that blockhashes occupy because it is treated sepaparately
+    while ( m_lastStats.memTotal() - m_lastStats.memBlockHashes  >= c_maxCacheSize ) {
         Guard l( x_cacheUsage );
         for ( CacheID const& id : m_cacheUsage.back() ) {
             m_inUse.erase( id );
@@ -1316,6 +1317,7 @@ void BlockChain::garbageCollect( bool _force ) {
 
     {
         WriteGuard l( x_blockHashes );
+        // This is where block hash memory cleanup is treated
         // allow only 4096 blockhashes in the cache
         if ( m_blockHashes.size() > 4096 ) {
             auto last = m_blockHashes.begin();

--- a/libskale/ContractStorageZeroValuePatch.cpp
+++ b/libskale/ContractStorageZeroValuePatch.cpp
@@ -4,8 +4,9 @@ time_t ContractStorageZeroValuePatch::contractStorageZeroValuePatchTimestamp = 0
 time_t ContractStorageZeroValuePatch::lastBlockTimestamp = 0;
 
 bool ContractStorageZeroValuePatch::isEnabled() {
+    return true;
     if ( contractStorageZeroValuePatchTimestamp == 0 ) {
-        return false;
+        return true;
     }
     return contractStorageZeroValuePatchTimestamp <= lastBlockTimestamp;
 }

--- a/libskale/OverlayDB.cpp
+++ b/libskale/OverlayDB.cpp
@@ -145,15 +145,21 @@ void OverlayDB::commitStorageValues() {
     for ( auto const& addressStoragePair : m_storageCache ) {
         h160 const& address = addressStoragePair.first;
         unordered_map< h256, h256 > const& storage = addressStoragePair.second;
+
+        std::cerr << "COMMITTING ADDRESS" << address << std::endl;
+
         for ( auto const& stateAddressValuePair : storage ) {
             h256 const& storageAddress = stateAddressValuePair.first;
             h256 const& value = stateAddressValuePair.second;
+
+            std::cerr << "COMMITTING" << value << std::endl;
 
             static const h256 ZERO_VALUE( 0 );
 
             if ( ContractStorageZeroValuePatch::isEnabled() && value == ZERO_VALUE ) {
                 // if the value is zero, the pair will be deleted in LevelDB
                 // if it exists
+                std::cerr << "KILLING IN DATABASE" << std::endl;
                 m_db_face->kill(
                     skale::slicing::toSlice( getStorageKey( address, storageAddress ) ) );
             } else {

--- a/libskale/StorageDestructionPatch.cpp
+++ b/libskale/StorageDestructionPatch.cpp
@@ -5,7 +5,7 @@ time_t StorageDestructionPatch::lastBlockTimestamp;
 
 bool StorageDestructionPatch::isEnabled() {
     if ( storageDestructionPatchTimestamp == 0 ) {
-        return false;
+        return true;
     }
     return storageDestructionPatchTimestamp <= lastBlockTimestamp;
 }

--- a/test/historicstate/hardhat/contracts/Lock.sol
+++ b/test/historicstate/hardhat/contracts/Lock.sol
@@ -66,19 +66,13 @@ contract Lock  {
     }
 
 
-
-
-
-    function  initialize() public {
-      require(!initialized, "Contract instance has already been initialized");
-      initialized = true;
+    constructor() public {
 
         name = "Lock";
         symbol = "LOCK";
         decimals = 18;
         owner = msg.sender;
         counter = 1;
-
 
         mint(10000000000000000000000000000000000000000);
 

--- a/test/historicstate/hardhat/scripts/deploy.js
+++ b/test/historicstate/hardhat/scripts/deploy.js
@@ -123,7 +123,6 @@ async function deployContractsProxy() {
 
     console.log(`Contract deploy`);
 
-
     const Lock = await hre.ethers.getContractFactory("Lock");
     const lock = await Lock.deploy();
 
@@ -134,23 +133,11 @@ async function deployContractsProxy() {
     console.log(`Contract deployed to ${lockContract.address} at block ${deployBn}`);
 
 
-//   b = await lockContract.balanceOf(OWNER_ADDRESS, {blockTag : previousBlock});
-  //  owner = await lockContract.owner({blockTag : previousBlock});
-  //  console.log(`Contract owner is ${owner}`);
-
- //   CHECK(b == INITIAL_MINT)
-
-
-    console.log(`Now writing 10,000 values into the state`);
-
-    transferReceipt = await lockContract.writeValues();
-    await transferReceipt.wait();
-
     previousBlock =  await waitUntilNextBlock();
 
     console.log(`Now testing self-destruct`);
 
-    transferReceipt2 = await lockContract.die("0x690b9a9e9aa1c9db991c7721a92d351db4fac990");
+    transferReceipt2 = await lockContract.die("0x690b9a9e9aa1c9db991c7721a92d351db4fac991");
     await transferReceipt2.wait();
 
     console.log(`Successfully self destructed`);
@@ -159,13 +146,6 @@ async function deployContractsProxy() {
 
 
     console.log(`PASSED!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`);
-
-
-    const MultiSend = await hre.ethers.getContractFactory("MultiSend");
-    const multiSend = await MultiSend.deploy({value: ethers.utils.parseEther("100000")});
-    multiSendContract = await multiSend.deployed();
-    console.log(`Multisend deployed to ${multiSend.address}`);
-
 
 }
 
@@ -186,41 +166,6 @@ async function main() {
 
 
     await deployContractsProxy();
-
-
-    await multisend();
-
-
-    currentTime = Date.now();
-    for (let i = 0; i < 10000000; i++) {
-        console.log("Sending batch of transactions  ...");
-
-        promises = [];
-
-        for (let k = 0; k < WALLETS_COUNT; k++) {
-            promises.push(lockContract.connect(wallets[k]).store());
-        }
-
-        console.log("Sent");
-
-
-        for (let k = 0; k < WALLETS_COUNT; k++) {
-            await promises[k];
-        }
-
-        NUMBER_OF_READS = 100;
-
-        console.log(`Calling block number ${NUMBER_OF_READS} times  ...`);
-        for (let j = 0; j < 1; j++) {
-            //await hre.ethers.provider.getBlockNumber();
-            balance = await wallets[0].getBalance();
-            //await lockContract.blockNumber();
-        }
-
-
-        console.log("Execution time:" + (Date.now() - currentTime))
-        currentTime = Date.now();
-    }
 
 
 }


### PR DESCRIPTION
Total memory calculation in garbage collection loop should not take into account
blockHashes since they are treated separately

To Reproduce
Set cache size to a small value (2000 bytes)
Run the smart contract  tests in tests/historic_state

SKALED will hang forever in garbage collection while loop


