### PR TITLE
Bug/is 869 transaction duplicates

### DIFF
--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -86,8 +86,10 @@ void GappedTransactionIndexCache::ensureCached( BlockNumber _bn,
         u256 diff = gasAfter - gasBefore;
         gasBefore = gasAfter;
 
-        // ignore transactions with 0 gas usage
-        if ( diff == 0 )
+        pair< h256, unsigned > loc = client.transactionLocation( th );
+
+        // ignore transactions with 0 gas usage OR different location!
+        if ( diff == 0 || client.numberFromHash( loc.first ) != _bn || loc.second != realIndex )
             continue;
 
         // cache it


### PR DESCRIPTION
Historic node needs to ignore invalid transactions when asked through JSON-RPC. It checks if transaction is invalid by looking for gasUsed=0 in it's receipt. But in the case, if invalid transaction was resubmitted and become valid in another block - it starts to appear as "valid" for historic node. To fix this, we compare transaction's block in it's receipt with original block number, If they are different - then transaction should be considered invalid still.

Tested by Sasha1 on QA network.