### PR TITLE
Small JSON-RPC timeout to lower proxygen RAM usage

### DIFF
--- a/libskutils/include/skutils/rest_call.h
+++ b/libskutils/include/skutils/rest_call.h
@@ -38,6 +38,7 @@ namespace skutils {
 namespace rest {
 
 extern long g_nClientConnectionTimeoutMS;
+extern long g_nRpcIdleTimeoutMS;
 
 enum class e_data_fetch_strategy {
     edfs_by_equal_json_id,

--- a/libskutils/src/http_pg.cpp
+++ b/libskutils/src/http_pg.cpp
@@ -367,7 +367,7 @@ bool server::start() {
 
     proxygen::HTTPServerOptions options;
     options.threads = static_cast< size_t >( threads_ );
-    options.idleTimeout = std::chrono::milliseconds( skutils::rest::g_nClientConnectionTimeoutMS );
+    options.idleTimeout = std::chrono::milliseconds( skutils::rest::g_nRpcIdleTimeoutMS );
     // // // options.shutdownOn = {SIGINT, SIGTERM}; // experimental only, not needed in `skaled`
     // here
     options.enableContentCompression = false;

--- a/libskutils/src/rest_call.cpp
+++ b/libskutils/src/rest_call.cpp
@@ -25,6 +25,7 @@ namespace skutils {
 namespace rest {
 
 long g_nClientConnectionTimeoutMS = 1000 * 60 * 30;  // 30 minutes in milliseconds, connect timeout
+long g_nRpcIdleTimeoutMS = 5000;
 
 data_t::data_t() {}
 data_t::data_t( const data_t& d ) {

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -710,8 +710,11 @@ int main( int argc, char** argv ) try {
 
     addClientOption( "no-snapshot-majority", po::value< string >()->value_name( "<url>" ), "" );
 
-    addClientOption( "network-idle-timeout", po::value< long >()->value_name( "<timeout>" ),
-        "Idle wait timeout for JSON RPC calls in milliseconds" );
+    addClientOption( "rpc-idle-timeout", po::value< long >()->value_name( "<timeout>" ),
+        "Idle wait timeout for incoming JSON RPC calls in milliseconds" );
+
+    addClientOption( "client-connection-timeout", po::value< long >()->value_name( "<timeout>" ),
+        "Idle wait timeout for outgoing calls in milliseconds" );
 
     std::string strPerformanceWarningDurationOptionDescription =
         "Specifies time margin in floating point format, in seconds, for displaying performance "
@@ -910,8 +913,11 @@ int main( int argc, char** argv ) try {
         return 0;
     }
 
-    if ( vm.count( "network-idle-timeout" ) )
-        skutils::rest::g_nClientConnectionTimeoutMS = vm["network-idle-timeout"].as< long >();
+    if ( vm.count( "rpc-idle-timeout" ) )
+        skutils::rest::g_nRpcIdleTimeoutMS = vm["network-idle-timeout"].as< long >();
+
+    if ( vm.count( "client-connection-timeout" ) )
+        skutils::rest::g_nClientConnectionTimeoutMS = vm["client-connection-timeout"].as< long >();
 
     if ( vm.count( "test-enable-crash-at" ) ) {
         std::string crash_at = vm["test-enable-crash-at"].as< string >();

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -710,6 +710,9 @@ int main( int argc, char** argv ) try {
 
     addClientOption( "no-snapshot-majority", po::value< string >()->value_name( "<url>" ), "" );
 
+    addClientOption( "network-idle-timeout", po::value< long >()->value_name( "<timeout>" ),
+        "IGNORED. Kept for backward compatibility" );
+
     addClientOption( "rpc-idle-timeout", po::value< long >()->value_name( "<timeout>" ),
         "Idle wait timeout for incoming JSON RPC calls in milliseconds" );
 


### PR DESCRIPTION
Looks like, we had 30 min timeout on socket inactivity. It caused RAM consumption growth under high load by requests.
Tested in stability test with RAM usage monitoring