### PR TITLE
Bug/1433 cleanup shared space if unsuccessful download

### DIFF
--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -274,6 +274,8 @@ void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >
                 throw std::runtime_error( strErrorDescription );
             }
         } catch ( ... ) {
+            // remove partially downloaded snapshot
+            boost::filesystem::remove( saveTo );
             std::throw_with_nested(
                 std::runtime_error( cc::error( "Exception while downloading snapshot" ) ) );
         }

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -276,8 +276,7 @@ void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >
         } catch ( ... ) {
             // remove partially downloaded snapshot
             boost::filesystem::remove( saveTo );
-            std::throw_with_nested(
-                std::runtime_error( cc::error( "Exception while downloading snapshot" ) ) );
+            std::throw_with_nested( std::runtime_error( "Exception while downloading snapshot" ) );
         }
         clog( VerbosityInfo, "downloadSnapshot" )
             << cc::success( "Snapshot download success for block " )


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skaled/issues/1433

tested manually on devnet as following:
1. Decrease network performance to 1500 Kb upload/ 3500 Kb Download on node A
2. Restart any skaled from the node A from the snapshot - skaled on node shouldn't download more than 1 snapshot fragment
3. Wait for 3 snapshot intervals
4. Check shared-space datadir
