### PR TITLE
Bug/1689 microprofile build

### DIFF
--- a/libdevcore/CMakeLists.txt
+++ b/libdevcore/CMakeLists.txt
@@ -15,8 +15,9 @@ add_library(devcore ${sources} ${headers})
 add_dependencies(devcore secp256k1)
 
 target_compile_options( devcore PRIVATE
-    -Wno-error=deprecated-copy -Wno-error=unused-result -Wno-error=unused-parameter -Wno-error=unused-variable -Wno-error=maybe-uninitialized
-    )
+    -Wno-error=deprecated-copy -Wno-error=unused-result -Wno-error=unused-parameter
+    -Wno-error=unused-variable -Wno-error=maybe-uninitialized -Wno-error=class-memaccess
+)
 
 # Needed to prevent including system-level boost headers:
 target_include_directories(devcore SYSTEM PUBLIC ${Boost_INCLUDE_DIR} PRIVATE ../utils)

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -550,6 +550,7 @@ int main( int argc, char** argv ) try {
     cc::_on_ = false;
     cc::_max_value_size_ = 2048;
     MicroProfileSetEnableAllGroups( true );
+    dev::setThreadName( "main" );
     BlockHeader::useTimestampHack = false;
     srand( time( nullptr ) );
     setCLocale();
@@ -2773,7 +2774,6 @@ int main( int argc, char** argv ) try {
             << cc::debug( "Done, programmatic shutdown via Web3 is disabled" );
     }
 
-    dev::setThreadName( "main" );
     if ( g_client ) {
         unsigned int n = g_client->blockChain().details().number;
         unsigned int mining = 0;


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skaled/issues/1689

fixed build by disabling compiler errors and fixed `SIGILL` by executing `dev::setThreadName("main")` earlier in the code

verified locally, skaled starts and mines blocks