### PR TITLE
1658 fix total memory calculation used for garbage collection final commit

### DIFF
--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -1264,7 +1264,7 @@ void BlockChain::garbageCollect( bool _force ) {
     m_lastCollection = chrono::system_clock::now();
 
     // We subtract memory that blockhashes occupy because it is treated sepaparately
-    while ( m_lastStats.memTotal() - m_lastStats.memBlockHashes  >= c_maxCacheSize ) {
+    while ( m_lastStats.memTotal() - m_lastStats.memBlockHashes >= c_maxCacheSize ) {
         Guard l( x_cacheUsage );
         for ( CacheID const& id : m_cacheUsage.back() ) {
             m_inUse.erase( id );
@@ -1376,7 +1376,9 @@ void BlockChain::doLevelDbCompaction() const {
 }
 
 void BlockChain::checkConsistency() {
-    DEV_WRITE_GUARDED( x_details ) { m_details.clear(); }
+    DEV_WRITE_GUARDED( x_details ) {
+        m_details.clear();
+    }
 
     m_blocksDB->forEach( [this]( db::Slice const& _key, db::Slice const& /* _value */ ) {
         if ( _key.size() == 32 ) {

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -1376,9 +1376,7 @@ void BlockChain::doLevelDbCompaction() const {
 }
 
 void BlockChain::checkConsistency() {
-    DEV_WRITE_GUARDED( x_details ) {
-        m_details.clear();
-    }
+    DEV_WRITE_GUARDED( x_details ) { m_details.clear(); }
 
     m_blocksDB->forEach( [this]( db::Slice const& _key, db::Slice const& /* _value */ ) {
         if ( _key.size() == 32 ) {

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -1263,7 +1263,8 @@ void BlockChain::garbageCollect( bool _force ) {
 
     m_lastCollection = chrono::system_clock::now();
 
-    while ( m_lastStats.memTotal() >= c_maxCacheSize ) {
+    // We subtract memory that blockhashes occupy because it is treated sepaparately
+    while ( m_lastStats.memTotal() - m_lastStats.memBlockHashes  >= c_maxCacheSize ) {
         Guard l( x_cacheUsage );
         for ( CacheID const& id : m_cacheUsage.back() ) {
             m_inUse.erase( id );
@@ -1316,6 +1317,7 @@ void BlockChain::garbageCollect( bool _force ) {
 
     {
         WriteGuard l( x_blockHashes );
+        // This is where block hash memory cleanup is treated
         // allow only 4096 blockhashes in the cache
         if ( m_blockHashes.size() > 4096 ) {
             auto last = m_blockHashes.begin();


### PR DESCRIPTION
Total memory calculation in garbage collection loop should not take into account
blockHashes since they are treated separately

To Reproduce
Set cache size to a small value (2000 bytes)
Run the smart contract tests in tests/historic_state

SKALED will hang forever in garbage collection while loop