### PR TITLE
Fix for duplicatiing transactions (IS-869)

### DIFF
--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -175,6 +175,7 @@ public:
     time_t verifyDaSigsPatchTimestamp = 0;
     time_t storageDestructionPatchTimestamp = 0;
     time_t powCheckPatchTimestamp = 0;
+    time_t skipInvalidTransactionsPatchTimestamp = 0;
 
     SChain() {
         name = "TestChain";

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -484,7 +484,7 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone(
                 LOG( m_logger ) << "Transaction " << tr.sha3() << " WouldNotBeInBlock: gasPrice "
                                 << tr.gasPrice() << " < " << _gasPrice;
 
-                if ( SkipInvalidTransactionsPatch::needToKeepTransaction( true ) ) {
+                if ( SkipInvalidTransactionsPatch::isEnabled() ) {
                     // Add to the user-originated transactions that we've executed.
                     m_transactions.push_back( tr );
                     m_transactionSet.insert( tr.sha3() );
@@ -508,8 +508,8 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone(
             ExecutionResult res =
                 execute( _bc.lastBlockHashes(), tr, Permanence::Committed, OnOpFunc() );
 
-            if ( SkipInvalidTransactionsPatch::needToKeepTransaction(
-                     res.excepted == TransactionException::WouldNotBeInBlock ) ) {
+            if ( !SkipInvalidTransactionsPatch::isEnabled() ||
+                 res.excepted != TransactionException::WouldNotBeInBlock ) {
                 receipts.push_back( m_receipts.back() );
 
                 // if added but bad
@@ -870,8 +870,8 @@ ExecutionResult Block::execute(
     if ( _p == Permanence::Committed || _p == Permanence::CommittedWithoutState ||
          _p == Permanence::Uncommitted ) {
         // Add to the user-originated transactions that we've executed.
-        if ( SkipInvalidTransactionsPatch::needToKeepTransaction(
-                 resultReceipt.first.excepted == TransactionException::WouldNotBeInBlock ) ) {
+        if ( !SkipInvalidTransactionsPatch::isEnabled() ||
+             resultReceipt.first.excepted != TransactionException::WouldNotBeInBlock ) {
             m_transactions.push_back( _t );
             m_receipts.push_back( resultReceipt.second );
             m_transactionSet.insert( _t.sha3() );

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -484,7 +484,7 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone(
                 LOG( m_logger ) << "Transaction " << tr.sha3() << " WouldNotBeInBlock: gasPrice "
                                 << tr.gasPrice() << " < " << _gasPrice;
 
-                if ( SkipInvalidTransactionsPatch::needToKeepTransaction( tr, true ) ) {
+                if ( SkipInvalidTransactionsPatch::needToKeepTransaction( true ) ) {
                     // Add to the user-originated transactions that we've executed.
                     m_transactions.push_back( tr );
                     m_transactionSet.insert( tr.sha3() );
@@ -509,7 +509,7 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone(
                 execute( _bc.lastBlockHashes(), tr, Permanence::Committed, OnOpFunc() );
 
             if ( SkipInvalidTransactionsPatch::needToKeepTransaction(
-                     tr, res.excepted == TransactionException::WouldNotBeInBlock ) ) {
+                     res.excepted == TransactionException::WouldNotBeInBlock ) ) {
                 receipts.push_back( m_receipts.back() );
 
                 // if added but bad
@@ -871,7 +871,7 @@ ExecutionResult Block::execute(
          _p == Permanence::Uncommitted ) {
         // Add to the user-originated transactions that we've executed.
         if ( SkipInvalidTransactionsPatch::needToKeepTransaction(
-                 _t, resultReceipt.first.excepted == TransactionException::WouldNotBeInBlock ) ) {
+                 resultReceipt.first.excepted == TransactionException::WouldNotBeInBlock ) ) {
             m_transactions.push_back( _t );
             m_receipts.push_back( resultReceipt.second );
             m_transactionSet.insert( _t.sha3() );

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -266,6 +266,11 @@ ChainParams ChainParams::loadConfig(
                                        sChainObj.at( "powCheckPatchTimestamp" ).get_int64() :
                                        0;
 
+        s.skipInvalidTransactionsPatchTimestamp =
+            sChainObj.count( "skipInvalidTransactionsPatchTimestamp" ) ?
+                sChainObj.at( "skipInvalidTransactionsPatchTimestamp" ).get_int64() :
+                0;
+
         if ( sChainObj.count( "nodeGroups" ) ) {
             std::vector< NodeGroup > nodeGroups;
             for ( const auto& nodeGroupConf : sChainObj["nodeGroups"].get_obj() ) {

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -55,6 +55,7 @@
 #include <libskale/ContractStorageZeroValuePatch.h>
 #include <libskale/POWCheckPatch.h>
 #include <libskale/RevertableFSPatch.h>
+#include <libskale/SkipInvalidTransactionsPatch.h>
 #include <libskale/State.h>
 #include <libskale/StorageDestructionPatch.h>
 #include <libskale/TotalStorageUsedPatch.h>
@@ -162,6 +163,7 @@ Client::Client( ChainParams const& _params, int _networkID,
     RevertableFSPatch::setTimestamp( chainParams().sChain.revertableFSPatchTimestamp );
     StorageDestructionPatch::setTimestamp( chainParams().sChain.storageDestructionPatchTimestamp );
     POWCheckPatch::setTimestamp( chainParams().sChain.powCheckPatchTimestamp );
+    SkipInvalidTransactionsPatch::init( this->chainParams() );
 }
 
 
@@ -654,7 +656,7 @@ size_t Client::syncTransactions(
     RevertableFSPatch::lastBlockTimestamp = blockChain().info().timestamp();
     StorageDestructionPatch::lastBlockTimestamp = blockChain().info().timestamp();
     POWCheckPatch::lastBlockTimestamp = blockChain().info().timestamp();
-
+    SkipInvalidTransactionsPatch::setLastBlock( blockChain().info() );
 
     DEV_WRITE_GUARDED( x_working ) {
         assert( !m_working.isSealed() );

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -163,7 +163,7 @@ Client::Client( ChainParams const& _params, int _networkID,
     RevertableFSPatch::setTimestamp( chainParams().sChain.revertableFSPatchTimestamp );
     StorageDestructionPatch::setTimestamp( chainParams().sChain.storageDestructionPatchTimestamp );
     POWCheckPatch::setTimestamp( chainParams().sChain.powCheckPatchTimestamp );
-    SkipInvalidTransactionsPatch::init( this->chainParams() );
+    SkipInvalidTransactionsPatch::init( this->chainParams(), this );
 }
 
 
@@ -656,7 +656,6 @@ size_t Client::syncTransactions(
     RevertableFSPatch::lastBlockTimestamp = blockChain().info().timestamp();
     StorageDestructionPatch::lastBlockTimestamp = blockChain().info().timestamp();
     POWCheckPatch::lastBlockTimestamp = blockChain().info().timestamp();
-    SkipInvalidTransactionsPatch::setLastBlock( blockChain().info() );
 
     DEV_WRITE_GUARDED( x_working ) {
         assert( !m_working.isSealed() );

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -163,8 +163,8 @@ Client::Client( ChainParams const& _params, int _networkID,
     RevertableFSPatch::setTimestamp( chainParams().sChain.revertableFSPatchTimestamp );
     StorageDestructionPatch::setTimestamp( chainParams().sChain.storageDestructionPatchTimestamp );
     POWCheckPatch::setTimestamp( chainParams().sChain.powCheckPatchTimestamp );
-    SkipInvalidTransactionsPatch::init(
-        this->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, this );
+    SkipInvalidTransactionsPatch::setTimestamp(
+        this->chainParams().sChain.skipInvalidTransactionsPatchTimestamp );
 }
 
 
@@ -657,6 +657,7 @@ size_t Client::syncTransactions(
     RevertableFSPatch::lastBlockTimestamp = blockChain().info().timestamp();
     StorageDestructionPatch::lastBlockTimestamp = blockChain().info().timestamp();
     POWCheckPatch::lastBlockTimestamp = blockChain().info().timestamp();
+    SkipInvalidTransactionsPatch::lastBlockTimestamp = blockChain().info().timestamp();
 
     DEV_WRITE_GUARDED( x_working ) {
         assert( !m_working.isSealed() );

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -163,7 +163,8 @@ Client::Client( ChainParams const& _params, int _networkID,
     RevertableFSPatch::setTimestamp( chainParams().sChain.revertableFSPatchTimestamp );
     StorageDestructionPatch::setTimestamp( chainParams().sChain.storageDestructionPatchTimestamp );
     POWCheckPatch::setTimestamp( chainParams().sChain.powCheckPatchTimestamp );
-    SkipInvalidTransactionsPatch::init( this->chainParams(), this );
+    SkipInvalidTransactionsPatch::init(
+        this->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, this );
 }
 
 

--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -268,7 +268,9 @@ void validateConfigJson( js::mObject const& _obj ) {
             { "storageDestructionPatchTimestamp",
                 { { js::int_type }, JsonFieldPresence::Optional } },
             { "powCheckPatchTimestamp", { { js::int_type }, JsonFieldPresence::Optional } },
-            { "nodeGroups", { { js::obj_type }, JsonFieldPresence::Optional } } } );
+            { "nodeGroups", { { js::obj_type }, JsonFieldPresence::Optional } },
+            { "skipInvalidTransactionsPatchTimestamp",
+                { { js::int_type }, JsonFieldPresence::Optional } } } );
 
     js::mArray const& nodes = sChain.at( "nodes" ).get_array();
     for ( auto const& obj : nodes ) {

--- a/libskale/CMakeLists.txt
+++ b/libskale/CMakeLists.txt
@@ -20,6 +20,7 @@ set(sources
     OverlayFS.cpp
     StorageDestructionPatch.cpp
     POWCheckPatch.cpp
+    SkipInvalidTransactionsPatch.cpp
 )
 
 set(headers
@@ -39,6 +40,7 @@ set(headers
     RevertableFSPatch.h
     POWCheckPatch.h
     OverlayFS.h
+    SkipInvalidTransactionsPatch.h
 )
 
 add_library(skale ${sources} ${headers})

--- a/libskale/SkipInvalidTransactionsPatch.cpp
+++ b/libskale/SkipInvalidTransactionsPatch.cpp
@@ -3,26 +3,10 @@
 using namespace dev::eth;
 
 time_t SkipInvalidTransactionsPatch::activationTimestamp;
-const dev::eth::Interface* SkipInvalidTransactionsPatch::client;
+time_t SkipInvalidTransactionsPatch::lastBlockTimestamp;
 
 bool SkipInvalidTransactionsPatch::isEnabled() {
     if ( activationTimestamp == 0 )
         return false;
-    return client->blockInfo( client->number() ).timestamp() >= activationTimestamp;
-}
-
-// TODO better start to apply patches from 1st block after timestamp, not second
-bool SkipInvalidTransactionsPatch::isActiveInBlock( BlockNumber _bn ) {
-    if ( _bn == 0 )
-        return false;
-
-    if ( _bn == PendingBlock )
-        return isEnabled();
-
-    if ( _bn == LatestBlock )
-        _bn = client->number();
-
-    time_t prev_ts = client->blockInfo( _bn - 1 ).timestamp();
-
-    return prev_ts >= activationTimestamp;
+    return lastBlockTimestamp >= activationTimestamp;
 }

--- a/libskale/SkipInvalidTransactionsPatch.cpp
+++ b/libskale/SkipInvalidTransactionsPatch.cpp
@@ -1,0 +1,19 @@
+#include "SkipInvalidTransactionsPatch.h"
+
+using namespace dev::eth;
+
+time_t SkipInvalidTransactionsPatch::activationTimestamp;
+time_t SkipInvalidTransactionsPatch::lastBlockTimestamp;
+
+bool SkipInvalidTransactionsPatch::activateTimestampPassed() {
+    if ( activationTimestamp == 0 )
+        return false;
+    return lastBlockTimestamp >= activationTimestamp;
+}
+
+bool SkipInvalidTransactionsPatch::needToKeepTransaction( const Transaction& tr, bool excepted ) {
+    if ( !activateTimestampPassed() )
+        return true;
+    return !excepted;
+    ( void ) tr;
+}

--- a/libskale/SkipInvalidTransactionsPatch.cpp
+++ b/libskale/SkipInvalidTransactionsPatch.cpp
@@ -11,9 +11,8 @@ bool SkipInvalidTransactionsPatch::activateTimestampPassed() {
     return lastBlockTimestamp >= activationTimestamp;
 }
 
-bool SkipInvalidTransactionsPatch::needToKeepTransaction( const Transaction& tr, bool excepted ) {
+bool SkipInvalidTransactionsPatch::needToKeepTransaction( bool excepted ) {
     if ( !activateTimestampPassed() )
         return true;
     return !excepted;
-    ( void ) tr;
 }

--- a/libskale/SkipInvalidTransactionsPatch.cpp
+++ b/libskale/SkipInvalidTransactionsPatch.cpp
@@ -3,16 +3,29 @@
 using namespace dev::eth;
 
 time_t SkipInvalidTransactionsPatch::activationTimestamp;
-time_t SkipInvalidTransactionsPatch::lastBlockTimestamp;
+const dev::eth::Interface* SkipInvalidTransactionsPatch::client;
 
 bool SkipInvalidTransactionsPatch::activateTimestampPassed() {
     if ( activationTimestamp == 0 )
         return false;
-    return lastBlockTimestamp >= activationTimestamp;
+    return client->blockInfo( client->number() ).timestamp() >= activationTimestamp;
 }
 
 bool SkipInvalidTransactionsPatch::needToKeepTransaction( bool _excepted ) {
     if ( !activateTimestampPassed() )
         return true;
     return !_excepted;
+}
+
+// TODO better start to apply patches from 1st block after timestamp, not second
+bool SkipInvalidTransactionsPatch::isActiveInBlock( BlockNumber _bn ) {
+    assert( _bn != PendingBlock );
+    assert( _bn != 0 );
+
+    if ( _bn == LatestBlock )
+        _bn = client->number();
+
+    time_t prev_ts = client->blockInfo( _bn - 1 ).timestamp();
+
+    return prev_ts >= activationTimestamp;
 }

--- a/libskale/SkipInvalidTransactionsPatch.cpp
+++ b/libskale/SkipInvalidTransactionsPatch.cpp
@@ -11,8 +11,8 @@ bool SkipInvalidTransactionsPatch::activateTimestampPassed() {
     return lastBlockTimestamp >= activationTimestamp;
 }
 
-bool SkipInvalidTransactionsPatch::needToKeepTransaction( bool excepted ) {
+bool SkipInvalidTransactionsPatch::needToKeepTransaction( bool _excepted ) {
     if ( !activateTimestampPassed() )
         return true;
-    return !excepted;
+    return !_excepted;
 }

--- a/libskale/SkipInvalidTransactionsPatch.cpp
+++ b/libskale/SkipInvalidTransactionsPatch.cpp
@@ -19,8 +19,11 @@ bool SkipInvalidTransactionsPatch::needToKeepTransaction( bool _excepted ) {
 
 // TODO better start to apply patches from 1st block after timestamp, not second
 bool SkipInvalidTransactionsPatch::isActiveInBlock( BlockNumber _bn ) {
-    assert( _bn != PendingBlock );
-    assert( _bn != 0 );
+    if ( _bn == 0 )
+        return false;
+
+    if ( _bn == PendingBlock )
+        return activateTimestampPassed();
 
     if ( _bn == LatestBlock )
         _bn = client->number();

--- a/libskale/SkipInvalidTransactionsPatch.cpp
+++ b/libskale/SkipInvalidTransactionsPatch.cpp
@@ -5,16 +5,10 @@ using namespace dev::eth;
 time_t SkipInvalidTransactionsPatch::activationTimestamp;
 const dev::eth::Interface* SkipInvalidTransactionsPatch::client;
 
-bool SkipInvalidTransactionsPatch::activateTimestampPassed() {
+bool SkipInvalidTransactionsPatch::isEnabled() {
     if ( activationTimestamp == 0 )
         return false;
     return client->blockInfo( client->number() ).timestamp() >= activationTimestamp;
-}
-
-bool SkipInvalidTransactionsPatch::needToKeepTransaction( bool _excepted ) {
-    if ( !activateTimestampPassed() )
-        return true;
-    return !_excepted;
 }
 
 // TODO better start to apply patches from 1st block after timestamp, not second
@@ -23,7 +17,7 @@ bool SkipInvalidTransactionsPatch::isActiveInBlock( BlockNumber _bn ) {
         return false;
 
     if ( _bn == PendingBlock )
-        return activateTimestampPassed();
+        return isEnabled();
 
     if ( _bn == LatestBlock )
         _bn = client->number();

--- a/libskale/SkipInvalidTransactionsPatch.h
+++ b/libskale/SkipInvalidTransactionsPatch.h
@@ -28,6 +28,7 @@ class SkipInvalidTransactionsPatch : public SchainPatch {
 public:
     static void init( const dev::eth::ChainParams& cp ) {
         activationTimestamp = cp.sChain.skipInvalidTransactionsPatchTimestamp;
+        printInfo( __FILE__, activationTimestamp );
     }
     static void setLastBlock( const dev::eth::BlockHeader& bh ) {
         lastBlockTimestamp = bh.timestamp();

--- a/libskale/SkipInvalidTransactionsPatch.h
+++ b/libskale/SkipInvalidTransactionsPatch.h
@@ -7,6 +7,12 @@
 #include <libethereum/SchainPatch.h>
 #include <libethereum/Transaction.h>
 
+namespace dev {
+namespace eth {
+class Client;
+}
+}  // namespace dev
+
 // What this patch does:
 // 1. "Invalid" transactions that came with winning block proposal from consensus
 // are skipped, and not included in block.
@@ -25,22 +31,22 @@
 // 5) eth_getTransactionByBlockHash/NumberAndIndex
 // Transactions are removed from Transaction Queue as usually.
 
+// TODO better start to apply patches from 1st block after timestamp, not second
 class SkipInvalidTransactionsPatch : public SchainPatch {
 public:
     static bool isEnabled();
 
-    static void init( time_t _activationTimestamp, const dev::eth::Interface* _client ) {
+    static void setTimestamp( time_t _activationTimestamp ) {
         activationTimestamp = _activationTimestamp;
         printInfo( __FILE__, _activationTimestamp );
-        assert( _client );
-        client = _client;
     }
 
-    static bool isActiveInBlock( dev::eth::BlockNumber _bn );
+    static time_t getActivationTimestamp() { return activationTimestamp; }
 
 private:
+    friend class dev::eth::Client;
     static time_t activationTimestamp;
-    static const dev::eth::Interface* client;
+    static time_t lastBlockTimestamp;
 };
 
 #endif  // SKIPINVALIDTRANSACTIONSPATCH_H

--- a/libskale/SkipInvalidTransactionsPatch.h
+++ b/libskale/SkipInvalidTransactionsPatch.h
@@ -32,7 +32,7 @@ public:
     static void setLastBlock( const dev::eth::BlockHeader& bh ) {
         lastBlockTimestamp = bh.timestamp();
     }
-    static bool needToKeepTransaction( const dev::eth::Transaction& tr, bool excepted );
+    static bool needToKeepTransaction( bool excepted );
 
 private:
     static bool activateTimestampPassed();

--- a/libskale/SkipInvalidTransactionsPatch.h
+++ b/libskale/SkipInvalidTransactionsPatch.h
@@ -1,0 +1,43 @@
+#ifndef SKIPINVALIDTRANSACTIONSPATCH_H
+#define SKIPINVALIDTRANSACTIONSPATCH_H
+
+#include <libethcore/BlockHeader.h>
+#include <libethereum/ChainParams.h>
+#include <libethereum/SchainPatch.h>
+#include <libethereum/Transaction.h>
+
+// What this patch does:
+// 1. "Invalid" transactions that came with winning block proposal from consensus
+// are skipped, and not included in block.
+// Their "validity is determined in Block::syncEveryone:
+// a) Transactions should have gasPrice >= current block min gas price
+// b) State::execute should not throw (it causes WouldNotBeInBlock exception).
+//    Usually this exception is caused by Executive::verifyTransaction() failure.
+//
+// 2. Specifically for historic node - we ignore "invalid" transactions that
+//    are already in block as though they never came.
+// This affects following JSON-RPC calls:
+// 1) eth_getBlockByHash/Number
+// 2) eth_getTransactionReceipt (affects "transactionIndex" field)
+// 3) eth_getBlockTransactionCountByHash/Number
+// 4) eth_getTransactionByHash (invalid transactions are treated as never present)
+// 5) eth_getTransactionByBlockHash/NumberAndIndex
+// Transactions are removed from Transaction Queue as usually.
+
+class SkipInvalidTransactionsPatch : public SchainPatch {
+public:
+    static void init( const dev::eth::ChainParams& cp ) {
+        activationTimestamp = cp.sChain.skipInvalidTransactionsPatchTimestamp;
+    }
+    static void setLastBlock( const dev::eth::BlockHeader& bh ) {
+        lastBlockTimestamp = bh.timestamp();
+    }
+    static bool needToKeepTransaction( const dev::eth::Transaction& tr, bool excepted );
+
+private:
+    static bool activateTimestampPassed();
+    static time_t activationTimestamp;
+    static time_t lastBlockTimestamp;
+};
+
+#endif  // SKIPINVALIDTRANSACTIONSPATCH_H

--- a/libskale/SkipInvalidTransactionsPatch.h
+++ b/libskale/SkipInvalidTransactionsPatch.h
@@ -27,19 +27,19 @@
 
 class SkipInvalidTransactionsPatch : public SchainPatch {
 public:
-    static void init( const dev::eth::ChainParams& _cp, const dev::eth::Interface* _client ) {
-        activationTimestamp = _cp.sChain.skipInvalidTransactionsPatchTimestamp;
-        printInfo( __FILE__, activationTimestamp );
+    static bool isEnabled();
+
+    static void init( time_t _activationTimestamp, const dev::eth::Interface* _client ) {
+        activationTimestamp = _activationTimestamp;
+        printInfo( __FILE__, _activationTimestamp );
         assert( _client );
         client = _client;
     }
-    static bool needToKeepTransaction( bool _excepted );
+
     static bool isActiveInBlock( dev::eth::BlockNumber _bn );
 
 private:
-    static bool activateTimestampPassed();
     static time_t activationTimestamp;
-    static time_t lastBlockTimestamp;
     static const dev::eth::Interface* client;
 };
 

--- a/libskale/SkipInvalidTransactionsPatch.h
+++ b/libskale/SkipInvalidTransactionsPatch.h
@@ -3,6 +3,7 @@
 
 #include <libethcore/BlockHeader.h>
 #include <libethereum/ChainParams.h>
+#include <libethereum/Interface.h>
 #include <libethereum/SchainPatch.h>
 #include <libethereum/Transaction.h>
 
@@ -26,19 +27,20 @@
 
 class SkipInvalidTransactionsPatch : public SchainPatch {
 public:
-    static void init( const dev::eth::ChainParams& _cp ) {
+    static void init( const dev::eth::ChainParams& _cp, const dev::eth::Interface* _client ) {
         activationTimestamp = _cp.sChain.skipInvalidTransactionsPatchTimestamp;
         printInfo( __FILE__, activationTimestamp );
-    }
-    static void setLastBlock( const dev::eth::BlockHeader& _bh ) {
-        lastBlockTimestamp = _bh.timestamp();
+        assert( _client );
+        client = _client;
     }
     static bool needToKeepTransaction( bool _excepted );
+    static bool isActiveInBlock( dev::eth::BlockNumber _bn );
 
 private:
     static bool activateTimestampPassed();
     static time_t activationTimestamp;
     static time_t lastBlockTimestamp;
+    static const dev::eth::Interface* client;
 };
 
 #endif  // SKIPINVALIDTRANSACTIONSPATCH_H

--- a/libskale/SkipInvalidTransactionsPatch.h
+++ b/libskale/SkipInvalidTransactionsPatch.h
@@ -26,14 +26,14 @@
 
 class SkipInvalidTransactionsPatch : public SchainPatch {
 public:
-    static void init( const dev::eth::ChainParams& cp ) {
-        activationTimestamp = cp.sChain.skipInvalidTransactionsPatchTimestamp;
+    static void init( const dev::eth::ChainParams& _cp ) {
+        activationTimestamp = _cp.sChain.skipInvalidTransactionsPatchTimestamp;
         printInfo( __FILE__, activationTimestamp );
     }
-    static void setLastBlock( const dev::eth::BlockHeader& bh ) {
-        lastBlockTimestamp = bh.timestamp();
+    static void setLastBlock( const dev::eth::BlockHeader& _bh ) {
+        lastBlockTimestamp = _bh.timestamp();
     }
-    static bool needToKeepTransaction( bool excepted );
+    static bool needToKeepTransaction( bool _excepted );
 
 private:
     static bool activateTimestampPassed();

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -556,6 +556,13 @@ Json::Value Eth::eth_getBlockByNumber( string const& _blockNumber, bool _include
         if ( !client()->isKnown( h ) )
             return Json::Value( Json::nullValue );
 
+#ifdef HISTORIC_STATE
+        h256 bh = client()->hashFromNumber( h );
+        return eth_getBlockByHash( "0x" + bh.hex(), _includeTransactions );
+    } catch ( const JsonRpcException& ) {
+        throw;
+#else
+
         if ( _includeTransactions )
             return toJson( client()->blockInfo( h ), client()->blockDetails( h ),
                 client()->uncleHashes( h ), client()->transactions( h ), client()->sealEngine() );
@@ -563,6 +570,7 @@ Json::Value Eth::eth_getBlockByNumber( string const& _blockNumber, bool _include
             return toJson( client()->blockInfo( h ), client()->blockDetails( h ),
                 client()->uncleHashes( h ), client()->transactionHashes( h ),
                 client()->sealEngine() );
+#endif
     } catch ( ... ) {
         BOOST_THROW_EXCEPTION( JsonRpcException( Errors::ERROR_RPC_INVALID_PARAMS ) );
     }

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -119,7 +119,7 @@ void simulateMining( Client& client, size_t numBlocks, const dev::Address &addre
     for ( size_t blockNumber = 0; blockNumber < numBlocks; ++blockNumber ) {
         reward += client.sealEngine()->blockReward( blockNumber );
     }
-    state.addBalance( client.author(), reward );
+    state.addBalance( address, reward );
     state.commit();
     const auto balanceAfter = client.balanceAt( address );
     balanceAfter > balanceBefore; // make compiler happy

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -236,7 +236,7 @@ BOOST_DATA_TEST_CASE( validTransaction, skipInvalidTransactionsVariants, skipInv
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
+    SkipInvalidTransactionsPatch::setTimestamp(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp);
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -286,7 +286,7 @@ BOOST_DATA_TEST_CASE( transactionRlpBad, skipInvalidTransactionsVariants, skipIn
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
+    SkipInvalidTransactionsPatch::setTimestamp(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp);
 
     auto senderAddress = coinbase.address();
 
@@ -372,7 +372,7 @@ BOOST_DATA_TEST_CASE( transactionSigZero, skipInvalidTransactionsVariants, skipI
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
+    SkipInvalidTransactionsPatch::setTimestamp(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp);
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -427,7 +427,7 @@ BOOST_DATA_TEST_CASE( transactionSigBad, skipInvalidTransactionsVariants, skipIn
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
+    SkipInvalidTransactionsPatch::setTimestamp(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp);
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -482,7 +482,7 @@ BOOST_DATA_TEST_CASE( transactionGasIncorrect, skipInvalidTransactionsVariants, 
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
+    SkipInvalidTransactionsPatch::setTimestamp(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp);
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -535,7 +535,7 @@ BOOST_DATA_TEST_CASE( transactionGasNotEnough, skipInvalidTransactionsVariants, 
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
+    SkipInvalidTransactionsPatch::setTimestamp(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp);
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -596,7 +596,7 @@ BOOST_DATA_TEST_CASE( transactionNonceBig, skipInvalidTransactionsVariants, skip
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
+    SkipInvalidTransactionsPatch::setTimestamp(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp);
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -648,7 +648,7 @@ BOOST_DATA_TEST_CASE( transactionNonceSmall, skipInvalidTransactionsVariants, sk
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
+    SkipInvalidTransactionsPatch::setTimestamp(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp);
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -712,7 +712,7 @@ BOOST_DATA_TEST_CASE( transactionBalanceBad, skipInvalidTransactionsVariants, sk
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
+    SkipInvalidTransactionsPatch::setTimestamp(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp);
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -764,7 +764,7 @@ BOOST_DATA_TEST_CASE( transactionGasBlockLimitExceeded, skipInvalidTransactionsV
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
+    SkipInvalidTransactionsPatch::setTimestamp(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp);
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -236,7 +236,7 @@ BOOST_DATA_TEST_CASE( validTransaction, skipInvalidTransactionsVariants, skipInv
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
+    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -286,7 +286,7 @@ BOOST_DATA_TEST_CASE( transactionRlpBad, skipInvalidTransactionsVariants, skipIn
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
+    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
 
     auto senderAddress = coinbase.address();
 
@@ -372,7 +372,7 @@ BOOST_DATA_TEST_CASE( transactionSigZero, skipInvalidTransactionsVariants, skipI
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
+    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -427,7 +427,7 @@ BOOST_DATA_TEST_CASE( transactionSigBad, skipInvalidTransactionsVariants, skipIn
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
+    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -482,7 +482,7 @@ BOOST_DATA_TEST_CASE( transactionGasIncorrect, skipInvalidTransactionsVariants, 
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
+    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -535,7 +535,7 @@ BOOST_DATA_TEST_CASE( transactionGasNotEnough, skipInvalidTransactionsVariants, 
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
+    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -596,7 +596,7 @@ BOOST_DATA_TEST_CASE( transactionNonceBig, skipInvalidTransactionsVariants, skip
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
+    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -648,7 +648,7 @@ BOOST_DATA_TEST_CASE( transactionNonceSmall, skipInvalidTransactionsVariants, sk
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
+    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -712,7 +712,7 @@ BOOST_DATA_TEST_CASE( transactionBalanceBad, skipInvalidTransactionsVariants, sk
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
+    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -764,7 +764,7 @@ BOOST_DATA_TEST_CASE( transactionGasBlockLimitExceeded, skipInvalidTransactionsV
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
+    SkipInvalidTransactionsPatch::init(client->chainParams().sChain.skipInvalidTransactionsPatchTimestamp, client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -14,12 +14,15 @@
 #include <libp2p/Network.h>
 #include <libweb3jsonrpc/AccountHolder.h>
 #include <libweb3jsonrpc/JsonHelper.h>
+#include <libskale/SkipInvalidTransactionsPatch.h>
 
 #include <libethcore/SealEngine.h>
 
 #include <libdevcore/TransientDirectory.h>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/data/monomorphic.hpp>
 
 #include <memory>
 
@@ -124,6 +127,9 @@ struct SkaleHostFixture : public TestOutputHelperFixture {
         chainParams.nodeInfo.port = chainParams.nodeInfo.port6 = rand_port;
         chainParams.sChain.nodes[0].port = chainParams.sChain.nodes[0].port6 = rand_port;
 
+        // not 0-timestamp genesis - to test patch
+        chainParams.timestamp = 1;
+
         if( params.count("multiTransactionMode") && stoi( params.at( "multiTransactionMode" ) ) )
             chainParams.sChain.multiTransactionMode = true;
 
@@ -223,7 +229,15 @@ struct SkaleHostFixture : public TestOutputHelperFixture {
 
 BOOST_FIXTURE_TEST_SUITE( SkaleHostSuite, SkaleHostFixture )  //, *boost::unit_test::disabled() )
 
-BOOST_AUTO_TEST_CASE( validTransaction ) {
+auto skipInvalidTransactionsVariants = boost::unit_test::data::make({false, true});
+
+BOOST_DATA_TEST_CASE( validTransaction, skipInvalidTransactionsVariants, skipInvalidTransactionsFlag ) {
+
+    if(skipInvalidTransactionsFlag){
+        const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
+    }
+    SkipInvalidTransactionsPatch::init(client->chainParams());
+
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
 
@@ -260,14 +274,20 @@ BOOST_AUTO_TEST_CASE( validTransaction ) {
     REQUIRE_BALANCE_DECREASE( senderAddress, value + gasPrice * 21000 );
 }
 
-// Transaction should be IGNORED during execution
+// Transaction should be IGNORED or EXCLUDED during execution (depending on skipInvalidTransactionsFlag)
 // Proposer should be penalized
 // 1 Small amount of random bytes
 // 2 110 random bytes
 // 3 110 bytes of semi-correct RLP
-BOOST_AUTO_TEST_CASE( transactionRlpBad
+BOOST_DATA_TEST_CASE( transactionRlpBad, skipInvalidTransactionsVariants, skipInvalidTransactionsFlag
                       // , *boost::unit_test::precondition( dev::test::run_not_express )
                       ) {
+
+    if(skipInvalidTransactionsFlag){
+        const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
+    }
+    SkipInvalidTransactionsPatch::init(client->chainParams());
+
     auto senderAddress = coinbase.address();
 
     bytes small_tx1 = bytes();
@@ -290,7 +310,13 @@ BOOST_AUTO_TEST_CASE( transactionRlpBad
         1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
-    REQUIRE_BLOCK_SIZE( 1, 3 );
+
+    if(skipInvalidTransactionsFlag){
+        REQUIRE_BLOCK_SIZE( 1, 0 );
+    }
+    else{
+        REQUIRE_BLOCK_SIZE( 1, 3 );
+    }
 
     REQUIRE_NONCE_INCREASE( senderAddress, 0 );
     REQUIRE_BALANCE_DECREASE( senderAddress, 0 );
@@ -299,31 +325,33 @@ BOOST_AUTO_TEST_CASE( transactionRlpBad
     Transactions txns = client->transactions( 1 );
     //    cerr << toJson( txns );
 
-    REQUIRE_BLOCK_TRANSACTION( 1, 0, txns[0].sha3() );
-    REQUIRE_BLOCK_TRANSACTION( 1, 1, txns[1].sha3() );
-    REQUIRE_BLOCK_TRANSACTION( 1, 2, txns[2].sha3() );
+    if(!skipInvalidTransactionsFlag){
+        REQUIRE_BLOCK_TRANSACTION( 1, 0, txns[0].sha3() );
+        REQUIRE_BLOCK_TRANSACTION( 1, 1, txns[1].sha3() );
+        REQUIRE_BLOCK_TRANSACTION( 1, 2, txns[2].sha3() );
 
-    // check also receipts and locations
-    size_t i = 0;
-    for ( const Transaction& tx : txns ) {
-        Transaction tx2 = client->transaction( tx.sha3() );
-        LocalisedTransaction lt = client->localisedTransaction( tx.sha3() );
-        LocalisedTransactionReceipt lr = client->localisedTransactionReceipt( tx.sha3() );
+        // check also receipts and locations
+        size_t i = 0;
+        for ( const Transaction& tx : txns ) {
+            Transaction tx2 = client->transaction( tx.sha3() );
+            LocalisedTransaction lt = client->localisedTransaction( tx.sha3() );
+            LocalisedTransactionReceipt lr = client->localisedTransactionReceipt( tx.sha3() );
 
-        BOOST_REQUIRE_EQUAL( tx2, tx );
+            BOOST_REQUIRE_EQUAL( tx2, tx );
 
-        BOOST_REQUIRE_EQUAL( lt, tx );
-        BOOST_REQUIRE_EQUAL( lt.blockNumber(), 1 );
-        BOOST_REQUIRE_EQUAL( lt.blockHash(), client->hashFromNumber( 1 ) );
-        BOOST_REQUIRE_EQUAL( lt.transactionIndex(), i );
+            BOOST_REQUIRE_EQUAL( lt, tx );
+            BOOST_REQUIRE_EQUAL( lt.blockNumber(), 1 );
+            BOOST_REQUIRE_EQUAL( lt.blockHash(), client->hashFromNumber( 1 ) );
+            BOOST_REQUIRE_EQUAL( lt.transactionIndex(), i );
 
-        BOOST_REQUIRE_EQUAL( lr.hash(), tx.sha3() );
-        BOOST_REQUIRE_EQUAL( lr.blockNumber(), lt.blockNumber() );
-        BOOST_REQUIRE_EQUAL( lr.blockHash(), lt.blockHash() );
-        BOOST_REQUIRE_EQUAL( lr.transactionIndex(), i );
+            BOOST_REQUIRE_EQUAL( lr.hash(), tx.sha3() );
+            BOOST_REQUIRE_EQUAL( lr.blockNumber(), lt.blockNumber() );
+            BOOST_REQUIRE_EQUAL( lr.blockHash(), lt.blockHash() );
+            BOOST_REQUIRE_EQUAL( lr.transactionIndex(), i );
 
-        ++i;
-    }  // for
+            ++i;
+        }  // for
+    }
 }
 
 class VrsHackedTransaction : public Transaction {
@@ -334,12 +362,18 @@ public:
     }
 };
 
-// Transaction should be IGNORED during execution
+// Transaction should be IGNORED during execution or absent if skipInvalidTransactionsFlag
 // Proposer should be penalized
 // zero signature
-BOOST_AUTO_TEST_CASE( transactionSigZero
+BOOST_DATA_TEST_CASE( transactionSigZero, skipInvalidTransactionsVariants, skipInvalidTransactionsFlag
                       // , *boost::unit_test::precondition( dev::test::run_not_express )
                       ) {
+
+    if(skipInvalidTransactionsFlag){
+        const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
+    }
+    SkipInvalidTransactionsPatch::init(client->chainParams());
+
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
 
@@ -369,21 +403,32 @@ BOOST_AUTO_TEST_CASE( transactionSigZero
         stub->createBlock( ConsensusExtFace::transactions_vector{stream.out()}, utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
-    REQUIRE_BLOCK_SIZE( 1, 1 );
 
-    h256 txHash = sha3( stream.out() );
-    REQUIRE_BLOCK_TRANSACTION( 1, 0, txHash );
+    if(skipInvalidTransactionsFlag){
+        REQUIRE_BLOCK_SIZE( 1, 0 );
+    }
+    else {
+        REQUIRE_BLOCK_SIZE( 1, 1 );
+        h256 txHash = sha3( stream.out() );
+        REQUIRE_BLOCK_TRANSACTION( 1, 0, txHash );
+    }
 
     REQUIRE_NONCE_INCREASE( senderAddress, 0 );
     REQUIRE_BALANCE_DECREASE( senderAddress, 0 );
 }
 
-// Transaction should be IGNORED during execution
+// Transaction should be IGNORED during execution or absent if skipInvalidTransactionsFlag
 // Proposer should be penalized
 // corrupted signature
-BOOST_AUTO_TEST_CASE( transactionSigBad
+BOOST_DATA_TEST_CASE( transactionSigBad, skipInvalidTransactionsVariants, skipInvalidTransactionsFlag
                       // , *boost::unit_test::precondition( dev::test::run_not_express )
                       ) {
+
+    if(skipInvalidTransactionsFlag){
+        const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
+    }
+    SkipInvalidTransactionsPatch::init(client->chainParams());
+
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
 
@@ -412,21 +457,33 @@ BOOST_AUTO_TEST_CASE( transactionSigBad
         stub->createBlock( ConsensusExtFace::transactions_vector{data}, utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
-    REQUIRE_BLOCK_SIZE( 1, 1 );
 
-    h256 txHash = sha3( data );
-    REQUIRE_BLOCK_TRANSACTION( 1, 0, txHash );
+
+    if(skipInvalidTransactionsFlag){
+        REQUIRE_BLOCK_SIZE( 1, 0 );
+    }
+    else {
+        REQUIRE_BLOCK_SIZE( 1, 1 );
+        h256 txHash = sha3( data );
+        REQUIRE_BLOCK_TRANSACTION( 1, 0, txHash );
+    }
 
     REQUIRE_NONCE_INCREASE( senderAddress, 0 );
     REQUIRE_BALANCE_DECREASE( senderAddress, 0 );
 }
 
-// Transaction should be IGNORED during execution
+// Transaction should be IGNORED during execution or absent if skipInvalidTransactionsFlag
 // Proposer should be penalized
 // gas < min_gas
-BOOST_AUTO_TEST_CASE( transactionGasIncorrect
+BOOST_DATA_TEST_CASE( transactionGasIncorrect, skipInvalidTransactionsVariants, skipInvalidTransactionsFlag
                       // , *boost::unit_test::precondition( dev::test::run_not_express )
                       ) {
+
+    if(skipInvalidTransactionsFlag){
+        const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
+    }
+    SkipInvalidTransactionsPatch::init(client->chainParams());
+
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
 
@@ -454,8 +511,14 @@ BOOST_AUTO_TEST_CASE( transactionGasIncorrect
         stub->createBlock( ConsensusExtFace::transactions_vector{stream.out()}, utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
-    REQUIRE_BLOCK_SIZE( 1, 1 );
-    REQUIRE_BLOCK_TRANSACTION( 1, 0, txHash );
+
+    if(skipInvalidTransactionsFlag){
+        REQUIRE_BLOCK_SIZE( 1, 0 );
+    }
+    else {
+        REQUIRE_BLOCK_SIZE( 1, 1 );
+        REQUIRE_BLOCK_TRANSACTION( 1, 0, txHash );
+    }
 
     REQUIRE_NONCE_INCREASE( senderAddress, 0 );
     REQUIRE_BALANCE_DECREASE( senderAddress, 0 );
@@ -465,9 +528,15 @@ BOOST_AUTO_TEST_CASE( transactionGasIncorrect
 // Sender should be charged for gas consumed
 // Proposer should NOT be penalized
 // transaction exceedes it's gas limit
-BOOST_AUTO_TEST_CASE( transactionGasNotEnough
+BOOST_DATA_TEST_CASE( transactionGasNotEnough, skipInvalidTransactionsVariants, skipInvalidTransactionsFlag
                       // , *boost::unit_test::precondition( dev::test::run_not_express )
                       ) {
+
+    if(skipInvalidTransactionsFlag){
+        const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
+    }
+    SkipInvalidTransactionsPatch::init(client->chainParams());
+
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
 
@@ -519,11 +588,16 @@ BOOST_AUTO_TEST_CASE( transactionGasNotEnough
 }
 
 
-// Transaction should be IGNORED during execution
+// Transaction should be IGNORED during execution or absent if skipInvalidTransactionsFlag
 // Proposer should be penalized
 // nonce too big
-BOOST_AUTO_TEST_CASE( transactionNonceBig, 
-    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+BOOST_DATA_TEST_CASE( transactionNonceBig, skipInvalidTransactionsVariants, skipInvalidTransactionsFlag ) {
+
+    if(skipInvalidTransactionsFlag){
+        const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
+    }
+    SkipInvalidTransactionsPatch::init(client->chainParams());
+
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
 
@@ -551,19 +625,31 @@ BOOST_AUTO_TEST_CASE( transactionNonceBig,
         stub->createBlock( ConsensusExtFace::transactions_vector{stream.out()}, utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
-    REQUIRE_BLOCK_SIZE( 1, 1 );
-    REQUIRE_BLOCK_TRANSACTION( 1, 0, txHash );
+
+    if(skipInvalidTransactionsFlag){
+        REQUIRE_BLOCK_SIZE( 1, 0 );
+    }
+    else {
+        REQUIRE_BLOCK_SIZE( 1, 1 );
+        REQUIRE_BLOCK_TRANSACTION( 1, 0, txHash );
+    }
 
     REQUIRE_NONCE_INCREASE( senderAddress, 0 );
     REQUIRE_BALANCE_DECREASE( senderAddress, 0 );
 }
 
-// Transaction should be IGNORED during execution
+// Transaction should be IGNORED during execution or absent if skipInvalidTransactionsFlag
 // Proposer should be penalized
 // nonce too small
-BOOST_AUTO_TEST_CASE( transactionNonceSmall
+BOOST_DATA_TEST_CASE( transactionNonceSmall, skipInvalidTransactionsVariants, skipInvalidTransactionsFlag
                       //, *boost::unit_test::precondition( dev::test::run_not_express )
                       ) {
+
+    if(skipInvalidTransactionsFlag){
+        const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
+    }
+    SkipInvalidTransactionsPatch::init(client->chainParams());
+
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
 
@@ -605,18 +691,29 @@ BOOST_AUTO_TEST_CASE( transactionNonceSmall
         stub->createBlock( ConsensusExtFace::transactions_vector{stream2.out()}, utcTime(), 2U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
-    REQUIRE_BLOCK_SIZE( 2, 1 );
-    REQUIRE_BLOCK_TRANSACTION( 2, 0, txHash );
+
+    if(skipInvalidTransactionsFlag){
+        REQUIRE_BLOCK_SIZE( 2, 0 );
+    }
+    else {
+        REQUIRE_BLOCK_SIZE( 2, 1 );
+        REQUIRE_BLOCK_TRANSACTION( 2, 0, txHash );
+    }
 
     REQUIRE_NONCE_INCREASE( senderAddress, 0 );
     REQUIRE_BALANCE_DECREASE( senderAddress, 0 );
 }
 
-// Transaction should be IGNORED during execution
+// Transaction should be IGNORED during execution or absent if skipInvalidTransactionsFlag
 // Proposer should be penalized
 // not enough cash
-BOOST_AUTO_TEST_CASE( transactionBalanceBad, 
-    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+BOOST_DATA_TEST_CASE( transactionBalanceBad, skipInvalidTransactionsVariants, skipInvalidTransactionsFlag ) {
+
+    if(skipInvalidTransactionsFlag){
+        const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
+    }
+    SkipInvalidTransactionsPatch::init(client->chainParams());
+
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
 
@@ -644,19 +741,31 @@ BOOST_AUTO_TEST_CASE( transactionBalanceBad,
         stub->createBlock( ConsensusExtFace::transactions_vector{stream.out()}, utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
-    REQUIRE_BLOCK_SIZE( 1, 1 );
-    REQUIRE_BLOCK_TRANSACTION( 1, 0, txHash );
+
+    if(skipInvalidTransactionsFlag){
+        REQUIRE_BLOCK_SIZE( 1, 0 );
+    }
+    else {
+        REQUIRE_BLOCK_SIZE( 1, 1 );
+        REQUIRE_BLOCK_TRANSACTION( 1, 0, txHash );
+    }
 
     REQUIRE_NONCE_INCREASE( senderAddress, 0 );
     REQUIRE_BALANCE_DECREASE( senderAddress, 0 );
 }
 
-// Transaction should be IGNORED during execution
+// Transaction should be IGNORED during execution or absent if skipInvalidTransactionsFlag
 // Proposer should be penalized
 // transaction goes beyond block gas limit
-BOOST_AUTO_TEST_CASE( transactionGasBlockLimitExceeded
+BOOST_DATA_TEST_CASE( transactionGasBlockLimitExceeded, skipInvalidTransactionsVariants, skipInvalidTransactionsFlag
                       // , *boost::unit_test::precondition( dev::test::run_not_express )
                       ) {
+
+    if(skipInvalidTransactionsFlag){
+        const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
+    }
+    SkipInvalidTransactionsPatch::init(client->chainParams());
+
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
 
@@ -696,9 +805,18 @@ BOOST_AUTO_TEST_CASE( transactionGasBlockLimitExceeded
     BOOST_REQUIRE_EQUAL( client->number(), 1 );
 
     REQUIRE_BLOCK_INCREASE( 1 );
-    REQUIRE_BLOCK_SIZE( 1, 2 );
-    REQUIRE_BLOCK_TRANSACTION( 1, 0, txHash1 );
-    REQUIRE_BLOCK_TRANSACTION( 1, 1, txHash2 );
+
+    if(skipInvalidTransactionsFlag){
+        REQUIRE_BLOCK_SIZE( 1, 1 );
+
+        REQUIRE_BLOCK_TRANSACTION( 1, 0, txHash1 );
+    }
+    else {
+        REQUIRE_BLOCK_SIZE( 1, 2 );
+
+        REQUIRE_BLOCK_TRANSACTION( 1, 0, txHash1 );
+        REQUIRE_BLOCK_TRANSACTION( 1, 1, txHash2 );
+    }
 
     REQUIRE_NONCE_INCREASE( senderAddress, 1 );
     REQUIRE_BALANCE_DECREASE( senderAddress, 10000 * dev::eth::szabo );  // only 1st!

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -236,7 +236,7 @@ BOOST_DATA_TEST_CASE( validTransaction, skipInvalidTransactionsVariants, skipInv
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams());
+    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -286,7 +286,7 @@ BOOST_DATA_TEST_CASE( transactionRlpBad, skipInvalidTransactionsVariants, skipIn
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams());
+    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
 
     auto senderAddress = coinbase.address();
 
@@ -372,7 +372,7 @@ BOOST_DATA_TEST_CASE( transactionSigZero, skipInvalidTransactionsVariants, skipI
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams());
+    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -427,7 +427,7 @@ BOOST_DATA_TEST_CASE( transactionSigBad, skipInvalidTransactionsVariants, skipIn
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams());
+    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -482,7 +482,7 @@ BOOST_DATA_TEST_CASE( transactionGasIncorrect, skipInvalidTransactionsVariants, 
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams());
+    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -535,7 +535,7 @@ BOOST_DATA_TEST_CASE( transactionGasNotEnough, skipInvalidTransactionsVariants, 
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams());
+    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -596,7 +596,7 @@ BOOST_DATA_TEST_CASE( transactionNonceBig, skipInvalidTransactionsVariants, skip
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams());
+    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -648,7 +648,7 @@ BOOST_DATA_TEST_CASE( transactionNonceSmall, skipInvalidTransactionsVariants, sk
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams());
+    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -712,7 +712,7 @@ BOOST_DATA_TEST_CASE( transactionBalanceBad, skipInvalidTransactionsVariants, sk
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams());
+    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();
@@ -764,7 +764,7 @@ BOOST_DATA_TEST_CASE( transactionGasBlockLimitExceeded, skipInvalidTransactionsV
     if(skipInvalidTransactionsFlag){
         const_cast<ChainParams&>(client->chainParams()).sChain.skipInvalidTransactionsPatchTimestamp = 1;
     }
-    SkipInvalidTransactionsPatch::init(client->chainParams());
+    SkipInvalidTransactionsPatch::init(client->chainParams(), client.get());
 
     auto senderAddress = coinbase.address();
     auto receiver = KeyPair::create();

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -3196,6 +3196,8 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_FIXTURE_TEST_SUITE( GappedCacheSuite, JsonRpcFixture )
 
+#ifdef HISTORIC_STATE
+
 BOOST_AUTO_TEST_CASE( test_blocks ) {
     dev::rpc::_detail::GappedTransactionIndexCache cache(10, *client);
     BOOST_REQUIRE_EQUAL(cache.realBlockTransactionCount(LatestBlock), 0);
@@ -3256,6 +3258,8 @@ BOOST_AUTO_TEST_CASE( test_exceptions ) {
     BOOST_REQUIRE_THROW(cache.gappedIndexFromReal(LatestBlock, 0), std::out_of_range);
     BOOST_REQUIRE_THROW(cache.transactionPresent(LatestBlock, 2), std::out_of_range);
 }
+
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
1. Skip invalid transactions from block, starting from "patch timestamp"
2. Ignore them in historic build, if they are present in block

Fixes https://github.com/skalenetwork/internal-support/issues/869

Tests:
1. test/unittests/libethereum/SkaleHost.cpp tests how various kinds of invalid transactions are skipped from block (both for enabled patch and for disabled patch)
2. test/unittests/libweb3jsonrpc/jsonrpc.cpp -> skip_invalid_transactions tests affected JSON-RPC calls on historic node