### PR TITLE
1199 eth syncing

### DIFF
--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -1128,6 +1128,8 @@ Transactions Client::pending() const {
 }
 
 SyncStatus Client::syncStatus() const {
+    if ( !m_skaleHost )
+        BOOST_THROW_EXCEPTION( std::runtime_error( "SkaleHost was not initialized" ) );
     return m_skaleHost->syncStatus();
 }
 

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -1128,10 +1128,7 @@ Transactions Client::pending() const {
 }
 
 SyncStatus Client::syncStatus() const {
-    // TODO implement this when syncing will be needed
-    SyncStatus s;
-    s.startBlockNumber = s.currentBlockNumber = s.highestBlockNumber = 0;
-    return s;
+    return m_skaleHost->syncStatus();
 }
 
 TransactionSkeleton Client::populateTransactionWithDefaults( TransactionSkeleton const& _t ) const {

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -945,6 +945,8 @@ u256 SkaleHost::getBlockRandom() const {
 dev::eth::SyncStatus SkaleHost::syncStatus() const {
     auto syncInfo = m_consensus->getSyncInfo();
     dev::eth::SyncStatus syncStatus;
+    // SKALE: catchup downloads blocks with transactions, then the node executes them
+    // we don't download state changes separately
     syncStatus.state = syncInfo.isSyncing ? dev::eth::SyncState::Blocks : dev::eth::SyncState::Idle;
     syncStatus.startBlockNumber = syncInfo.startingBlock;
     syncStatus.currentBlockNumber = syncInfo.currentBlock;

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -942,6 +942,17 @@ u256 SkaleHost::getBlockRandom() const {
     return m_consensus->getRandomForBlockId( m_client.number() );
 }
 
+dev::eth::SyncStatus SkaleHost::syncStatus() const {
+    auto syncInfo = m_consensus->getSyncInfo();
+    dev::eth::SyncStatus syncStatus;
+    syncStatus.state = syncInfo.isSyncing ? dev::eth::SyncState::Blocks : dev::eth::SyncState::Idle;
+    syncStatus.startBlockNumber = syncInfo.startingBlock;
+    syncStatus.currentBlockNumber = syncInfo.currentBlock;
+    syncStatus.highestBlockNumber = syncInfo.highestBlock;
+    syncStatus.majorSyncing = syncInfo.isSyncing;
+    return syncStatus;
+}
+
 std::map< std::string, uint64_t > SkaleHost::getConsensusDbUsage() const {
     return m_consensus->getConsensusDbUsage();
 }

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -943,6 +943,8 @@ u256 SkaleHost::getBlockRandom() const {
 }
 
 dev::eth::SyncStatus SkaleHost::syncStatus() const {
+    if ( !m_consensus )
+        BOOST_THROW_EXCEPTION( std::runtime_error( "Consensus was not initialized" ) );
     auto syncInfo = m_consensus->getSyncInfo();
     dev::eth::SyncStatus syncStatus;
     // SKALE: catchup downloads blocks with transactions, then the node executes them

--- a/libethereum/SkaleHost.h
+++ b/libethereum/SkaleHost.h
@@ -51,6 +51,7 @@
 
 namespace dev {
 namespace eth {
+struct SyncStatus;
 class Client;
 class TransactionQueue;
 class BlockHeader;
@@ -123,6 +124,7 @@ public:
 
     dev::u256 getGasPrice() const;
     dev::u256 getBlockRandom() const;
+    dev::eth::SyncStatus syncStatus() const;
     std::map< std::string, uint64_t > getConsensusDbUsage() const;
     std::array< std::string, 4 > getIMABLSPublicKey() const;
 

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -893,10 +893,12 @@ Json::Value Eth::eth_getWork() {
 
 Json::Value Eth::eth_syncing() {
     try {
-        // ask consensus whether the node is in catchup mode
-        if ( !client() )
+        auto client = client();
+        if ( !client )
             BOOST_THROW_EXCEPTION( std::runtime_error( "Client was not initialized" ) );
-        dev::eth::SyncStatus sync = client()->syncStatus();
+        
+        // ask consensus whether the node is in catchup mode
+        dev::eth::SyncStatus sync = client->syncStatus();
         if ( !sync.majorSyncing )
             return Json::Value( false );
 

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -896,7 +896,7 @@ Json::Value Eth::eth_syncing() {
         auto client = client();
         if ( !client )
             BOOST_THROW_EXCEPTION( std::runtime_error( "Client was not initialized" ) );
-        
+
         // ask consensus whether the node is in catchup mode
         dev::eth::SyncStatus sync = client->syncStatus();
         if ( !sync.majorSyncing )

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -892,16 +892,22 @@ Json::Value Eth::eth_getWork() {
 }
 
 Json::Value Eth::eth_syncing() {
-    // ask consensus whether the node is in catchup mode
-    dev::eth::SyncStatus sync = client()->syncStatus();
-    if ( !sync.majorSyncing )
-        return Json::Value( false );
+    try {
+        // ask consensus whether the node is in catchup mode
+        if ( !client() )
+            BOOST_THROW_EXCEPTION( std::runtime_error( "Client was not initialized" ) );
+        dev::eth::SyncStatus sync = client()->syncStatus();
+        if ( !sync.majorSyncing )
+            return Json::Value( false );
 
-    Json::Value info( Json::objectValue );
-    info["startingBlock"] = sync.startBlockNumber;
-    info["highestBlock"] = sync.highestBlockNumber;
-    info["currentBlock"] = sync.currentBlockNumber;
-    return info;
+        Json::Value info( Json::objectValue );
+        info["startingBlock"] = sync.startBlockNumber;
+        info["highestBlock"] = sync.highestBlockNumber;
+        info["currentBlock"] = sync.currentBlockNumber;
+        return info;
+    } catch ( const Exception& e ) {
+        BOOST_THROW_EXCEPTION( jsonrpc::JsonRpcException( e.what() ) );
+    }
 }
 
 string Eth::eth_chainId() {

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -893,7 +893,7 @@ Json::Value Eth::eth_getWork() {
 
 Json::Value Eth::eth_syncing() {
     try {
-        auto client = client();
+        auto client = this->client();
         if ( !client )
             BOOST_THROW_EXCEPTION( std::runtime_error( "Client was not initialized" ) );
 

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -893,7 +893,7 @@ Json::Value Eth::eth_getWork() {
 
 Json::Value Eth::eth_syncing() {
     dev::eth::SyncStatus sync = client()->syncStatus();
-    if ( sync.state == SyncState::Idle || !sync.majorSyncing )
+    if ( !sync.majorSyncing )
         return Json::Value( false );
 
     Json::Value info( Json::objectValue );

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -892,6 +892,7 @@ Json::Value Eth::eth_getWork() {
 }
 
 Json::Value Eth::eth_syncing() {
+    // ask consensus whether the node is in catchup mode
     dev::eth::SyncStatus sync = client()->syncStatus();
     if ( !sync.majorSyncing )
         return Json::Value( false );


### PR DESCRIPTION
fixes #1199

tested manually on devnet as following:
- run load test
- turn off one of the nodes
- wait for 1 hour
- turn the node back on. the node should catchup the missing blocks
- check `eth_syncing()`. it should return something like 
```
> eth.syncing
{
  currentBlock: 158312,
  healedBytecodeBytes: 0,
  healedBytecodes: 0,
  healedTrienodeBytes: 0,
  healedTrienodes: 0,
  healingBytecode: 0,
  healingTrienodes: 0,
  highestBlock: 159200,
  startingBlock: 156449,
  syncedAccountBytes: 0,
  syncedAccounts: 0,
  syncedBytecodeBytes: 0,
  syncedBytecodes: 0,
  syncedStorage: 0,
  syncedStorageBytes: 0
}
```
via geth or
```
{"id":73,"jsonrpc":"2.0","result":{"currentBlock":165382,"highestBlock":167451,"startingBlock":165145}}
``` 
via json-rpc during catchup and 
```
> eth.syncing
false
```
via geth or 
```
{"id":73,"jsonrpc":"2.0","result":false}
```
via json-rpc when catchup is finished.