### PR TITLE
SKALED-1431 debug_getFutureTransactions call

### DIFF
--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -127,6 +127,8 @@ public:
     /// Retrieve pending transactions
     Transactions pending() const override;
 
+    Transactions DEBUG_getFutureTransactions() const { return m_tq.DEBUGgetFutureTransactions(); }
+
     /// Queues a block for import.
     ImportResult queueBlock( bytes const& _block, bool _isSafe = false );
 

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -537,3 +537,14 @@ void TransactionQueue::verifierBody() {
         MICROPROFILE_LEAVE();
     }
 }
+
+Transactions TransactionQueue::DEBUGgetFutureTransactions() const {
+    Transactions res;
+    ReadGuard l( m_lock );
+    for ( auto addressAndMap : m_future ) {
+        for ( auto nonceAndTransaction : addressAndMap.second ) {
+            res.push_back( nonceAndTransaction.second.transaction );
+        }  // for nonce
+    }      // for address
+    return res;
+}

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -123,6 +123,8 @@ public:
     template < class... Args >
     Transactions topTransactionsSync( unsigned _limit, Args... args );
 
+    Transactions DEBUGgetFutureTransactions() const;
+
     /// Get a hash set of transactions in the queue
     /// @returns A hash set of all transactions in the queue
     const h256Hash knownTransactions() const;

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -314,3 +314,7 @@ uint64_t Debug::debug_doBlocksDbCompaction() {
 
     return boost::chrono::duration_cast< boost::chrono::milliseconds >( t2 - t1 ).count();
 }
+
+Json::Value Debug::debug_getFutureTransactions() {
+    return toJson( m_eth.DEBUG_getFutureTransactions() );
+}

--- a/libweb3jsonrpc/Debug.h
+++ b/libweb3jsonrpc/Debug.h
@@ -60,6 +60,8 @@ public:
     virtual uint64_t debug_doStateDbCompaction() override;
     virtual uint64_t debug_doBlocksDbCompaction() override;
 
+    virtual Json::Value debug_getFutureTransactions() override;
+
 private:
     eth::Client const& m_eth;
     SkaleDebugInterface* m_debugInterface = nullptr;

--- a/libweb3jsonrpc/DebugFace.h
+++ b/libweb3jsonrpc/DebugFace.h
@@ -98,6 +98,10 @@ public:
         this->bindAndAddMethod( jsonrpc::Procedure( "debug_doBlocksDbCompaction",
                                     jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, NULL ),
             &dev::rpc::DebugFace::debug_doBlocksDbCompactionI );
+
+        this->bindAndAddMethod( jsonrpc::Procedure( "debug_getFutureTransactions",
+                                    jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, NULL ),
+            &dev::rpc::DebugFace::debug_getFutureTransactionsI );
     }
     inline virtual void debug_accountRangeAtI( const Json::Value& request, Json::Value& response ) {
         response = this->debug_accountRangeAt( request[0u].asString(), request[1u].asInt(),
@@ -179,6 +183,10 @@ public:
         response = this->debug_doBlocksDbCompaction();
     }
 
+    virtual void debug_getFutureTransactionsI( const Json::Value&, Json::Value& response ) {
+        response = this->debug_getFutureTransactions();
+    }
+
     virtual Json::Value debug_accountRangeAt(
         const std::string& param1, int param2, const std::string& param3, int param4 ) = 0;
     virtual Json::Value debug_traceTransaction(
@@ -206,6 +214,8 @@ public:
 
     virtual uint64_t debug_doStateDbCompaction() = 0;
     virtual uint64_t debug_doBlocksDbCompaction() = 0;
+
+    virtual Json::Value debug_getFutureTransactions() = 0;
 };
 
 }  // namespace rpc


### PR DESCRIPTION
Waiting for merge from latest develop

Test sequence:
1. Add balance for your account to skaled's config.
2. Run skaled with `--enable-debug-behavior-apis`
3. Send transaction with too big nonce.
4. Send `curl -X POST --data '{"id":4,"jsonrpc":"2.0","method":"debug_getFutureTransactions","params":[]}' <URL>`
5. See your transaction.
6. Repeat the same without `--enable-debug-behavior-apis`, METHOD_NOT_FOUND error should be returned.