### PR TITLE
IS-450 Reload rotation timestamp on each isExitTime request

### DIFF
--- a/libethereum/InstanceMonitor.cpp
+++ b/libethereum/InstanceMonitor.cpp
@@ -46,23 +46,20 @@ void InstanceMonitor::initRotationParams( uint64_t _finishTimestamp ) {
     std::ofstream rotationInfoFile( m_rotationInfoFilePath.string() );
     rotationInfoFile << rotationJson;
 
-    m_finishTimestamp = _finishTimestamp;
-    LOG( m_logger ) << "Set rotation time to " << m_finishTimestamp;
+    LOG( m_logger ) << "Set rotation time to " << _finishTimestamp;
 }
 
 bool InstanceMonitor::isTimeToRotate( uint64_t _finishTimestamp ) {
     if ( !fs::exists( m_rotationInfoFilePath ) ) {
         return false;
     }
-    return m_finishTimestamp <= _finishTimestamp;
+    return getRotationTimestamp() <= _finishTimestamp;
 }
 
-void InstanceMonitor::restoreRotationParams() {
-    if ( fs::exists( m_rotationInfoFilePath ) ) {
-        std::ifstream rotationInfoFile( m_rotationInfoFilePath.string() );
-        auto rotationJson = nlohmann::json::parse( rotationInfoFile );
-        m_finishTimestamp = rotationJson["timestamp"].get< uint64_t >();
-    }
+uint64_t InstanceMonitor::getRotationTimestamp() {
+    std::ifstream rotationInfoFile( m_rotationInfoFilePath.string() );
+    auto rotationJson = nlohmann::json::parse( rotationInfoFile );
+    return rotationJson["timestamp"].get< uint64_t >();
 }
 
 void InstanceMonitor::reportExitTimeReached( bool _reached ) {

--- a/libethereum/InstanceMonitor.cpp
+++ b/libethereum/InstanceMonitor.cpp
@@ -53,10 +53,10 @@ bool InstanceMonitor::isTimeToRotate( uint64_t _finishTimestamp ) {
     if ( !fs::exists( m_rotationInfoFilePath ) ) {
         return false;
     }
-    return getRotationTimestamp() <= _finishTimestamp;
+    return rotationTimestamp() <= _finishTimestamp;
 }
 
-uint64_t InstanceMonitor::getRotationTimestamp() {
+uint64_t InstanceMonitor::rotationTimestamp() const {
     std::ifstream rotationInfoFile( m_rotationInfoFilePath.string() );
     auto rotationJson = nlohmann::json::parse( rotationInfoFile );
     return rotationJson["timestamp"].get< uint64_t >();

--- a/libethereum/InstanceMonitor.cpp
+++ b/libethereum/InstanceMonitor.cpp
@@ -47,9 +47,9 @@ void InstanceMonitor::initRotationParams( uint64_t _finishTimestamp ) {
         std::ofstream rotationInfoFile( m_rotationInfoFilePath.string() );
         rotationInfoFile << rotationJson;
 
-        LOG( m_info_logger ) << "Set rotation time to " << _finishTimestamp;
+        LOG( m_infoLogger ) << "Set rotation time to " << _finishTimestamp;
     } catch ( ... ) {
-        LOG( m_error_logger ) << "Setting rotation timestamp failed";
+        LOG( m_errorLogger ) << "Setting rotation timestamp failed";
         throw_with_nested( std::runtime_error( "cannot save rotation timestamp" ) );
     }
 }
@@ -71,18 +71,18 @@ uint64_t InstanceMonitor::rotationTimestamp() const {
     try {
         auto rotationJson = nlohmann::json::parse( rotationInfoFile );
         auto timestamp = rotationJson["timestamp"].get< uint64_t >();
-        LOG( m_info_logger ) << "Rotation scheduled for " << timestamp;
+        LOG( m_infoLogger ) << "Rotation scheduled for " << timestamp;
         return timestamp;
     } catch ( ... ) {
-        LOG( m_error_logger ) << "Rotation file is malformed or missing";
+        LOG( m_errorLogger ) << "Rotation file is malformed or missing";
         throw InvalidRotationInfoFileException( m_rotationInfoFilePath );
     }
 }
 
 void InstanceMonitor::reportExitTimeReached( bool _reached ) {
     if ( m_statusAndControl ) {
-        LOG( m_info_logger ) << "Setting ExitTimeReached = " << _reached;
+        LOG( m_infoLogger ) << "Setting ExitTimeReached = " << _reached;
         m_statusAndControl->setExitState( StatusAndControl::ExitTimeReached, _reached );
     } else
-        LOG( m_info_logger ) << "Simulating setting ExitTimeReached = " << _reached;
+        LOG( m_infoLogger ) << "Simulating setting ExitTimeReached = " << _reached;
 }

--- a/libethereum/InstanceMonitor.cpp
+++ b/libethereum/InstanceMonitor.cpp
@@ -32,7 +32,7 @@
 using namespace dev;
 namespace fs = boost::filesystem;
 
-const std::string InstanceMonitor::rotation_info_file_name = "rotation.txt";
+const std::string InstanceMonitor::rotation_info_file_name = "rotation.json";
 
 void InstanceMonitor::prepareRotation() {
     reportExitTimeReached( true );

--- a/libethereum/InstanceMonitor.cpp
+++ b/libethereum/InstanceMonitor.cpp
@@ -49,17 +49,19 @@ void InstanceMonitor::initRotationParams( uint64_t _finishTimestamp ) {
     LOG( m_logger ) << "Set rotation time to " << _finishTimestamp;
 }
 
-bool InstanceMonitor::isTimeToRotate( uint64_t _finishTimestamp ) {
+bool InstanceMonitor::isTimeToRotate( uint64_t _blockTimestamp ) const {
     if ( !fs::exists( m_rotationInfoFilePath ) ) {
         return false;
     }
-    return rotationTimestamp() <= _finishTimestamp;
+    return rotationTimestamp() <= _blockTimestamp;
 }
 
 uint64_t InstanceMonitor::rotationTimestamp() const {
     std::ifstream rotationInfoFile( m_rotationInfoFilePath.string() );
     auto rotationJson = nlohmann::json::parse( rotationInfoFile );
-    return rotationJson["timestamp"].get< uint64_t >();
+    auto timestamp = rotationJson["timestamp"].get< uint64_t >();
+    LOG( m_logger ) << "Rotation scheduled for " << timestamp;
+    return timestamp;
 }
 
 void InstanceMonitor::reportExitTimeReached( bool _reached ) {

--- a/libethereum/InstanceMonitor.cpp
+++ b/libethereum/InstanceMonitor.cpp
@@ -47,9 +47,9 @@ void InstanceMonitor::initRotationParams( uint64_t _finishTimestamp ) {
         std::ofstream rotationInfoFile( m_rotationInfoFilePath.string() );
         rotationInfoFile << rotationJson;
 
-        LOG( m_logger ) << "Set rotation time to " << _finishTimestamp;
+        LOG( m_info_logger ) << "Set rotation time to " << _finishTimestamp;
     } catch ( ... ) {
-        LOG( m_logger ) << "Setting rotation timestamp failed";
+        LOG( m_error_logger ) << "Setting rotation timestamp failed";
         throw_with_nested( std::runtime_error( "cannot save rotation timestamp" ) );
     }
 }
@@ -71,18 +71,18 @@ uint64_t InstanceMonitor::rotationTimestamp() const {
     try {
         auto rotationJson = nlohmann::json::parse( rotationInfoFile );
         auto timestamp = rotationJson["timestamp"].get< uint64_t >();
-        LOG( m_logger ) << "Rotation scheduled for " << timestamp;
+        LOG( m_info_logger ) << "Rotation scheduled for " << timestamp;
         return timestamp;
     } catch ( ... ) {
-        LOG( m_logger ) << "Rotation file is malformed or missing";
+        LOG( m_error_logger ) << "Rotation file is malformed or missing";
         throw InvalidRotationInfoFileException( m_rotationInfoFilePath );
     }
 }
 
 void InstanceMonitor::reportExitTimeReached( bool _reached ) {
     if ( m_statusAndControl ) {
-        LOG( m_logger ) << "Setting ExitTimeReached = " << _reached;
+        LOG( m_info_logger ) << "Setting ExitTimeReached = " << _reached;
         m_statusAndControl->setExitState( StatusAndControl::ExitTimeReached, _reached );
     } else
-        LOG( m_logger ) << "Simulating setting ExitTimeReached = " << _reached;
+        LOG( m_info_logger ) << "Simulating setting ExitTimeReached = " << _reached;
 }

--- a/libethereum/InstanceMonitor.h
+++ b/libethereum/InstanceMonitor.h
@@ -43,9 +43,9 @@ public:
     void prepareRotation();
     void initRotationParams( uint64_t _finishTimestamp );
     bool isTimeToRotate( uint64_t _finishTimestamp );
-    uint64_t getRotationTimestamp();
 
 protected:
+    [[nodiscard]] uint64_t rotationTimestamp() const;
     [[nodiscard]] fs::path rotationInfoFilePath() const { return m_rotationInfoFilePath; }
 
     const fs::path m_rotationInfoFilePath;

--- a/libethereum/InstanceMonitor.h
+++ b/libethereum/InstanceMonitor.h
@@ -70,5 +70,6 @@ protected:
 
 
 private:
-    mutable dev::Logger m_logger{ createLogger( dev::VerbosityInfo, "instance-monitor" ) };
+    mutable dev::Logger m_info_logger{ createLogger( dev::VerbosityInfo, "instance-monitor" ) };
+    mutable dev::Logger m_error_logger{ createLogger( dev::VerbosityError, "instance-monitor" ) };
 };

--- a/libethereum/InstanceMonitor.h
+++ b/libethereum/InstanceMonitor.h
@@ -42,7 +42,7 @@ public:
     }
     void prepareRotation();
     void initRotationParams( uint64_t _finishTimestamp );
-    bool isTimeToRotate( uint64_t _finishTimestamp );
+    bool isTimeToRotate( uint64_t _blockTimestamp ) const;
 
 protected:
     [[nodiscard]] uint64_t rotationTimestamp() const;
@@ -56,5 +56,5 @@ protected:
     void reportExitTimeReached( bool _reached );
 
 private:
-    dev::Logger m_logger{ createLogger( dev::VerbosityInfo, "instance-monitor" ) };
+    mutable dev::Logger m_logger{ createLogger( dev::VerbosityInfo, "instance-monitor" ) };
 };

--- a/libethereum/InstanceMonitor.h
+++ b/libethereum/InstanceMonitor.h
@@ -36,23 +36,18 @@ class InstanceMonitor {
 public:
     explicit InstanceMonitor( const boost::filesystem::path& _rotationInfoFileDirPath,
         std::shared_ptr< StatusAndControl > _statusAndControl = nullptr )
-        : m_finishTimestamp( 0 ),
-          m_rotationInfoFilePath( _rotationInfoFileDirPath / rotation_info_file_name ),
+        : m_rotationInfoFilePath( _rotationInfoFileDirPath / rotation_info_file_name ),
           m_statusAndControl( _statusAndControl ) {
-        restoreRotationParams();
         reportExitTimeReached( false );
     }
     void prepareRotation();
     void initRotationParams( uint64_t _finishTimestamp );
     bool isTimeToRotate( uint64_t _finishTimestamp );
+    uint64_t getRotationTimestamp();
 
 protected:
-    void restoreRotationParams();
-    [[nodiscard]] uint64_t finishTimestamp() const { return m_finishTimestamp; }
-
     [[nodiscard]] fs::path rotationInfoFilePath() const { return m_rotationInfoFilePath; }
 
-    uint64_t m_finishTimestamp;
     const fs::path m_rotationInfoFilePath;
     std::shared_ptr< StatusAndControl > m_statusAndControl;
 

--- a/libethereum/InstanceMonitor.h
+++ b/libethereum/InstanceMonitor.h
@@ -55,6 +55,20 @@ protected:
 
     void reportExitTimeReached( bool _reached );
 
+    class InvalidRotationInfoFileException : public std::exception {
+    protected:
+        std::string what_str;
+
+    public:
+        boost::filesystem::path path;
+
+        InvalidRotationInfoFileException( const boost::filesystem::path& _path ) : path( _path ) {
+            what_str = "File " + path.string() + " is malformed or missing";
+        }
+        virtual const char* what() const noexcept override { return what_str.c_str(); }
+    };
+
+
 private:
     mutable dev::Logger m_logger{ createLogger( dev::VerbosityInfo, "instance-monitor" ) };
 };

--- a/libethereum/InstanceMonitor.h
+++ b/libethereum/InstanceMonitor.h
@@ -70,6 +70,6 @@ protected:
 
 
 private:
-    mutable dev::Logger m_info_logger{ createLogger( dev::VerbosityInfo, "instance-monitor" ) };
-    mutable dev::Logger m_error_logger{ createLogger( dev::VerbosityError, "instance-monitor" ) };
+    mutable dev::Logger m_infoLogger{ createLogger( dev::VerbosityInfo, "instance-monitor" ) };
+    mutable dev::Logger m_errorLogger{ createLogger( dev::VerbosityError, "instance-monitor" ) };
 };

--- a/libweb3jsonrpc/Net.h
+++ b/libweb3jsonrpc/Net.h
@@ -44,7 +44,7 @@ public:
     virtual bool net_listening() override;
 
 private:
-    const dev::eth::ChainParams& m_chainParams;
+    const dev::eth::ChainParams m_chainParams;
 };
 
 }  // namespace rpc

--- a/test/unittests/libethereum/InstanceMonitorTest.cpp
+++ b/test/unittests/libethereum/InstanceMonitorTest.cpp
@@ -28,6 +28,10 @@ public:
     void removeFlagFileTest(){
         this->reportExitTimeReached( false );
     }
+
+    uint64_t getRotationTimestamp() const {
+        return this->rotationTimestamp();
+    }
 };
 
 class InstanceMonitorTestFixture : public TestOutputHelperFixture {

--- a/test/unittests/libethereum/InstanceMonitorTest.cpp
+++ b/test/unittests/libethereum/InstanceMonitorTest.cpp
@@ -17,10 +17,6 @@ class InstanceMonitorMock: public InstanceMonitor {
 public:
     explicit InstanceMonitorMock(fs::path const &rotationFlagFilePath, std::shared_ptr<StatusAndControl> statusAndControl) : InstanceMonitor(rotationFlagFilePath, statusAndControl) {};
 
-    uint64_t getFinishTimestamp() {
-        return this->finishTimestamp();
-    };
-
     fs::path getRotationInfoFilePath() {
         return this->rotationInfoFilePath();
     }
@@ -70,7 +66,7 @@ BOOST_AUTO_TEST_CASE( test_initRotationParams ) {
     uint64_t ts = 100;
     BOOST_REQUIRE( !fs::exists(instanceMonitor->getRotationInfoFilePath() ) );
     instanceMonitor->initRotationParams(ts);
-    BOOST_CHECK_EQUAL(instanceMonitor->getFinishTimestamp(), ts);
+    BOOST_CHECK_EQUAL(instanceMonitor->getRotationTimestamp(), ts);
 
     BOOST_REQUIRE( fs::exists(instanceMonitor->getRotationInfoFilePath() ) );
 
@@ -98,6 +94,9 @@ BOOST_AUTO_TEST_CASE( test_isTimeToRotate_true ) {
 
     instanceMonitor->initRotationParams(50);
     BOOST_REQUIRE( instanceMonitor->isTimeToRotate( currentTime ) );
+
+    currentTime = 49;
+    BOOST_REQUIRE( !instanceMonitor->isTimeToRotate( currentTime ) );
 }
 
 BOOST_AUTO_TEST_CASE( test_rotation ) {

--- a/test/unittests/libethereum/InstanceMonitorTest.cpp
+++ b/test/unittests/libethereum/InstanceMonitorTest.cpp
@@ -80,6 +80,15 @@ BOOST_AUTO_TEST_CASE( test_initRotationParams ) {
     BOOST_CHECK_EQUAL(rotateJson["timestamp"].get< uint64_t >(), ts);
 }
 
+
+BOOST_AUTO_TEST_CASE( test_isTimeToRotate_invalid_file ) {
+    uint64_t currentTime = 100;
+    std::ofstream rotationInfoFile(instanceMonitor->getRotationInfoFilePath().string() );
+    rotationInfoFile << "Broken file";
+    BOOST_REQUIRE( !instanceMonitor->isTimeToRotate( currentTime ) );
+}
+
+
 BOOST_AUTO_TEST_CASE( test_isTimeToRotate_false ) {
     uint64_t currentTime = 100;
     uint64_t finishTime = 200;


### PR DESCRIPTION
### Problem 
The solution for https://github.com/skalenetwork/internal-support/issues/450 making skale-admin will write it to corresponding file directly instead of sending rpc call. The issue is that InstanceMonitor.cpp loads this file once during startup, which effectively says that timestamp won't be passed to skaled at all. 

### Changes
`isExitTime` will check the content of rotation.txt file and compare it to current block timestamp instead on relaying on `m_finishTimestamp` field.

### Performance 
Since `rotation.txt` file is only 4 bytes and reading is happening in background performance should not be affected. 
### Unit tests
Modified tests in `InstanceMonitorTest.cpp`.

### Testing 
Tested by running rotation procedure on local network. 
