### PR TITLE
Bug/1588 change snapshot hash computation

### DIFF
--- a/libdevcore/LevelDB.cpp
+++ b/libdevcore/LevelDB.cpp
@@ -236,6 +236,7 @@ h256 LevelDB::hashBase() const {
     if ( it == nullptr ) {
         BOOST_THROW_EXCEPTION( DatabaseError() << errinfo_comment( "null iterator" ) );
     }
+
     secp256k1_sha256_t ctx;
     secp256k1_sha256_initialize( &ctx );
     for ( it->SeekToFirst(); it->Valid(); it->Next() ) {
@@ -251,6 +252,7 @@ h256 LevelDB::hashBase() const {
         bytesConstRef str_key_value( usc.data(), usc.size() );
         secp256k1_sha256_write( &ctx, str_key_value.data(), str_key_value.size() );
     }
+
     h256 hash;
     secp256k1_sha256_finalize( &ctx, hash.data() );
     return hash;
@@ -285,6 +287,7 @@ void LevelDB::hashBasePartially(
     if ( it == nullptr ) {
         BOOST_THROW_EXCEPTION( DatabaseError() << errinfo_comment( "null iterator" ) );
     }
+
     for ( it->Seek( start ); it->Valid() && it->key().ToString() < finish; it->Next() ) {
         std::string key_ = it->key().ToString();
         std::string value_ = it->value().ToString();
@@ -293,10 +296,10 @@ void LevelDB::hashBasePartially(
         // TODO Move this logic to separate "compatiliblity layer"!
         if ( key_ == "pieceUsageBytes" )
             continue;
-        std::string key_value = key_ + value_;
-        const std::vector< uint8_t > usc( key_value.begin(), key_value.end() );
-        bytesConstRef str_key_value( usc.data(), usc.size() );
-        secp256k1_sha256_write( ctx, str_key_value.data(), str_key_value.size() );
+        std::string keyValue = key_ + value_;
+        const std::vector< uint8_t > usc( keyValue.begin(), keyValue.end() );
+        bytesConstRef strKeyValue( usc.data(), usc.size() );
+        secp256k1_sha256_write( ctx, strKeyValue.data(), strKeyValue.size() );
     }
 }
 

--- a/libdevcore/LevelDB.cpp
+++ b/libdevcore/LevelDB.cpp
@@ -240,17 +240,17 @@ h256 LevelDB::hashBase() const {
     secp256k1_sha256_t ctx;
     secp256k1_sha256_initialize( &ctx );
     for ( it->SeekToFirst(); it->Valid(); it->Next() ) {
-        std::string key_ = it->key().ToString();
-        std::string value_ = it->value().ToString();
+        std::string keyTmp = it->key().ToString();
+        std::string valueTmp = it->value().ToString();
         // HACK! For backward compatibility! When snapshot could happen between update of two nodes
         // - it would lead to stateRoot mismatch
         // TODO Move this logic to separate "compatiliblity layer"!
-        if ( key_ == "pieceUsageBytes" )
+        if ( keyTmp == "pieceUsageBytes" )
             continue;
-        std::string key_value = key_ + value_;
-        const std::vector< uint8_t > usc( key_value.begin(), key_value.end() );
-        bytesConstRef str_key_value( usc.data(), usc.size() );
-        secp256k1_sha256_write( &ctx, str_key_value.data(), str_key_value.size() );
+        std::string keyValue = keyTmp + valueTmp;
+        const std::vector< uint8_t > usc( keyValue.begin(), keyValue.end() );
+        bytesConstRef strKeyValue( usc.data(), usc.size() );
+        secp256k1_sha256_write( &ctx, strKeyValue.data(), strKeyValue.size() );
     }
 
     h256 hash;
@@ -268,12 +268,12 @@ h256 LevelDB::hashBaseWithPrefix( char _prefix ) const {
     secp256k1_sha256_initialize( &ctx );
     for ( it->SeekToFirst(); it->Valid(); it->Next() ) {
         if ( it->key()[0] == _prefix ) {
-            std::string key_ = it->key().ToString();
-            std::string value_ = it->value().ToString();
-            std::string key_value = key_ + value_;
-            const std::vector< uint8_t > usc( key_value.begin(), key_value.end() );
-            bytesConstRef str_key_value( usc.data(), usc.size() );
-            secp256k1_sha256_write( &ctx, str_key_value.data(), str_key_value.size() );
+            std::string keyTmp = it->key().ToString();
+            std::string valueTmp = it->value().ToString();
+            std::string keyValue = keyTmp + valueTmp;
+            const std::vector< uint8_t > usc( keyValue.begin(), keyValue.end() );
+            bytesConstRef strKeyValue( usc.data(), usc.size() );
+            secp256k1_sha256_write( &ctx, strKeyValue.data(), strKeyValue.size() );
         }
     }
     h256 hash;
@@ -294,14 +294,14 @@ void LevelDB::hashBasePartially(
         it->SeekToFirst();
 
     for ( size_t counter = 0; it->Valid() && counter < batchSize; it->Next() ) {
-        std::string key_ = it->key().ToString();
-        std::string value_ = it->value().ToString();
+        std::string keyTmp = it->key().ToString();
+        std::string valueTmp = it->value().ToString();
         // HACK! For backward compatibility! When snapshot could happen between update of two nodes
         // - it would lead to stateRoot mismatch
         // TODO Move this logic to separate "compatiliblity layer"!
-        if ( key_ == "pieceUsageBytes" )
+        if ( keyTmp == "pieceUsageBytes" )
             continue;
-        std::string keyValue = key_ + value_;
+        std::string keyValue = keyTmp + valueTmp;
         const std::vector< uint8_t > usc( keyValue.begin(), keyValue.end() );
         bytesConstRef strKeyValue( usc.data(), usc.size() );
         secp256k1_sha256_write( ctx, strKeyValue.data(), strKeyValue.size() );

--- a/libdevcore/LevelDB.cpp
+++ b/libdevcore/LevelDB.cpp
@@ -212,7 +212,6 @@ void LevelDB::forEach( std::function< bool( Slice, Slice ) > f ) const {
     }
 }
 
-
 void LevelDB::forEachWithPrefix(
     std::string& _prefix, std::function< bool( Slice, Slice ) > f ) const {
     cnote << "Iterating over the LevelDB prefix: " << _prefix;

--- a/libdevcore/LevelDB.cpp
+++ b/libdevcore/LevelDB.cpp
@@ -283,7 +283,7 @@ h256 LevelDB::hashBaseWithPrefix( char _prefix ) const {
     return hash;
 }
 
-void LevelDB::hashBasePartially( secp256k1_sha256_t* ctx, std::string& lastHashedKey ) const {
+bool LevelDB::hashBasePartially( secp256k1_sha256_t* ctx, std::string& lastHashedKey ) const {
     std::unique_ptr< leveldb::Iterator > it( m_db->NewIterator( m_readOptions ) );
     if ( it == nullptr ) {
         BOOST_THROW_EXCEPTION( DatabaseError() << errinfo_comment( "null iterator" ) );
@@ -309,10 +309,11 @@ void LevelDB::hashBasePartially( secp256k1_sha256_t* ctx, std::string& lastHashe
         ++counter;
     }
 
-    if ( it->Valid() )
+    if ( it->Valid() ) {
         lastHashedKey = it->key().ToString();
-    else
-        lastHashedKey = "stop";
+        return true;
+    } else
+        return false;
 }
 
 void LevelDB::doCompaction() const {

--- a/libdevcore/LevelDB.h
+++ b/libdevcore/LevelDB.h
@@ -61,7 +61,7 @@ public:
     h256 hashBase() const override;
     h256 hashBaseWithPrefix( char _prefix ) const;
 
-    void hashBasePartially( secp256k1_sha256_t* ctx, std::string& lastHashedKey ) const;
+    bool hashBasePartially( secp256k1_sha256_t* ctx, std::string& lastHashedKey ) const;
 
     void doCompaction() const;
 

--- a/libdevcore/LevelDB.h
+++ b/libdevcore/LevelDB.h
@@ -62,7 +62,7 @@ public:
     h256 hashBaseWithPrefix( char _prefix ) const;
 
     void hashBasePartially(
-        secp256k1_sha256_t* ctx, const std::string& start, const std::string& finish ) const;
+        secp256k1_sha256_t* ctx, std::string& lastHashedKey, size_t batchSize = 10000 ) const;
 
     void doCompaction() const;
 

--- a/libdevcore/LevelDB.h
+++ b/libdevcore/LevelDB.h
@@ -61,8 +61,7 @@ public:
     h256 hashBase() const override;
     h256 hashBaseWithPrefix( char _prefix ) const;
 
-    void hashBasePartially(
-        secp256k1_sha256_t* ctx, std::string& lastHashedKey, size_t batchSize = 10000 ) const;
+    void hashBasePartially( secp256k1_sha256_t* ctx, std::string& lastHashedKey ) const;
 
     void doCompaction() const;
 
@@ -79,6 +78,8 @@ private:
     leveldb::WriteOptions const m_writeOptions;
     leveldb::Options m_options;
     boost::filesystem::path const m_path;
+
+    static const size_t BATCH_CHUNK_SIZE;
 };
 
 }  // namespace db

--- a/libdevcore/LevelDB.h
+++ b/libdevcore/LevelDB.h
@@ -26,6 +26,8 @@
 #include <leveldb/write_batch.h>
 #include <boost/filesystem.hpp>
 
+#include <secp256k1_sha256.h>
+
 namespace dev {
 namespace db {
 class LevelDB : public DatabaseFace {
@@ -58,6 +60,9 @@ public:
 
     h256 hashBase() const override;
     h256 hashBaseWithPrefix( char _prefix ) const;
+
+    void hashBasePartially(
+        secp256k1_sha256_t* ctx, const std::string& start, const std::string& finish ) const;
 
     void doCompaction() const;
 

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -445,11 +445,13 @@ void SnapshotManager::computeDatabaseHash(
         BOOST_THROW_EXCEPTION( InvalidPath( _dbDir ) );
     }
 
-    //    std::array< std::string, 23 > lexographicKeysSegments = { "0", "1", "2", "3", "4", "5",
-    //    "6",
-    //        "7", "8", "9", "A", "B", "C", "D", "E", "F", "a", "b", "c", "d", "e", "f", "{" };
-    std::array< std::string, 11 > lexographicKeysSegments = { "0", "2", "4", "6", "8", "A", "F",
-        "a", "c", "e", "{" };
+    std::array< std::string, 17 > lexographicKeysSegments = { std::string( 1, char( 0 ) ),
+        std::string( 1, char( 16 ) ), std::string( 1, char( 32 ) ), std::string( 1, char( 48 ) ),
+        std::string( 1, char( 64 ) ), std::string( 1, char( 80 ) ), std::string( 1, char( 96 ) ),
+        std::string( 1, char( 112 ) ), std::string( 1, char( 128 ) ), std::string( 1, char( 144 ) ),
+        std::string( 1, char( 160 ) ), std::string( 1, char( 176 ) ), std::string( 1, char( 192 ) ),
+        std::string( 1, char( 208 ) ), std::string( 1, char( 224 ) ), std::string( 1, char( 240 ) ),
+        std::string( 1000, char( 255 ) ) };
 
     secp256k1_sha256_t dbCtx;
     secp256k1_sha256_initialize( &dbCtx );

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -448,14 +448,14 @@ void SnapshotManager::computeDatabaseHash(
     secp256k1_sha256_t dbCtx;
     secp256k1_sha256_initialize( &dbCtx );
 
-    std::string finishKey = "start";
+    std::string lastHashedKey = "start";
 
-    while ( finishKey != "stop" ) {
+    while ( lastHashedKey != "stop" ) {
         std::unique_ptr< dev::db::LevelDB > m_db( new dev::db::LevelDB( _dbDir.string(),
             dev::db::LevelDB::defaultSnapshotReadOptions(), dev::db::LevelDB::defaultWriteOptions(),
             dev::db::LevelDB::defaultSnapshotDBOptions() ) );
 
-        m_db->hashBasePartially( &dbCtx, finishKey );
+        m_db->hashBasePartially( &dbCtx, lastHashedKey );
     }
 
     dev::h256 dbHash;

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -445,24 +445,17 @@ void SnapshotManager::computeDatabaseHash(
         BOOST_THROW_EXCEPTION( InvalidPath( _dbDir ) );
     }
 
-    std::array< std::string, 17 > lexographicKeysSegments = { std::string( 1, char( 0 ) ),
-        std::string( 1, char( 16 ) ), std::string( 1, char( 32 ) ), std::string( 1, char( 48 ) ),
-        std::string( 1, char( 64 ) ), std::string( 1, char( 80 ) ), std::string( 1, char( 96 ) ),
-        std::string( 1, char( 112 ) ), std::string( 1, char( 128 ) ), std::string( 1, char( 144 ) ),
-        std::string( 1, char( 160 ) ), std::string( 1, char( 176 ) ), std::string( 1, char( 192 ) ),
-        std::string( 1, char( 208 ) ), std::string( 1, char( 224 ) ), std::string( 1, char( 240 ) ),
-        std::string( 1000, char( 255 ) ) };
-
     secp256k1_sha256_t dbCtx;
     secp256k1_sha256_initialize( &dbCtx );
 
-    for ( size_t i = 0; i < lexographicKeysSegments.size() - 1; ++i ) {
+    std::string finishKey = "start";
+
+    while ( finishKey != "stop" ) {
         std::unique_ptr< dev::db::LevelDB > m_db( new dev::db::LevelDB( _dbDir.string(),
             dev::db::LevelDB::defaultSnapshotReadOptions(), dev::db::LevelDB::defaultWriteOptions(),
             dev::db::LevelDB::defaultSnapshotDBOptions() ) );
 
-        m_db->hashBasePartially(
-            &dbCtx, lexographicKeysSegments[i], lexographicKeysSegments[i + 1] );
+        m_db->hashBasePartially( &dbCtx, finishKey );
     }
 
     dev::h256 dbHash;

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -445,8 +445,11 @@ void SnapshotManager::computeDatabaseHash(
         BOOST_THROW_EXCEPTION( InvalidPath( _dbDir ) );
     }
 
-    std::array< std::string, 17 > lexographicKeysSegments = { "0", "1", "2", "3", "4", "5", "6",
-        "7", "8", "9", "a", "b", "c", "d", "e", "f", "g" };
+    //    std::array< std::string, 23 > lexographicKeysSegments = { "0", "1", "2", "3", "4", "5",
+    //    "6",
+    //        "7", "8", "9", "A", "B", "C", "D", "E", "F", "a", "b", "c", "d", "e", "f", "{" };
+    std::array< std::string, 11 > lexographicKeysSegments = { "0", "2", "4", "6", "8", "A", "F",
+        "a", "c", "e", "{" };
 
     secp256k1_sha256_t dbCtx;
     secp256k1_sha256_initialize( &dbCtx );

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -449,13 +449,14 @@ void SnapshotManager::computeDatabaseHash(
     secp256k1_sha256_initialize( &dbCtx );
 
     std::string lastHashedKey = "start";
+    bool isContinue = true;
 
-    while ( lastHashedKey != "stop" ) {
+    while ( isContinue ) {
         std::unique_ptr< dev::db::LevelDB > m_db( new dev::db::LevelDB( _dbDir.string(),
             dev::db::LevelDB::defaultSnapshotReadOptions(), dev::db::LevelDB::defaultWriteOptions(),
             dev::db::LevelDB::defaultSnapshotDBOptions() ) );
 
-        m_db->hashBasePartially( &dbCtx, lastHashedKey );
+        isContinue = m_db->hashBasePartially( &dbCtx, lastHashedKey );
     }
 
     dev::h256 dbHash;

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -438,9 +438,9 @@ bool tryDownloadSnapshot( std::shared_ptr< SnapshotManager >& snapshotManager,
             try {
                 snapshotManager->computeSnapshotHash( blockNumber, true );
             } catch ( const std::exception& ) {
-                std::throw_with_nested(
-                    std::runtime_error( cc::fatal( "FATAL:" ) + " " +
-                                        cc::error( "Exception while computing snapshot hash " ) ) );
+                std::throw_with_nested( std::runtime_error(
+                    std::string( "FATAL:" ) +
+                    std::string( " Exception while computing snapshot hash " ) ) );
             }
 
             dev::h256 calculated_hash = snapshotManager->getSnapshotHash( blockNumber );
@@ -449,18 +449,15 @@ bool tryDownloadSnapshot( std::shared_ptr< SnapshotManager >& snapshotManager,
                 successfullDownload = true;
                 if ( isRegularSnapshot ) {
                     snapshotManager->restoreSnapshot( blockNumber );
-                    std::cout << cc::success( "Snapshot restore success for block " )
-                              << cc::u( to_string( blockNumber ) ) << std::endl;
+                    std::cout << "Snapshot restore success for block " << to_string( blockNumber )
+                              << std::endl;
                 }
                 return successfullDownload;
             } else {
                 clog( VerbosityWarning, "tryDownloadSnapshot" )
-                    << cc::notice(
-                           "Downloaded snapshot with incorrect hash! Incoming "
-                           "hash " )
-                    << cc::notice( votedHash.first.hex() )
-                    << cc::notice( " is not equal to calculated hash " )
-                    << cc::notice( calculated_hash.hex() ) << cc::notice( " Will try again" );
+                    << "Downloaded snapshot with incorrect hash! Incoming hash "
+                    << votedHash.first.hex() << " is not equal to calculated hash "
+                    << calculated_hash.hex() << " Will try again";
                 if ( isRegularSnapshot )
                     snapshotManager->cleanup();
                 else

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -460,7 +460,7 @@ bool tryDownloadSnapshot( std::shared_ptr< SnapshotManager >& snapshotManager,
                            "hash " )
                     << cc::notice( votedHash.first.hex() )
                     << cc::notice( " is not equal to calculated hash " )
-                    << cc::notice( calculated_hash.hex() ) << cc::notice( "Will try again" );
+                    << cc::notice( calculated_hash.hex() ) << cc::notice( " Will try again" );
                 if ( isRegularSnapshot )
                     snapshotManager->cleanup();
                 else

--- a/test/unittests/libweb3core/LevelDBHash.cpp
+++ b/test/unittests/libweb3core/LevelDBHash.cpp
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE( hash ) {
                 dev::db::LevelDB::defaultSnapshotReadOptions(), dev::db::LevelDB::defaultWriteOptions(),
                 dev::db::LevelDB::defaultSnapshotDBOptions() ) );
 
-            m_db->hashBasePartially( &dbCtx, lastHashedKey, 10 );
+            m_db->hashBasePartially( &dbCtx, lastHashedKey );
         }
 
         secp256k1_sha256_finalize( &dbCtx, hashPartially.data() );

--- a/test/unittests/libweb3core/LevelDBHash.cpp
+++ b/test/unittests/libweb3core/LevelDBHash.cpp
@@ -70,23 +70,16 @@ BOOST_AUTO_TEST_CASE( hash ) {
             db_copy->insert( dev::db::Slice( "ppieceUsageBytes" ), dev::db::Slice( "123456789" ) );
         }
 
-        std::array< std::string, 17 > lexographicKeysSegments = { std::string( 1, char( 0 ) ),
-            std::string( 1, char( 16 ) ), std::string( 1, char( 32 ) ), std::string( 1, char( 48 ) ),
-            std::string( 1, char( 64 ) ), std::string( 1, char( 80 ) ), std::string( 1, char( 96 ) ),
-            std::string( 1, char( 112 ) ), std::string( 1, char( 128 ) ), std::string( 1, char( 144 ) ),
-            std::string( 1, char( 160 ) ), std::string( 1, char( 176 ) ), std::string( 1, char( 192 ) ),
-            std::string( 1, char( 208 ) ), std::string( 1, char( 224 ) ), std::string( 1, char( 240 ) ),
-            std::string( 1000, char( 255 ) ) };
-
         secp256k1_sha256_t dbCtx;
         secp256k1_sha256_initialize( &dbCtx );
 
-        for (size_t i = 0; i < lexographicKeysSegments.size() - 1; ++i) {
-            std::unique_ptr< dev::db::LevelDB > db( new dev::db::LevelDB( td.path(),
+        std::string finishKey = "start";
+        while ( finishKey != "stop" ) {
+            std::unique_ptr< dev::db::LevelDB > m_db( new dev::db::LevelDB( td.path(),
                 dev::db::LevelDB::defaultSnapshotReadOptions(), dev::db::LevelDB::defaultWriteOptions(),
                 dev::db::LevelDB::defaultSnapshotDBOptions() ) );
 
-            db->hashBasePartially( &dbCtx, lexographicKeysSegments[i], lexographicKeysSegments[i + 1] );
+            m_db->hashBasePartially( &dbCtx, finishKey, 10 );
         }
 
         secp256k1_sha256_finalize( &dbCtx, hashPartially.data() );

--- a/test/unittests/libweb3core/LevelDBHash.cpp
+++ b/test/unittests/libweb3core/LevelDBHash.cpp
@@ -74,12 +74,13 @@ BOOST_AUTO_TEST_CASE( hash ) {
         secp256k1_sha256_initialize( &dbCtx );
 
         std::string lastHashedKey = "start";
-        while ( lastHashedKey != "stop" ) {
+        bool isContinue = true;
+        while ( isContinue ) {
             std::unique_ptr< dev::db::LevelDB > m_db( new dev::db::LevelDB( td.path(),
                 dev::db::LevelDB::defaultSnapshotReadOptions(), dev::db::LevelDB::defaultWriteOptions(),
                 dev::db::LevelDB::defaultSnapshotDBOptions() ) );
 
-            m_db->hashBasePartially( &dbCtx, lastHashedKey );
+            isContinue = m_db->hashBasePartially( &dbCtx, lastHashedKey );
         }
 
         secp256k1_sha256_finalize( &dbCtx, hashPartially.data() );

--- a/test/unittests/libweb3core/LevelDBHash.cpp
+++ b/test/unittests/libweb3core/LevelDBHash.cpp
@@ -70,8 +70,13 @@ BOOST_AUTO_TEST_CASE( hash ) {
             db_copy->insert( dev::db::Slice( "ppieceUsageBytes" ), dev::db::Slice( "123456789" ) );
         }
 
-        std::array< std::string, 11 > lexographicKeysSegments = { "0", "2", "4", "6", "8", "A",
-                                                                  "F", "a", "c", "e", "{" };
+        std::array< std::string, 17 > lexographicKeysSegments = { std::string( 1, char( 0 ) ),
+            std::string( 1, char( 16 ) ), std::string( 1, char( 32 ) ), std::string( 1, char( 48 ) ),
+            std::string( 1, char( 64 ) ), std::string( 1, char( 80 ) ), std::string( 1, char( 96 ) ),
+            std::string( 1, char( 112 ) ), std::string( 1, char( 128 ) ), std::string( 1, char( 144 ) ),
+            std::string( 1, char( 160 ) ), std::string( 1, char( 176 ) ), std::string( 1, char( 192 ) ),
+            std::string( 1, char( 208 ) ), std::string( 1, char( 224 ) ), std::string( 1, char( 240 ) ),
+            std::string( 1000, char( 255 ) ) };
 
         secp256k1_sha256_t dbCtx;
         secp256k1_sha256_initialize( &dbCtx );

--- a/test/unittests/libweb3core/LevelDBHash.cpp
+++ b/test/unittests/libweb3core/LevelDBHash.cpp
@@ -73,13 +73,13 @@ BOOST_AUTO_TEST_CASE( hash ) {
         secp256k1_sha256_t dbCtx;
         secp256k1_sha256_initialize( &dbCtx );
 
-        std::string finishKey = "start";
-        while ( finishKey != "stop" ) {
+        std::string lastHashedKey = "start";
+        while ( lastHashedKey != "stop" ) {
             std::unique_ptr< dev::db::LevelDB > m_db( new dev::db::LevelDB( td.path(),
                 dev::db::LevelDB::defaultSnapshotReadOptions(), dev::db::LevelDB::defaultWriteOptions(),
                 dev::db::LevelDB::defaultSnapshotDBOptions() ) );
 
-            m_db->hashBasePartially( &dbCtx, finishKey, 10 );
+            m_db->hashBasePartially( &dbCtx, lastHashedKey, 10 );
         }
 
         secp256k1_sha256_finalize( &dbCtx, hashPartially.data() );

--- a/test/unittests/libweb3core/LevelDBHash.cpp
+++ b/test/unittests/libweb3core/LevelDBHash.cpp
@@ -39,6 +39,39 @@ BOOST_AUTO_TEST_CASE( hash ) {
 
     BOOST_REQUIRE( hash == hash_same );
 
+    dev::h256 hashPartially;
+    {
+        {
+            std::unique_ptr< dev::db::LevelDB > db_copy( new dev::db::LevelDB( td.path() ) );
+            BOOST_REQUIRE( db_copy );
+
+            for ( size_t i = 0; i < 123; ++i ) {
+                std::string key = std::to_string( 43 + i );
+                std::string value = std::to_string( i );
+                db_copy->insert( dev::db::Slice(key), dev::db::Slice(value) );
+            }
+        }
+
+        std::array< std::string, 17 > lexographicKeysSegments = { "0", "1", "2", "3", "4", "5", "6",
+                                                                  "7", "8", "9", "a", "b", "c", "d",
+                                                                  "e", "f", "g" };
+
+        secp256k1_sha256_t dbCtx;
+        secp256k1_sha256_initialize( &dbCtx );
+
+        for (size_t i = 0; i < lexographicKeysSegments.size() - 1; ++i) {
+            std::unique_ptr< dev::db::LevelDB > db( new dev::db::LevelDB( td.path(),
+                dev::db::LevelDB::defaultSnapshotReadOptions(), dev::db::LevelDB::defaultWriteOptions(),
+                dev::db::LevelDB::defaultSnapshotDBOptions() ) );
+
+            db->hashBasePartially( &dbCtx, lexographicKeysSegments[i], lexographicKeysSegments[i + 1] );
+        }
+
+        secp256k1_sha256_finalize( &dbCtx, hashPartially.data() );
+    }
+
+    BOOST_REQUIRE( hash == hashPartially );
+
     dev::h256 hash_diff;
     {
         std::unique_ptr< dev::db::LevelDB > db_diff( new dev::db::LevelDB( td.path() ) );


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skaled/issues/1588

do not force leveldb to store all the key-value pairs in OS buffer
instead iterate over the database batch by batch to decrease RAM usage during snapshot hash calculation

tested on devnet:
- update one node to the version with fix
- run load tests for the long time. you will see that RAM and swap usage is less for the updated node ( @oleksandrSydorenkoJ )
- non updated nodes will eventually fail with out of memory error, while updated node will stay healthy 