### PR TITLE
Skaled 1674 kill snapsot sending monitoring thread

### DIFF
--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -210,7 +210,7 @@ nlohmann::json Skale::impl_skale_getSnapshot( const nlohmann::json& joRequest, C
                         m_client.chainParams().sChain.snapshotDownloadTimeout ) {
                 if ( threadExitRequested )
                     break;
-                sleep( 30 );
+                sleep( 10 );
             }
 
             clog( VerbosityInfo, "skale_downloadSnapshotFragmentMonitorThread" )

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -64,12 +64,21 @@ namespace rpc {
 
 std::string exceptionToErrorMessage();
 
-Skale::Skale( Client& _client, std::shared_ptr< SharedSpace > _sharedSpace )
-    : m_client( _client ), m_shared_space( _sharedSpace ) {}
-
 volatile bool Skale::g_bShutdownViaWeb3Enabled = false;
 volatile bool Skale::g_bNodeInstanceShouldShutdown = false;
 Skale::list_fn_on_shutdown_t Skale::g_list_fn_on_shutdown;
+
+Skale::Skale( Client& _client, std::shared_ptr< SharedSpace > _sharedSpace )
+    : m_client( _client ), m_shared_space( _sharedSpace ) {}
+
+Skale::~Skale() {
+    threadExitRequested = true;
+    if ( snapshotDownloadFragmentMonitorThread != nullptr &&
+         snapshotDownloadFragmentMonitorThread->joinable() ) {
+        clog( VerbosityInfo, "Skale" ) << "Joining downloadSnapshotFragmentMonitorThread";
+        snapshotDownloadFragmentMonitorThread->join();
+    }
+}
 
 bool Skale::isWeb3ShutdownEnabled() {
     return g_bShutdownViaWeb3Enabled;
@@ -199,11 +208,13 @@ nlohmann::json Skale::impl_skale_getSnapshot( const nlohmann::json& joRequest, C
                             m_client.chainParams().sChain.snapshotDownloadInactiveTimeout ) &&
                     time( NULL ) - currentSnapshotTime <
                         m_client.chainParams().sChain.snapshotDownloadTimeout ) {
+                if ( threadExitRequested )
+                    break;
                 sleep( 30 );
             }
 
             clog( VerbosityInfo, "skale_downloadSnapshotFragmentMonitorThread" )
-                << "Unlocking shared space as timeout was reached.\n";
+                << "Unlocking shared space.\n";
 
             std::lock_guard< std::mutex > lock( m_snapshot_mutex );
             if ( currentSnapshotBlockNumber >= 0 ) {

--- a/libweb3jsonrpc/Skale.h
+++ b/libweb3jsonrpc/Skale.h
@@ -57,6 +57,7 @@ class Skale : public dev::rpc::SkaleFace {
 public:
     explicit Skale(
         dev::eth::Client& _client, std::shared_ptr< SharedSpace > _sharedSpace = nullptr );
+    virtual ~Skale();
 
     virtual RPCModules implementedModules() const override {
         return RPCModules{ RPCModule{ "skale", "0.1" } };
@@ -105,6 +106,7 @@ private:
     std::atomic< time_t > currentSnapshotTime = 0;
     std::atomic< time_t > lastSnapshotDownloadFragmentTime = 0;
     std::unique_ptr< std::thread > snapshotDownloadFragmentMonitorThread;
+    std::atomic_bool threadExitRequested = false;
     mutable std::mutex m_snapshot_mutex;
 };
 


### PR DESCRIPTION
if skaled is sending snapshot, and is asked to exit - it should kill threads that monitor snapshot sending timeouts
Fixes #1674 