### PR TITLE
Add release option for custom build

### DIFF
--- a/.github/workflows/custom_build.yml
+++ b/.github/workflows/custom_build.yml
@@ -105,7 +105,7 @@ jobs:
           export CXX=g++-9
           export TARGET=all
           export CMAKE_BUILD_TYPE=$BUILD_TYPE
-          ( test $CMAKE_BUILD_TYPE = "Debug" && export DEBUG_FLAG=1 ) || export DEBUG_FLAG=0
+          [[ $CMAKE_BUILD_TYPE = "Debug" ]] && export DEBUG_FLAG=1 || export DEBUG_FLAG=0
           cd deps
           ./clean.sh
           rm -f ./libwebsockets-from-git.tar.gz
@@ -137,7 +137,7 @@ jobs:
         run: |
           cp build/skaled/skaled scripts/skale_build/executable/
           export BRANCH=${{ github.event.inputs.branch_name }}
-          ( test $BUILD_TYPE = "Debug" && export SUFFIX=debug ) || export SUFFIX=release
+          [[ $BUILD_TYPE = "Debug" ]] && export SUFFIX=debug || export SUFFIX=release
           export VERSION=${{ github.event.inputs.image_version }}-$SUFFIX
           echo "Version $VERSION"
           export RELEASE=true

--- a/.github/workflows/custom_build.yml
+++ b/.github/workflows/custom_build.yml
@@ -16,7 +16,7 @@ on:
         default: ''
         required: false
       build_type:
-        description: 'Build type'
+        description: 'Build type of skaled binary'
         type: choice
         required: true
         options: 

--- a/.github/workflows/custom_build.yml
+++ b/.github/workflows/custom_build.yml
@@ -103,18 +103,19 @@ jobs:
           export CC=gcc-9
           export CXX=g++-9
           export TARGET=all
-          export CMAKE_BUILD_TYPE=Debug
+          export CMAKE_BUILD_TYPE=${{ github.event.inputs.build_type }}
+          ( test $CMAKE_BUILD_TYPE = "Debug" && export DEBUG_FLAG=1 ) || export DEBUG_FLAG=0
           cd deps
           ./clean.sh
           rm -f ./libwebsockets-from-git.tar.gz
-          ./build.sh PARALLEL_COUNT=$(nproc) DEBUG=1
+          ./build.sh PARALLEL_COUNT=$(nproc) DEBUG=$DEBUG_FLAG
           cd ..
       - name: Configure all
         run: |
           export CC=gcc-9
           export CXX=g++-9
           export TARGET=all
-          export CMAKE_BUILD_TYPE=Debug
+          export CMAKE_BUILD_TYPE=${{ github.event.inputs.build_type }}
           mkdir -p build
           cd build
           cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE ${{ github.event.inputs.cmake_options }} ..
@@ -124,7 +125,7 @@ jobs:
           export CC=gcc-9
           export CXX=g++-9
           export TARGET=all
-          export CMAKE_BUILD_TYPE=Debug
+          export CMAKE_BUILD_TYPE=${{ github.event.inputs.build_type }}
           cd build
           make skaled -j$(nproc)
           #echo "Ensure release mode skaled does not have any debug markers"

--- a/.github/workflows/custom_build.yml
+++ b/.github/workflows/custom_build.yml
@@ -137,8 +137,8 @@ jobs:
         run: |
           cp build/skaled/skaled scripts/skale_build/executable/
           export BRANCH=${{ github.event.inputs.branch_name }}
-          [[ $BUILD_TYPE = "Debug" ]] && export SUFFIX=debug || export SUFFIX=release
-          export VERSION=${{ github.event.inputs.image_version }}-$SUFFIX
+          [[ $BUILD_TYPE = "Debug" ]] && export VERSION_SUFFIX=debug || export VERSION_SUFFIX=release
+          export VERSION=${{ github.event.inputs.image_version }}-$VERSION_SUFFIX
           echo "Version $VERSION"
           export RELEASE=true
           bash ./scripts/build_and_publish.sh

--- a/.github/workflows/custom_build.yml
+++ b/.github/workflows/custom_build.yml
@@ -22,7 +22,7 @@ on:
         options: 
         - Debug
         - RelWithDebInfo
-        default: Debug
+        default: RelWithDebInfo
 
 jobs:
   main_job:
@@ -31,6 +31,7 @@ jobs:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        BUILD_TYPE: ${{ github.event.inputs.build_type }}
     steps:
       - name: update apt
         run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test; sudo apt-get update
@@ -103,7 +104,7 @@ jobs:
           export CC=gcc-9
           export CXX=g++-9
           export TARGET=all
-          export CMAKE_BUILD_TYPE=${{ github.event.inputs.build_type }}
+          export CMAKE_BUILD_TYPE=$BUILD_TYPE
           ( test $CMAKE_BUILD_TYPE = "Debug" && export DEBUG_FLAG=1 ) || export DEBUG_FLAG=0
           cd deps
           ./clean.sh
@@ -115,7 +116,7 @@ jobs:
           export CC=gcc-9
           export CXX=g++-9
           export TARGET=all
-          export CMAKE_BUILD_TYPE=${{ github.event.inputs.build_type }}
+          export CMAKE_BUILD_TYPE=$BUILD_TYPE
           mkdir -p build
           cd build
           cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE ${{ github.event.inputs.cmake_options }} ..
@@ -125,7 +126,7 @@ jobs:
           export CC=gcc-9
           export CXX=g++-9
           export TARGET=all
-          export CMAKE_BUILD_TYPE=${{ github.event.inputs.build_type }}
+          export CMAKE_BUILD_TYPE=$BUILD_TYPE
           cd build
           make skaled -j$(nproc)
           #echo "Ensure release mode skaled does not have any debug markers"
@@ -136,7 +137,8 @@ jobs:
         run: |
           cp build/skaled/skaled scripts/skale_build/executable/
           export BRANCH=${{ github.event.inputs.branch_name }}
-          export VERSION=${{ github.event.inputs.image_version }}
+          ( test $BUILD_TYPE = "Debug" && export SUFFIX=debug ) || export SUFFIX=release
+          export VERSION=${{ github.event.inputs.image_version }}-$SUFFIX
           echo "Version $VERSION"
           export RELEASE=true
           bash ./scripts/build_and_publish.sh

--- a/.github/workflows/custom_build.yml
+++ b/.github/workflows/custom_build.yml
@@ -15,6 +15,14 @@ on:
         description: 'Additional cmake options'
         default: ''
         required: false
+      build_type:
+        description: 'Build type'
+        type: choice
+        required: true
+        options: 
+        - Debug
+        - RelWithDebInfo
+        default: Debug
 
 jobs:
   main_job:


### PR DESCRIPTION
This PR introduces build options for custom build workflow. There are 2 options:
- **Debug**, creates `VERSION_NAME-debug` image on DockerHub
- **RelWithDebInfo** (default), creates `VERSION_NAME-release` image on DockerHub

You can set these options in Github Actions in the `Custom Docker and Binary` section in `Run Workflow`

**No code changes** 