### PR TITLE
1347 data destruction

### DIFF
--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -812,8 +812,8 @@ void State::clearStorage( Address const& _contract ) {
            at the end of transaction
            see OverlayDB::commitStorageValues()
         */
-        h256 ZERO(0);
-        m_db_ptr->insert(_contract, key, ZERO);
+        h256 ZERO( 0 );
+        m_db_ptr->insert( _contract, key, ZERO );
     }
 
     totalStorageUsed_ -= ( accStorageUsed + storageUsage[_contract] );

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -803,8 +803,8 @@ void State::clearStorage( Address const& _contract ) {
         auto const& value = hashPairPair.second.first;
         // Set storage to zero in state cache
         clearStorageValue( _contract, key, value );
-        // Set storage to zero i account storage cache
-        // we have lots of caches, some of them may be unndeeded
+        // Set storage to zero in the account storage cache
+        // we have lots of caches, some of them may be unneeded
         // will analyze this more in future releases
         acc->setStorageCache( key, 0 );
         /* The corresponding key/value pair needs to be cleared in database


### PR DESCRIPTION
Storage values were deletes in cache but not in the actual LevelDB database. 

Fixed.  Tested using the self destruct test in skaled/tests