### PR TITLE
Enhancement/skaled 1693 func tests on both builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -150,6 +150,7 @@ jobs:
           export VERSION=$(cat VERSION)
           export VERSION=$(bash ./scripts/calculate_version.sh $BRANCH $VERSION)
           echo "::set-env name=VERSION::$VERSION"
+          echo "::set-env name=VERSION_ORIG::$VERSION"
           echo "Version $VERSION"
           ( test $BRANCH = "stable" && export PRERELEASE=false ) || export PRERELEASE=true
           echo "PRERELEASE=$PRERELEASE" >> $GITHUB_ENV
@@ -191,6 +192,7 @@ jobs:
           echo "Branch $BRANCH"
           export VERSION=$VERSION-historic
           echo "::set-env name=VERSION::$VERSION"
+          echo "::set-env name=VERSION_HISTORIC::$VERSION"
           echo "Version $VERSION"
           export RELEASE=true
           echo "::set-env name=RELEASE::$RELEASE"
@@ -214,7 +216,8 @@ jobs:
           asset_name: skaled-debug-historic
           asset_content_type: application/octet-stream
     outputs:
-      version: ${{ env.VERSION }}
+      version_orig: ${{ env.VERSION_ORIG }}
+      version_historic: ${{ env.VERSION_HISTORIC }}
     
   functional-tests:
     uses: ./.github/workflows/functional-tests.yml
@@ -222,4 +225,12 @@ jobs:
     needs: [build]
     with:
       version: ${{ needs.build.outputs.version }}
+    secrets: inherit
+
+  functional-tests-historic:
+    uses: ./.github/workflows/functional-tests.yml
+    name: Functional testing for build
+    needs: [build]
+    with:
+      version: ${{ needs.build.outputs.version_orig }}
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -224,7 +224,7 @@ jobs:
     name: Functional testing for build
     needs: [build]
     with:
-      version: ${{ needs.build.outputs.version }}
+      version: ${{ needs.build.outputs.version_orig }}
     secrets: inherit
 
   functional-tests-historic:
@@ -232,5 +232,5 @@ jobs:
     name: Functional testing for build
     needs: [build]
     with:
-      version: ${{ needs.build.outputs.version_orig }}
+      version: ${{ needs.build.outputs.version_historic }}
     secrets: inherit


### PR DESCRIPTION
Every time, after building and publishing schain container, we run 'functional tests' with it. Previously, we ran them only on 'historic' build. This PR runs them twice - on normal, then on historic build.

Tested on temporary repository https://github.com/skalenetwork/skaled_tmp/actions/runs/7571061421