### PR TITLE
1780 absence tracer in params

### DIFF
--- a/libskale/httpserveroverride.cpp
+++ b/libskale/httpserveroverride.cpp
@@ -60,7 +60,6 @@
 #include <libethereum/Block.h>
 #include <libethereum/Transaction.h>
 #include <libweb3jsonrpc/Eth.h>
-#include <libweb3jsonrpc/JsonHelper.h>
 #include <libweb3jsonrpc/Skale.h>
 
 #include <skutils/eth_utils.h>
@@ -71,8 +70,6 @@
 
 #include <iostream>
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #if INT_MAX == 32767
 // 16 bits
@@ -271,8 +268,6 @@ bool checkParamsIsObject( const char* strMethodName, const rapidjson::Document& 
 };  // namespace skale
 
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 namespace stats {
 
@@ -512,8 +507,6 @@ static nlohmann::json generate_subsystem_stats( const char* strSubSystem ) {
 
 };  // namespace stats
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 const char* esm2str( e_server_mode_t esm ) {
     switch ( esm ) {
@@ -525,8 +518,6 @@ const char* esm2str( e_server_mode_t esm ) {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 SkaleStatsSubscriptionManager::SkaleStatsSubscriptionManager() : next_subscription_( 1 ) {}
 SkaleStatsSubscriptionManager::~SkaleStatsSubscriptionManager() {
@@ -673,8 +664,6 @@ void SkaleStatsSubscriptionManager::unsubscribeAll() {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 SkaleServerConnectionsTrackHelper::SkaleServerConnectionsTrackHelper( SkaleServerOverride& sso )
     : m_sso( sso ) {
@@ -685,8 +674,6 @@ SkaleServerConnectionsTrackHelper::~SkaleServerConnectionsTrackHelper() {
     m_sso.connection_counter_dec();
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 SkaleWsPeer::SkaleWsPeer( skutils::ws::server& srv, const skutils::ws::hdl_t& hdl )
     : skutils::ws::peer( srv, hdl ),
@@ -845,7 +832,6 @@ void SkaleWsPeer::onMessage( const std::string& msg, skutils::ws::opcv eOpCode )
         stats::register_stats_exception(
             ( std::string( "RPC/" ) + pThis->getRelay().nfoGetSchemeUC() ).c_str(), "messages" );
         stats::register_stats_exception( pThis->getRelay().nfoGetSchemeUC().c_str(), "messages" );
-        // stats::register_stats_exception( "RPC", strMethod.c_str() );
         pThis.get_unconst()->sendMessage( skutils::tools::trim_copy( strResponse ) );
         stats::register_stats_answer(
             pThis->getRelay().nfoGetSchemeUC().c_str(), "messages", strResponse.size() );
@@ -1041,7 +1027,6 @@ void SkaleWsPeer::onMessage( const std::string& msg, skutils::ws::opcv eOpCode )
         }
     };  // WS-processing-lambda
     skutils::dispatch::async( pThis->m_strPeerQueueID, fnAsyncMessageHandler );
-    // skutils::ws::peer::onMessage( msg, eOpCode );
 }
 
 void SkaleWsPeer::onClose(
@@ -1314,8 +1299,6 @@ void SkaleWsPeer::eth_subscribe_logs(
                                         << ( pThis->desc() + cc::ws_tx( " <<< " ) +
                                                pThis->implPreformatTrafficJsonMessage(
                                                    strNotification, false ) );
-                                // skutils::dispatch::async( pThis->m_strPeerQueueID,
-                                // [pThis, strNotification]() -> void {
                                 bool bMessageSentOK = false;
                                 try {
                                     bMessageSentOK = const_cast< SkaleWsPeer* >( pThis.get() )
@@ -1433,8 +1416,6 @@ void SkaleWsPeer::eth_subscribe_newPendingTransactions(
                                  " <<< " + pThis->getRelay().nfoGetSchemeUC() + "/TX <<< " ) +
                                pThis->desc() + cc::ws_tx( " <<< " ) +
                                pThis->implPreformatTrafficJsonMessage( strNotification, false ) );
-                // skutils::dispatch::async( pThis->m_strPeerQueueID, [pThis, strNotification]() ->
-                // void {
                 bool bMessageSentOK = false;
                 try {
                     bMessageSentOK =
@@ -1846,8 +1827,6 @@ std::string SkaleWsPeer::implPreformatTrafficJsonMessage(
     return cc::j( jo2 );
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 SkaleRelayWS::SkaleRelayWS( int ipVer, const char* strBindAddr,
     const char* strScheme,  // "ws" or "wss"
@@ -2001,37 +1980,7 @@ dev::eth::Interface* SkaleRelayWS::ethereum() const {
     return pSO->ethereum();
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-/*
-SkaleRelayMiniHTTP::SkaleRelayMiniHTTP( SkaleServerOverride* pSO, int ipVer,
-    const char* strBindAddr, int nPort, const char* cert_path, const char* private_key_path,
-    const char*, // ca_path
-    int nServerIndex, size_t a_max_http_handler_queues,
-    bool is_async_http_transfer_mode )
-    : SkaleServerHelper( nServerIndex ),
-      m_pSO( pSO ),
-      ipVer_( ipVer ),
-      strBindAddr_( strBindAddr ),
-      nPort_( nPort ),
-      m_bHelperIsSSL( ( cert_path && cert_path[0] && private_key_path && private_key_path[0] ) ?
-                          true :
-                          false ) {
-    if ( m_bHelperIsSSL )
-        m_pServer.reset( new skutils::http::SSL_server(
-            cert_path, private_key_path, a_max_http_handler_queues, is_async_http_transfer_mode ) );
-    else
-        m_pServer.reset(
-            new skutils::http::server( a_max_http_handler_queues, is_async_http_transfer_mode ) );
-    m_pServer->ipVer_ = ipVer_;  // not known before listen
-}
 
-SkaleRelayMiniHTTP::~SkaleRelayMiniHTTP() {
-    m_pServer.reset();
-}
-*/
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 SkaleRelayProxygenHTTP::SkaleRelayProxygenHTTP( SkaleServerOverride* pSO, int ipVer,
     const char* strBindAddr, int nPort, const char* cert_path, const char* private_key_path,
@@ -2066,8 +2015,6 @@ bool SkaleRelayProxygenHTTP::is_running() const {
 
 void SkaleRelayProxygenHTTP::stop() {}
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 const double SkaleServerOverride::g_lfDefaultExecutionDurationMaxForPerformanceWarning =
     1.0;  // in seconds, default 1 second
@@ -2362,6 +2309,32 @@ string hostname_to_ip( string hostname ) {
     return "";
 }
 
+
+#ifdef HISTORIC_STATE
+// geth accepts no tracer  parameter instead of empty object parameter in trace calls
+// we add empty object if no tracer  parameter is present
+void SkaleServerOverride::preprocessTraceRequestIfNeeded(
+    const string& methodName, nlohmann::json& jsonRpcRequest ) {
+    if ( methodName.find( "debug_trace" ) == string::npos ) {
+        // not a debug trace call
+        return;
+    }
+
+    if ( jsonRpcRequest.count( "params" ) == 0 || !jsonRpcRequest["params"].is_array() ) {
+        return;
+    }
+
+    static std::unordered_set< std::string > traceMethodNames = { "debug_traceTransaction",
+        "debug_traceBlockByNumber", "debug_traceBlockByHash" };
+
+
+    if ( traceMethodNames.count( methodName ) > 0 && jsonRpcRequest["params"].size() == 1 ) {
+        // tracer parameter missing at the end of params array, add empty object parameter
+        jsonRpcRequest["params"].push_back( nlohmann::json::object() );
+    }
+}
+#endif
+
 skutils::result_of_http_request SkaleServerOverride::implHandleHttpRequest(
     const nlohmann::json& joIn, const std::string& strProtocol, int nServerIndex,
     std::string strOrigin, int ipVer, int nPort, e_server_mode_t esm ) {
@@ -2379,28 +2352,27 @@ skutils::result_of_http_request SkaleServerOverride::implHandleHttpRequest(
             jarrRequest = nlohmann::json::array();
             jarrRequest.push_back( joIn );
         }
-        for ( const nlohmann::json& joRequest : jarrRequest ) {
-            std::string strMethodWalk =
-                skutils::tools::getFieldSafe< std::string >( joRequest, "method" );
-            if ( strMethodWalk.empty() )
+        for ( nlohmann::json& jsonRpcRequest : jarrRequest ) {
+            std::string methodName =
+                skutils::tools::getFieldSafe< std::string >( jsonRpcRequest, "method" );
+            if ( methodName.empty() )
                 throw std::runtime_error( "Bad JSON RPC request, \"method\" name is missing" );
-            strMethod = strMethodWalk;
-            if ( joRequest.count( "id" ) == 0 )
+
+#ifdef HISTORIC_STATE
+            preprocessTraceRequestIfNeeded( methodName, jsonRpcRequest );
+#endif
+
+            strMethod = methodName;
+            if ( jsonRpcRequest.count( "id" ) == 0 )
                 throw std::runtime_error( "Bad JSON RPC request, \"id\" name is missing" );
-            joID = joRequest["id"];
-        }  // for( const nlohmann::json & joRequest : jarrRequest )
+            joID = jsonRpcRequest["id"];
+        }
         if ( isBatch ) {
             size_t cntInBatch = jarrRequest.size();
             if ( cntInBatch > maxCountInBatchJsonRpcRequest_ )
                 throw std::runtime_error( "Bad JSON RPC request, too much requests in batch" );
         }
     } catch ( ... ) {
-        //                if ( strMethod.empty() ) {
-        //                    if ( isBatch )
-        //                        strMethod = "batch_json_rpc_request";
-        //                    else
-        //                        strMethod = "unknown_json_rpc_method";
-        //                }
         std::string e = "Bad JSON RPC request: " + joIn.dump();
         throw std::runtime_error( e );
     }
@@ -2575,143 +2547,7 @@ skutils::result_of_http_request SkaleServerOverride::implHandleHttpRequest(
     return rslt;
 }
 
-/*
-bool SkaleServerOverride::implStartListening(  // mini HTTP
-    std::shared_ptr< SkaleRelayMiniHTTP >& pSrv, int ipVer, const std::string& strAddr, int nPort,
-    const std::string& strPathSslKey, const std::string& strPathSslCert,
-    const std::string& strPathSslCA, int nServerIndex, e_server_mode_t esm,
-    size_t a_max_http_handler_queues, bool is_async_http_transfer_mode ) {
-    bool bIsSSL = false;
-    SkaleServerOverride* pSO = this;
-    if ( ( !strPathSslKey.empty() ) && ( !strPathSslCert.empty() ) )
-        bIsSSL = true;
-    try {
-        implStopListening( pSrv, ipVer, bIsSSL, esm );
-        if ( strAddr.empty() || nPort <= 0 )
-            return true;
-        logTraceServerEvent( false, ipVer, bIsSSL ? "HTTPS" : "HTTP", -1, esm,
-            cc::debug( "starting " ) + cc::attention( "mini" ) + cc::debug( "/" ) +
-                cc::info( bIsSSL ? "HTTPS" : "HTTP" ) + cc::debug( "/" ) +
-                cc::num10( nServerIndex ) + cc::debug( "/" ) + cc::notice( esm2str( esm ) ) +
-                cc::debug( " server on address " ) + cc::info( strAddr ) +
-                cc::debug( " and port " ) + cc::c( nPort ) + cc::debug( "..." ) );
-        if ( bIsSSL )
-            pSrv.reset( new SkaleRelayMiniHTTP( pSO, ipVer, strAddr.c_str(), nPort,
-                strPathSslCert.c_str(), strPathSslKey.c_str(), strPathSslCA.c_str(), nServerIndex,
-                a_max_http_handler_queues, is_async_http_transfer_mode ) );
-        else
-            pSrv.reset( new SkaleRelayMiniHTTP( pSO, ipVer, strAddr.c_str(), nPort, nullptr,
-                nullptr, nullptr, nServerIndex, a_max_http_handler_queues,
-                is_async_http_transfer_mode ) );
-        pSrv->m_pServer->Options(
-            "/", [=]( const skutils::http::request& req, skutils::http::response& res ) {
-                stats::register_stats_message(
-                    bIsSSL ? "HTTPS" : "HTTP", "query options", req.body_.size() );
-                if ( opts_.isTraceCalls_ )
-                    logTraceServerTraffic( true, dev::VerbosityTrace, ipVer,
-                        bIsSSL ? "HTTPS" : "HTTP", nServerIndex, esm, req.origin_.c_str(),
-                        cc::info( "OPTTIONS" ) + cc::debug( " request handler" ) );
-                res.set_header( "access-control-allow-headers", "Content-Type" );
-                res.set_header( "access-control-allow-methods", "POST" );
-                res.set_header( "access-control-allow-origin", "*" );
-                res.set_header( "content-length", "0" );
-                res.set_header( "vary",
-                    "Origin, Access-Control-request-Method, Access-Control-request-Headers" );
-                stats::register_stats_answer(
-                    bIsSSL ? "HTTPS" : "HTTP", "query options", res.body_.size() );
-            } );
-        pSrv->m_pServer->Post( "/", [=, &pSrv]( const skutils::http::request& req,
-                                        skutils::http::response& res ) {
-            nlohmann::json joID = "-1";
-            try {
-                if ( isShutdownMode() )
-                    throw std::runtime_error( "query was cancelled due to server shutdown mode" );
-                nlohmann::json joIn = nlohmann::json::parse( req.body_ );
-                if ( joIn.count( "id" ) > 0 )
-                    joID = joIn["id"];
-                skutils::result_of_http_request rslt = implHandleHttpRequest(
-                    joIn, bIsSSL ? "HTTPS" : "HTTP", nServerIndex, req.origin_, ipVer, nPort, esm );
-                res.set_header( "access-control-allow-origin", "*" );
-                res.set_header( "vary", "Origin" );
-                if ( rslt.isBinary_ ) {
-                    res.set_content( ( char* ) rslt.vecBytes_.data(), rslt.vecBytes_.size(),
-                        "application/octet-stream" );
-                } else {
-                    std::string strOut = rslt.joOut_.dump();
-                    res.set_content(
-                        ( char* ) strOut.c_str(), strOut.size(), "application/octet-stream" );
-                }
-                return true;
-            } catch ( const std::exception& ex ) {
-                logTraceServerTraffic( false, dev::VerbosityError, ipVer, bIsSSL ? "HTTPS" : "HTTP",
-                    nServerIndex, esm, req.origin_.c_str(), cc::warn( ex.what() ) );
-                nlohmann::json joErrorResponce;
-                joErrorResponce["id"] = joID;
-                joErrorResponce["result"] = "error";
-                joErrorResponce["error"] = std::string( ex.what() );
-                std::string strOut = joErrorResponce.dump();
-                stats::register_stats_exception( bIsSSL ? "HTTPS" : "HTTP", "POST" );
-                res.set_header( "access-control-allow-origin", "*" );
-                res.set_header( "vary", "Origin" );
-                res.set_content(
-                    ( char* ) strOut.c_str(), strOut.size(), "application/octet-stream" );
-                return true;
-            } catch ( ... ) {
-                const char* e = "unknown exception in SkaleServerOverride";
-                logTraceServerTraffic( false, dev::VerbosityError, ipVer, bIsSSL ? "HTTPS" : "HTTP",
-                    nServerIndex, esm, req.origin_.c_str(), cc::warn( e ) );
-                nlohmann::json joErrorResponce;
-                joErrorResponce["id"] = joID;
-                joErrorResponce["result"] = "error";
-                joErrorResponce["error"] = std::string( e );
-                std::string strOut = joErrorResponce.dump();
-                stats::register_stats_exception( bIsSSL ? "HTTPS" : "HTTP", "POST" );
-                res.set_header( "access-control-allow-origin", "*" );
-                res.set_header( "vary", "Origin" );
-                res.set_content(
-                    ( char* ) strOut.c_str(), strOut.size(), "application/octet-stream" );
-                return true;
-            }
-        } );
-        // check if somebody is already listening
-        stat_check_port_availability_for_server_to_start_listen(
-            ipVer, strAddr.c_str(), nPort, esm, bIsSSL ? "HTTPS" : "HTTP", nServerIndex, this );
-        // make server listen in its dedicated thread
-        std::thread( [=]() {
-            skutils::multithreading::threadNameAppender tn(
-                "/" + std::string( bIsSSL ? "HTTPS" : "HTTP" ) + "-listener" );
-            if ( !pSrv->m_pServer->listen( ipVer, strAddr.c_str(), nPort ) ) {
-                stats::register_stats_error( bIsSSL ? "HTTPS" : "HTTP", "LISTEN" );
-                return;
-            }
-            stats::register_stats_message( bIsSSL ? "HTTPS" : "HTTP", "LISTEN" );
-        } )
-            .detach();
-        logTraceServerEvent( false, ipVer, bIsSSL ? "HTTPS" : "HTTP", nServerIndex, esm,
-            cc::success( "OK, started " ) + cc::attention( "mini" ) + cc::debug( "/" ) +
-                cc::info( bIsSSL ? "HTTPS" : "HTTP" ) + cc::debug( "/" ) +
-                cc::num10( nServerIndex ) + cc::success( " server on address " ) +
-                cc::info( strAddr ) + cc::success( " and port " ) + cc::c( nPort ) +
-                cc::success( "/" ) + cc::notice( esm2str( esm ) ) + " " );
-        return true;
-    } catch ( const std::exception& ex ) {
-        logTraceServerEvent( false, ipVer, bIsSSL ? "HTTPS" : "HTTP", nServerIndex, esm,
-            cc::fatal( "FAILED" ) + cc::error( " to start " ) + cc::attention( "mini" ) +
-                cc::debug( "/" ) + cc::warn( bIsSSL ? "HTTPS" : "HTTP" ) +
-                cc::error( " server: " ) + cc::warn( ex.what() ) );
-    } catch ( ... ) {
-        logTraceServerEvent( false, ipVer, bIsSSL ? "HTTPS" : "HTTP", nServerIndex, esm,
-            cc::fatal( "FAILED" ) + cc::error( " to start " ) + cc::attention( "mini" ) +
-                cc::debug( "/" ) + cc::warn( bIsSSL ? "HTTPS" : "HTTP" ) +
-                cc::error( " server: " ) + cc::warn( "unknown exception" ) );
-    }
-    try {
-        implStopListening( pSrv, ipVer, bIsSSL, esm );
-    } catch ( ... ) {
-    }
-    return false;
-}
-*/
+
 
 bool SkaleServerOverride::implStartListening(  // web socket
     std::shared_ptr< SkaleRelayWS >& pSrv, int ipVer, const std::string& strAddr, int nPort,
@@ -2821,43 +2657,6 @@ bool SkaleServerOverride::implStartListening(  // proxygen HTTP
     return false;
 }
 
-/*
-bool SkaleServerOverride::implStopListening(  // mini HTTP
-    std::shared_ptr< SkaleRelayMiniHTTP >& pSrv, int ipVer, bool bIsSSL, e_server_mode_t esm ) {
-    try {
-        if ( !pSrv )
-            return true;
-        const net_bind_opts_t& bo = ( esm == e_server_mode_t::esm_standard ) ?
-                                        opts_.netOpts_.bindOptsStandard_ :
-                                        opts_.netOpts_.bindOptsInformational_;
-        int nServerIndex = pSrv->serverIndex();
-        std::string strAddr = ( ipVer == 4 ) ?
-                                  ( bIsSSL ? bo.strAddrMiniHTTPS4_ : bo.strAddrMiniHTTP4_ ) :
-                                  ( bIsSSL ? bo.strAddrMiniHTTPS6_ : bo.strAddrMiniHTTP6_ );
-        int nPort =
-            ( ( ipVer == 4 ) ? ( bIsSSL ? bo.nBasePortMiniHTTPS4_ : bo.nBasePortMiniHTTP4_ ) :
-                               ( bIsSSL ? bo.nBasePortMiniHTTPS6_ : bo.nBasePortMiniHTTP6_ ) ) +
-            nServerIndex;
-        logTraceServerEvent( false, ipVer, bIsSSL ? "HTTPS" : "HTTP", nServerIndex, esm,
-            cc::notice( "Will stop " ) + cc::attention( "mini" ) + cc::debug( "/" ) +
-                cc::info( bIsSSL ? "HTTPS" : "HTTP" ) + cc::notice( " server on address " ) +
-                cc::info( strAddr ) + cc::success( " and port " ) + cc::c( nPort ) +
-                cc::debug( "/" ) + cc::notice( esm2str( esm ) ) + cc::notice( "..." ) );
-        if ( pSrv->m_pServer && pSrv->m_pServer->is_running() ) {
-            pSrv->m_pServer->stop();
-            stats::register_stats_message( bIsSSL ? "HTTPS" : "HTTP", "STOP" );
-        }
-        pSrv.reset();
-        logTraceServerEvent( false, ipVer, bIsSSL ? "HTTPS" : "HTTP", nServerIndex, esm,
-            cc::success( "OK, stopped " ) + cc::attention( "mini" ) + cc::debug( "/" ) +
-                cc::info( bIsSSL ? "HTTPS" : "HTTP" ) + cc::success( " server on address " ) +
-                cc::info( strAddr ) + cc::success( " and port " ) + cc::c( nPort ) +
-                cc::debug( "/" ) + cc::notice( esm2str( esm ) ) );
-    } catch ( ... ) {
-    }
-    return true;
-}
-*/
 
 bool SkaleServerOverride::implStopListening(  // web socket
     std::shared_ptr< SkaleRelayWS >& pSrv, int ipVer, bool bIsSSL, e_server_mode_t esm ) {
@@ -2931,78 +2730,7 @@ bool SkaleServerOverride::StartListening( e_server_mode_t esm ) {
                                     opts_.netOpts_.bindOptsStandard_ :
                                     opts_.netOpts_.bindOptsInformational_;
     size_t nServerIndex;
-    //
-    //
-    //    std::list< std::shared_ptr< SkaleRelayMiniHTTP > >& serversMiniHTTP4 =
-    //        ( esm == e_server_mode_t::esm_standard ) ? serversMiniHTTP4std_ :
-    //        serversMiniHTTP4nfo_;
-    //    if ( 0 <= bo.nBasePortMiniHTTP4_ && bo.nBasePortMiniHTTP4_ <= 65535 ) {
-    //        for ( nServerIndex = 0; nServerIndex < bo.cntServers_; ++nServerIndex ) {
-    //            std::shared_ptr< SkaleRelayMiniHTTP > pServer;
-    //            if ( !implStartListening(  // mini HTTP
-    //                     pServer, 4, bo.strAddrMiniHTTP4_, bo.nBasePortMiniHTTP4_ + nServerIndex,
-    //                     "",
-    //                     "", "", nServerIndex, esm, max_http_handler_queues_,
-    //                     is_async_http_transfer_mode_ ) )
-    //                return false;
-    //            serversMiniHTTP4.push_back( pServer );
-    //        }
-    //    }
-    //    std::list< std::shared_ptr< SkaleRelayMiniHTTP > >& serversMiniHTTP6 =
-    //        ( esm == e_server_mode_t::esm_standard ) ? serversMiniHTTP6std_ :
-    //        serversMiniHTTP6nfo_;
-    //    if ( 0 <= bo.nBasePortMiniHTTP6_ && bo.nBasePortMiniHTTP6_ <= 65535 ) {
-    //        for ( nServerIndex = 0; nServerIndex < bo.cntServers_; ++nServerIndex ) {
-    //            std::shared_ptr< SkaleRelayMiniHTTP > pServer;
-    //            if ( !implStartListening(  // mini HTTP
-    //                     pServer, 6, bo.strAddrMiniHTTP6_, bo.nBasePortMiniHTTP6_ + nServerIndex,
-    //                     "",
-    //                     "", "", nServerIndex, esm, max_http_handler_queues_,
-    //                     is_async_http_transfer_mode_ ) )
-    //                return false;
-    //            serversMiniHTTP6.push_back( pServer );
-    //        }
-    //    }
-    //    std::list< std::shared_ptr< SkaleRelayMiniHTTP > >& serversMiniHTTPS4 =
-    //        ( esm == e_server_mode_t::esm_standard ) ? serversMiniHTTPS4std_ :
-    //        serversMiniHTTPS4nfo_;
-    //    if ( 0 <= bo.nBasePortMiniHTTPS4_ && bo.nBasePortMiniHTTPS4_ <= 65535 &&
-    //         ( !opts_.netOpts_.strPathSslKey_.empty() ) &&
-    //         ( !opts_.netOpts_.strPathSslCert_.empty() ) &&
-    //         bo.nBasePortMiniHTTPS4_ != bo.nBasePortMiniHTTP4_ ) {
-    //        for ( nServerIndex = 0; nServerIndex < bo.cntServers_; ++nServerIndex ) {
-    //            std::shared_ptr< SkaleRelayMiniHTTP > pServer;
-    //            if ( !implStartListening(  // mini HTTP
-    //                     pServer, 4, bo.strAddrMiniHTTPS4_, bo.nBasePortMiniHTTPS4_ +
-    //                     nServerIndex, opts_.netOpts_.strPathSslKey_,
-    //                     opts_.netOpts_.strPathSslCert_, opts_.netOpts_.strPathSslCA_,
-    //                     nServerIndex, esm, max_http_handler_queues_, is_async_http_transfer_mode_
-    //                     ) )
-    //                return false;
-    //            serversMiniHTTPS4.push_back( pServer );
-    //        }
-    //    }
-    //    std::list< std::shared_ptr< SkaleRelayMiniHTTP > >& serversMiniHTTPS6 =
-    //        ( esm == e_server_mode_t::esm_standard ) ? serversMiniHTTPS6std_ :
-    //        serversMiniHTTPS6nfo_;
-    //    if ( 0 <= bo.nBasePortMiniHTTPS6_ && bo.nBasePortMiniHTTPS6_ <= 65535 &&
-    //         ( !opts_.netOpts_.strPathSslKey_.empty() ) &&
-    //         ( !opts_.netOpts_.strPathSslCert_.empty() ) &&
-    //         bo.nBasePortMiniHTTPS6_ != bo.nBasePortMiniHTTP6_ ) {
-    //        for ( nServerIndex = 0; nServerIndex < bo.cntServers_; ++nServerIndex ) {
-    //            std::shared_ptr< SkaleRelayMiniHTTP > pServer;
-    //            if ( !implStartListening(  // mini HTTP
-    //                     pServer, 6, bo.strAddrMiniHTTPS6_, bo.nBasePortMiniHTTPS6_ +
-    //                     nServerIndex, opts_.netOpts_.strPathSslKey_,
-    //                     opts_.netOpts_.strPathSslCert_, opts_.netOpts_.strPathSslCA_,
-    //                     nServerIndex, esm, max_http_handler_queues_, is_async_http_transfer_mode_
-    //                     ) )
-    //                return false;
-    //            serversMiniHTTPS6.push_back( pServer );
-    //        }
-    //    }
-    //
-    //
+
     std::list< std::shared_ptr< SkaleRelayWS > >& serversWS4 =
         ( esm == e_server_mode_t::esm_standard ) ? serversWS4std_ : serversWS4nfo_;
     if ( 0 <= bo.nBasePortWS4_ && bo.nBasePortWS4_ <= 65535 &&
@@ -3183,9 +2911,6 @@ bool SkaleServerOverride::StartListening() {
                 skutils::url u( strOrigin );
                 std::string strSchemeUC =
                     skutils::tools::to_upper( skutils::tools::trim_copy( u.scheme() ) );
-                // std::string strAddress = skutils::tools::to_upper( skutils::tools::trim_copy(
-                // u.host() ) ); int ipVer = ( skutils::is_ipv6( strClientAddress ) &&
-                // skutils::is_valid_ipv6( strClientAddress ) ) ? 6 : 4;
                 std::string strPort = skutils::tools::trim_copy( u.port() );
                 int nPort = 0;
                 if ( strPort.empty() ) {
@@ -3221,44 +2946,7 @@ bool SkaleServerOverride::StopListening( e_server_mode_t esm ) {
         skutils::http_pg::pg_stop( hProxygenServer_ );
         hProxygenServer_ = nullptr;
     }
-    //
-    //
-    //
-    //
-    //    std::list< std::shared_ptr< SkaleRelayMiniHTTP > >& serversMiniHTTP4 =
-    //        ( esm == e_server_mode_t::esm_standard ) ? serversMiniHTTP4std_ :
-    //        serversMiniHTTP4nfo_;
-    //    for ( auto pServer : serversMiniHTTP4 ) {
-    //        if ( !implStopListening( pServer, 4, false, esm ) )
-    //            bRetVal = false;
-    //    }
-    //    serversMiniHTTP4.clear();
-    //    std::list< std::shared_ptr< SkaleRelayMiniHTTP > >& serversMiniHTTP6 =
-    //        ( esm == e_server_mode_t::esm_standard ) ? serversMiniHTTP6std_ :
-    //        serversMiniHTTP6nfo_;
-    //    for ( auto pServer : serversMiniHTTP6 ) {
-    //        if ( !implStopListening( pServer, 6, false, esm ) )
-    //            bRetVal = false;
-    //    }
-    //    serversMiniHTTP6.clear();
-    //    std::list< std::shared_ptr< SkaleRelayMiniHTTP > >& serversMiniHTTPS4 =
-    //        ( esm == e_server_mode_t::esm_standard ) ? serversMiniHTTPS4std_ :
-    //        serversMiniHTTPS4nfo_;
-    //    for ( auto pServer : serversMiniHTTPS4 ) {
-    //        if ( !implStopListening( pServer, 4, true, esm ) )
-    //            bRetVal = false;
-    //    }
-    //    serversMiniHTTPS4.clear();
-    //    std::list< std::shared_ptr< SkaleRelayMiniHTTP > >& serversMiniHTTPS6 =
-    //        ( esm == e_server_mode_t::esm_standard ) ? serversMiniHTTPS6std_ :
-    //        serversMiniHTTPS6nfo_;
-    //    for ( auto pServer : serversMiniHTTPS6 ) {
-    //        if ( !implStopListening( pServer, 6, true, esm ) )
-    //            bRetVal = false;
-    //    }
-    //    serversMiniHTTPS6.clear();
-    //
-    //
+
     std::list< std::shared_ptr< SkaleRelayWS > >& serversWS4 =
         ( esm == e_server_mode_t::esm_standard ) ? serversWS4std_ : serversWS4nfo_;
     for ( auto pServer : serversWS4 ) {
@@ -3321,8 +3009,6 @@ bool SkaleServerOverride::StopListening( e_server_mode_t esm ) {
             bRetVal = false;
     }
     serversProxygenHTTPS6.clear();
-    //
-    //
     return bRetVal;
 }
 bool SkaleServerOverride::StopListening() {
@@ -3333,38 +3019,7 @@ bool SkaleServerOverride::StopListening() {
     return b;
 }
 
-/*
-int SkaleServerOverride::getServerPortStatusMiniHTTP( int ipVer, e_server_mode_t esm ) const {
-    const net_bind_opts_t& bo = ( esm == e_server_mode_t::esm_standard ) ?
-                                    opts_.netOpts_.bindOptsStandard_ :
-                                    opts_.netOpts_.bindOptsInformational_;
-    const std::list< std::shared_ptr< SkaleRelayMiniHTTP > >& serversMiniHTTP4 =
-        ( esm == e_server_mode_t::esm_standard ) ? serversMiniHTTP4std_ : serversMiniHTTP4nfo_;
-    const std::list< std::shared_ptr< SkaleRelayMiniHTTP > >& serversMiniHTTP6 =
-        ( esm == e_server_mode_t::esm_standard ) ? serversMiniHTTP6std_ : serversMiniHTTP6nfo_;
-    for ( auto pServer : ( ( ipVer == 4 ) ? serversMiniHTTP4 : serversMiniHTTP6 ) ) {
-        if ( pServer && pServer->m_pServer && pServer->m_pServer->is_running() )
-            return ( ( ipVer == 4 ) ? bo.nBasePortMiniHTTP4_ : bo.nBasePortMiniHTTP6_ ) +
-                   pServer->serverIndex();
-    }
-    return -1;
-}
-int SkaleServerOverride::getServerPortStatusMiniHTTPS( int ipVer, e_server_mode_t esm ) const {
-    const net_bind_opts_t& bo = ( esm == e_server_mode_t::esm_standard ) ?
-                                    opts_.netOpts_.bindOptsStandard_ :
-                                    opts_.netOpts_.bindOptsInformational_;
-    const std::list< std::shared_ptr< SkaleRelayMiniHTTP > >& serversMiniHTTPS4 =
-        ( esm == e_server_mode_t::esm_standard ) ? serversMiniHTTPS4std_ : serversMiniHTTPS4nfo_;
-    const std::list< std::shared_ptr< SkaleRelayMiniHTTP > >& serversMiniHTTPS6 =
-        ( esm == e_server_mode_t::esm_standard ) ? serversMiniHTTPS6std_ : serversMiniHTTPS6nfo_;
-    for ( auto pServer : ( ( ipVer == 4 ) ? serversMiniHTTPS4 : serversMiniHTTPS6 ) ) {
-        if ( pServer && pServer->m_pServer && pServer->m_pServer->is_running() )
-            return ( ( ipVer == 4 ) ? bo.nBasePortMiniHTTPS4_ : bo.nBasePortMiniHTTPS6_ ) +
-                   pServer->serverIndex();
-    }
-    return -1;
-}
-*/
+
 
 int SkaleServerOverride::getServerPortStatusWS( int ipVer, e_server_mode_t esm ) const {
     const net_bind_opts_t& bo = ( esm == e_server_mode_t::esm_standard ) ?
@@ -3484,13 +3139,9 @@ nlohmann::json SkaleServerOverride::provideSkaleStats() {  // abstract from
         skutils::stats::time_tracker::queue::getQueueForSubsystem( "RPC" ).getAllStats();
     joStats["executionPerformance"] = joExecutionPerformance;
     joStats["protocols"]["http"]["listenerCount"] =
-        // serversMiniHTTP4std_.size() + serversMiniHTTP4nfo_.size() +
-        // serversMiniHTTP6std_.size() + serversMiniHTTP6nfo_.size() +
         serversProxygenHTTP4std_.size() + serversProxygenHTTP4nfo_.size() +
         serversProxygenHTTP6std_.size() + serversProxygenHTTP6nfo_.size();
     joStats["protocols"]["https"]["listenerCount"] =
-        // serversMiniHTTPS4std_.size() + serversMiniHTTPS4nfo_.size() +
-        // serversMiniHTTPS6std_.size() + serversMiniHTTPS6nfo_.size() +
         serversProxygenHTTPS4std_.size() + serversProxygenHTTPS4nfo_.size() +
         serversProxygenHTTPS6std_.size() + serversProxygenHTTPS6nfo_.size();
     joStats["protocols"]["wss"]["listenerCount"] = serversWSS4std_.size() + serversWSS4nfo_.size() +
@@ -3656,10 +3307,6 @@ bool SkaleServerOverride::handleRequestWithBinaryAnswer(
     buffer.clear();
     std::string strMethodName = skutils::tools::getFieldSafe< std::string >( joRequest, "method" );
     if ( strMethodName == "skale_downloadSnapshotFragment" && opts_.fn_binary_snapshot_download_ ) {
-        //        std::cout << cc::attention( "------------ " )
-        //                  << cc::info( "skale_downloadSnapshotFragment" ) << cc::normal( " call
-        //                  with " )
-        //                  << cc::j( joRequest ) << "\n";
         const nlohmann::json& joParams = joRequest["params"];
         if ( joParams.count( "isBinary" ) > 0 ) {
             bool isBinary = joParams["isBinary"].get< bool >();
@@ -3674,9 +3321,6 @@ bool SkaleServerOverride::handleRequestWithBinaryAnswer(
 
 bool SkaleServerOverride::handleAdminOriginFilter(
     const std::string& strMethod, const std::string& strOriginURL ) {
-    // std::cout << cc::attention( "------------ " ) << cc::info( strOriginURL ) <<
-    // cc::attention( "
-    // ------------> " ) << cc::info( strMethod ) << "\n";
     static const std::set< std::string > g_setAdminMethods = { "skale_getSnapshot",
         "skale_downloadSnapshotFragment" };
     if ( g_setAdminMethods.find( strMethod ) == g_setAdminMethods.end() )
@@ -3692,8 +3336,6 @@ bool SkaleServerOverride::handleAdminOriginFilter(
     return true;
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 bool SkaleServerOverride::handleProtocolSpecificRequest( const std::string& strOrigin,
     const rapidjson::Document& joRequest, rapidjson::Document& joResponse ) {
@@ -3716,8 +3358,6 @@ const SkaleServerOverride::protocol_rpc_map_t SkaleServerOverride::g_protocol_rp
     { "eth_getCode", &SkaleServerOverride::eth_getCode }
 };
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void SkaleServerOverride::setSchainExitTime( const std::string& strOrigin,
     const rapidjson::Document& joRequest, rapidjson::Document& joResponse ) {
@@ -3896,10 +3536,7 @@ bool SkaleServerOverride::handleHttpSpecificRequest( const std::string& strOrigi
     d.SetObject();
     joResponse.AddMember( "result", d, joResponse.GetAllocator() );
 
-    //    rapidjson::StringBuffer buffer;
-    //    rapidjson::Writer< rapidjson::StringBuffer > writer( buffer );
-    //    joRequest.Accept( writer );
-    //    std::string strRequest = buffer.GetString();
+
 
     rapidjson::StringBuffer bufferResponse;
     rapidjson::Writer< rapidjson::StringBuffer > writerResponse( bufferResponse );
@@ -4021,5 +3658,3 @@ void SkaleServerOverride::stat_transformJsonForLogOutput( nlohmann::json& jo, bo
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/libskale/httpserveroverride.cpp
+++ b/libskale/httpserveroverride.cpp
@@ -268,7 +268,6 @@ bool checkParamsIsObject( const char* strMethodName, const rapidjson::Document& 
 };  // namespace skale
 
 
-
 namespace stats {
 
 typedef skutils::multithreading::recursive_mutex_type mutex_type_stats;
@@ -1981,7 +1980,6 @@ dev::eth::Interface* SkaleRelayWS::ethereum() const {
 }
 
 
-
 SkaleRelayProxygenHTTP::SkaleRelayProxygenHTTP( SkaleServerOverride* pSO, int ipVer,
     const char* strBindAddr, int nPort, const char* cert_path, const char* private_key_path,
     const char* ca_path, int nServerIndex, e_server_mode_t esm, int32_t threads,
@@ -2548,7 +2546,6 @@ skutils::result_of_http_request SkaleServerOverride::implHandleHttpRequest(
 }
 
 
-
 bool SkaleServerOverride::implStartListening(  // web socket
     std::shared_ptr< SkaleRelayWS >& pSrv, int ipVer, const std::string& strAddr, int nPort,
     const std::string& strPathSslKey, const std::string& strPathSslCert,
@@ -3018,7 +3015,6 @@ bool SkaleServerOverride::StopListening() {
     bool b = ( b1 && b2 ) ? true : false;
     return b;
 }
-
 
 
 int SkaleServerOverride::getServerPortStatusWS( int ipVer, e_server_mode_t esm ) const {
@@ -3537,7 +3533,6 @@ bool SkaleServerOverride::handleHttpSpecificRequest( const std::string& strOrigi
     joResponse.AddMember( "result", d, joResponse.GetAllocator() );
 
 
-
     rapidjson::StringBuffer bufferResponse;
     rapidjson::Writer< rapidjson::StringBuffer > writerResponse( bufferResponse );
     joResponse.Accept( writerResponse );
@@ -3657,4 +3652,3 @@ void SkaleServerOverride::stat_transformJsonForLogOutput( nlohmann::json& jo, bo
         }
     }
 }
-

--- a/libskale/httpserveroverride.cpp
+++ b/libskale/httpserveroverride.cpp
@@ -2308,31 +2308,6 @@ string hostname_to_ip( string hostname ) {
 }
 
 
-#ifdef HISTORIC_STATE
-// geth accepts no tracer  parameter instead of empty object parameter in trace calls
-// we add empty object if no tracer  parameter is present
-void SkaleServerOverride::preprocessTraceRequestIfNeeded(
-    const string& methodName, nlohmann::json& jsonRpcRequest ) {
-    if ( methodName.find( "debug_trace" ) != 0 ) {
-        // not a debug trace call
-        return;
-    }
-
-    if ( jsonRpcRequest.count( "params" ) == 0 || !jsonRpcRequest["params"].is_array() ) {
-        return;
-    }
-
-    static std::unordered_set< std::string > traceMethodNames = { "debug_traceTransaction",
-        "debug_traceBlockByNumber", "debug_traceBlockByHash" };
-
-
-    if ( traceMethodNames.count( methodName ) > 0 && jsonRpcRequest["params"].size() == 1 ) {
-        // tracer parameter missing at the end of params array, add empty object parameter
-        jsonRpcRequest["params"].push_back( nlohmann::json::object() );
-    }
-}
-#endif
-
 skutils::result_of_http_request SkaleServerOverride::implHandleHttpRequest(
     const nlohmann::json& joIn, const std::string& strProtocol, int nServerIndex,
     std::string strOrigin, int ipVer, int nPort, e_server_mode_t esm ) {
@@ -2355,10 +2330,6 @@ skutils::result_of_http_request SkaleServerOverride::implHandleHttpRequest(
                 skutils::tools::getFieldSafe< std::string >( jsonRpcRequest, "method" );
             if ( methodName.empty() )
                 throw std::runtime_error( "Bad JSON RPC request, \"method\" name is missing" );
-
-#ifdef HISTORIC_STATE
-            preprocessTraceRequestIfNeeded( methodName, jsonRpcRequest );
-#endif
 
             strMethod = methodName;
             if ( jsonRpcRequest.count( "id" ) == 0 )

--- a/libskale/httpserveroverride.cpp
+++ b/libskale/httpserveroverride.cpp
@@ -2313,7 +2313,7 @@ string hostname_to_ip( string hostname ) {
 // we add empty object if no tracer  parameter is present
 void SkaleServerOverride::preprocessTraceRequestIfNeeded(
     const string& methodName, nlohmann::json& jsonRpcRequest ) {
-    if ( methodName.find( "debug_trace" ) == string::npos ) {
+    if ( methodName.find( "debug_trace" ) != 0 ) {
         // not a debug trace call
         return;
     }

--- a/libskale/httpserveroverride.h
+++ b/libskale/httpserveroverride.h
@@ -419,11 +419,6 @@ public:
     dev::Verbosity methodTraceVerbosity( const std::string& strMethod ) const;
     bool checkAdminOriginAllowed( const std::string& origin ) const;
 
-#ifdef HISTORIC_STATE
-    void preprocessTraceRequestIfNeeded(
-        const std::string& methodName, nlohmann::json& jsonRpcRequest );
-#endif
-
 protected:
     skutils::result_of_http_request implHandleHttpRequest( const nlohmann::json& joIn,
         const std::string& strProtocol, int nServerIndex, std::string strOrigin, int ipVer,

--- a/libskale/httpserveroverride.h
+++ b/libskale/httpserveroverride.h
@@ -120,7 +120,6 @@ public:
 };  // class SkaleStatsSubscriptionManager
 
 
-
 struct SkaleServerConnectionsTrackHelper {
     SkaleServerOverride& m_sso;
     SkaleServerConnectionsTrackHelper( SkaleServerOverride& sso );
@@ -255,7 +254,6 @@ public:
 
     friend class SkaleWsPeer;
 };  /// class SkaleRelayWS
-
 
 
 class SkaleRelayProxygenHTTP : public SkaleServerHelper {
@@ -432,7 +430,6 @@ protected:
         int nPort, e_server_mode_t esm );
 
 private:
-
     bool implStartListening(  // web socket
         std::shared_ptr< SkaleRelayWS >& pSrv, int ipVer, const std::string& strAddr, int nPort,
         const std::string& strPathSslKey, const std::string& strPathSslCert,
@@ -478,7 +475,6 @@ public:
     std::atomic_bool m_bShutdownMode = false;
 
 private:
-
     std::list< std::shared_ptr< SkaleRelayWS > > serversWS4std_, serversWS6std_, serversWSS4std_,
         serversWSS6std_, serversWS4nfo_, serversWS6nfo_, serversWSS4nfo_, serversWSS6nfo_;
     std::list< std::shared_ptr< SkaleRelayProxygenHTTP > > serversProxygenHTTP4std_,
@@ -525,9 +521,7 @@ public:
         e_server_mode_t esm, const nlohmann::json& joRequest, std::vector< uint8_t >& buffer );
     bool handleAdminOriginFilter( const std::string& strMethod, const std::string& strOriginURL );
 
-    bool isShutdownMode() const {
-        return m_bShutdownMode;
-    }
+    bool isShutdownMode() const { return m_bShutdownMode; }
 
     bool handleProtocolSpecificRequest( const std::string& strOrigin,
         const rapidjson::Document& joRequest, rapidjson::Document& joResponse );

--- a/libskale/httpserveroverride.h
+++ b/libskale/httpserveroverride.h
@@ -82,15 +82,11 @@ class SkaleWsPeer;
 class SkaleRelayWS;
 class SkaleServerOverride;
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 enum class e_server_mode_t { esm_standard, esm_informational };
 
 extern const char* esm2str( e_server_mode_t esm );
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 class SkaleStatsSubscriptionManager {
 public:
@@ -123,8 +119,7 @@ public:
     virtual SkaleServerOverride& getSSO() = 0;
 };  // class SkaleStatsSubscriptionManager
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 
 struct SkaleServerConnectionsTrackHelper {
     SkaleServerOverride& m_sso;
@@ -132,8 +127,6 @@ struct SkaleServerConnectionsTrackHelper {
     ~SkaleServerConnectionsTrackHelper();
 };  /// struct SkaleServerConnectionsTrackHelper
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 class SkaleWsPeer : public skutils::ws::peer {
 public:
@@ -206,8 +199,6 @@ public:
     std::string implPreformatTrafficJsonMessage( const nlohmann::json& jo, bool isRequest ) const;
 };  /// class SkaleWsPeer
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 class SkaleServerHelper {
 protected:
@@ -219,8 +210,6 @@ public:
     int serverIndex() const { return m_nServerIndex; }
 };  /// class SkaleServerHelper
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 class SkaleRelayWS : public skutils::ws::server, public SkaleServerHelper {
 protected:
@@ -267,36 +256,11 @@ public:
     friend class SkaleWsPeer;
 };  /// class SkaleRelayWS
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-/*
-class SkaleRelayMiniHTTP : public SkaleServerHelper {
-protected:
-    SkaleServerOverride* m_pSO = nullptr;
 
-public:
-    int ipVer_;
-    std::string strBindAddr_;
-    int nPort_;
-    const bool m_bHelperIsSSL : 1;
-    std::shared_ptr< skutils::http::server > m_pServer;
-    SkaleRelayMiniHTTP( SkaleServerOverride* pSO, int ipVer, const char* strBindAddr, int nPort,
-        const char* cert_path = nullptr, const char* private_key_path = nullptr,
-        const char* ca_path = nullptr, int nServerIndex = -1,
-        size_t a_max_http_handler_queues = __SKUTILS_HTTP_DEFAULT_MAX_PARALLEL_QUEUES_COUNT__,
-        bool is_async_http_transfer_mode = true );
-    ~SkaleRelayMiniHTTP() override;
-    SkaleServerOverride* pso() { return m_pSO; }
-    const SkaleServerOverride* pso() const { return m_pSO; }
-};  /// class SkaleRelayMiniHTTP
-*/
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 class SkaleRelayProxygenHTTP : public SkaleServerHelper {
 protected:
     SkaleServerOverride* m_pSO = nullptr;
-    // skutils::http_pg::wrapped_proxygen_server_handle hProxygenServer_ = nullptr;
 
 public:
     int ipVer_;
@@ -317,8 +281,6 @@ public:
     void stop();
 };  /// class SkaleRelayProxygenHTTP
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 class SkaleServerOverride : public jsonrpc::AbstractServerConnector,
                             public SkaleStatsSubscriptionManager,
@@ -459,18 +421,18 @@ public:
     dev::Verbosity methodTraceVerbosity( const std::string& strMethod ) const;
     bool checkAdminOriginAllowed( const std::string& origin ) const;
 
+#ifdef HISTORIC_STATE
+    void preprocessTraceRequestIfNeeded(
+        const std::string& methodName, nlohmann::json& jsonRpcRequest );
+#endif
+
 protected:
     skutils::result_of_http_request implHandleHttpRequest( const nlohmann::json& joIn,
         const std::string& strProtocol, int nServerIndex, std::string strOrigin, int ipVer,
         int nPort, e_server_mode_t esm );
 
 private:
-    //    bool implStartListening(  // mini HTTP
-    //        std::shared_ptr< SkaleRelayMiniHTTP >& pSrv, int ipVer, const std::string& strAddr,
-    //        int nPort, const std::string& strPathSslKey, const std::string& strPathSslCert,
-    //        const std::string& strPathSslCA, int nServerIndex, e_server_mode_t esm,
-    //        size_t a_max_http_handler_queues = __SKUTILS_HTTP_DEFAULT_MAX_PARALLEL_QUEUES_COUNT__,
-    //        bool is_async_http_transfer_mode = true );
+
     bool implStartListening(  // web socket
         std::shared_ptr< SkaleRelayWS >& pSrv, int ipVer, const std::string& strAddr, int nPort,
         const std::string& strPathSslKey, const std::string& strPathSslCert,
@@ -481,9 +443,6 @@ private:
         const std::string& strPathSslCA, int nServerIndex, e_server_mode_t esm, int32_t threads = 0,
         int32_t threads_limit = 0 );
 
-    //    bool implStopListening(  // mini HTTP
-    //        std::shared_ptr< SkaleRelayMiniHTTP >& pSrv, int ipVer, bool bIsSSL, e_server_mode_t
-    //        esm );
     bool implStopListening(  // web socket
         std::shared_ptr< SkaleRelayWS >& pSrv, int ipVer, bool bIsSSL, e_server_mode_t esm );
     bool implStopListening(  // proxygen HTTP
@@ -519,10 +478,7 @@ public:
     std::atomic_bool m_bShutdownMode = false;
 
 private:
-    //    std::list< std::shared_ptr< SkaleRelayMiniHTTP > > serversMiniHTTP4std_,
-    //    serversMiniHTTP6std_,
-    //        serversMiniHTTPS4std_, serversMiniHTTPS6std_, serversMiniHTTP4nfo_,
-    //        serversMiniHTTP6nfo_, serversMiniHTTPS4nfo_, serversMiniHTTPS6nfo_;
+
     std::list< std::shared_ptr< SkaleRelayWS > > serversWS4std_, serversWS6std_, serversWSS4std_,
         serversWSS6std_, serversWS4nfo_, serversWS6nfo_, serversWSS4nfo_, serversWSS6nfo_;
     std::list< std::shared_ptr< SkaleRelayProxygenHTTP > > serversProxygenHTTP4std_,
@@ -535,9 +491,6 @@ private:
         const std::string& strDstAddress, int nDstPort, e_server_mode_t& esm );
 
 public:
-    // status API, returns running server port or -1 if server is not started
-    //    int getServerPortStatusMiniHTTP( int ipVer, e_server_mode_t esm ) const;
-    //    int getServerPortStatusMiniHTTPS( int ipVer, e_server_mode_t esm ) const;
     int getServerPortStatusWS( int ipVer, e_server_mode_t esm ) const;
     int getServerPortStatusWSS( int ipVer, e_server_mode_t esm ) const;
     int getServerPortStatusProxygenHTTP( int ipVer, e_server_mode_t esm ) const;
@@ -572,7 +525,9 @@ public:
         e_server_mode_t esm, const nlohmann::json& joRequest, std::vector< uint8_t >& buffer );
     bool handleAdminOriginFilter( const std::string& strMethod, const std::string& strOriginURL );
 
-    bool isShutdownMode() const { return m_bShutdownMode; }
+    bool isShutdownMode() const {
+        return m_bShutdownMode;
+    }
 
     bool handleProtocolSpecificRequest( const std::string& strOrigin,
         const rapidjson::Document& joRequest, rapidjson::Document& joResponse );
@@ -631,13 +586,10 @@ public:
         size_t nMaxStringValueLengthForJsonLogs, size_t nMaxStringValueLengthForTransactionParams,
         size_t nCallIndent = 0 );
 
-    // friend class SkaleRelayMiniHTTP;
     friend class SkaleRelayProxygenHTTP;
     friend class SkaleRelayWS;
     friend class SkaleWsPeer;
 };  /// class SkaleServerOverride
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #endif  ///(!defined __HTTP_SERVER_OVERRIDE_H)

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -12,7 +12,10 @@
 #include <libethereum/Client.h>
 #include <skutils/eth_utils.h>
 
+
+
 #ifdef HISTORIC_STATE
+
 #include <libhistoric/AlethExecutive.h>
 #include <libhistoric/AlethStandardTrace.h>
 #endif

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -13,7 +13,6 @@
 #include <skutils/eth_utils.h>
 
 
-
 #ifdef HISTORIC_STATE
 
 #include <libhistoric/AlethExecutive.h>

--- a/libweb3jsonrpc/DebugFace.h
+++ b/libweb3jsonrpc/DebugFace.h
@@ -6,6 +6,7 @@
 #define JSONRPC_CPP_STUB_DEV_RPC_DEBUGFACE_H_
 
 #include "ModularServer.h"
+#include "boost/throw_exception.hpp"
 
 namespace dev {
 namespace rpc {
@@ -17,9 +18,11 @@ public:
                                     jsonrpc::JSON_STRING, "param2", jsonrpc::JSON_INTEGER, "param3",
                                     jsonrpc::JSON_STRING, "param4", jsonrpc::JSON_INTEGER, NULL ),
             &dev::rpc::DebugFace::debug_accountRangeAtI );
-        this->bindAndAddMethod( jsonrpc::Procedure( "debug_traceTransaction",
-                                    jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",
-                                    jsonrpc::JSON_STRING, "param2", jsonrpc::JSON_OBJECT, NULL ),
+
+
+        this->bindAndAddMethod(
+            jsonrpc::Procedure( "debug_traceTransaction", jsonrpc::PARAMS_BY_POSITION,
+                jsonrpc::JSON_OBJECT, NULL ),
             &dev::rpc::DebugFace::debug_traceTransactionI );
         this->bindAndAddMethod(
             jsonrpc::Procedure( "debug_storageRangeAt", jsonrpc::PARAMS_BY_POSITION,
@@ -30,13 +33,13 @@ public:
         this->bindAndAddMethod( jsonrpc::Procedure( "debug_preimage", jsonrpc::PARAMS_BY_POSITION,
                                     jsonrpc::JSON_OBJECT, "param1", jsonrpc::JSON_STRING, NULL ),
             &dev::rpc::DebugFace::debug_preimageI );
-        this->bindAndAddMethod( jsonrpc::Procedure( "debug_traceBlockByNumber",
-                                    jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",
-                                    jsonrpc::JSON_STRING, "param2", jsonrpc::JSON_OBJECT, NULL ),
+        this->bindAndAddMethod(
+            jsonrpc::Procedure( "debug_traceBlockByNumber", jsonrpc::PARAMS_BY_POSITION,
+                jsonrpc::JSON_OBJECT, NULL ),
             &dev::rpc::DebugFace::debug_traceBlockByNumberI );
-        this->bindAndAddMethod( jsonrpc::Procedure( "debug_traceBlockByHash",
-                                    jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",
-                                    jsonrpc::JSON_STRING, "param2", jsonrpc::JSON_OBJECT, NULL ),
+        this->bindAndAddMethod(
+            jsonrpc::Procedure( "debug_traceBlockByHash", jsonrpc::PARAMS_BY_POSITION,
+                jsonrpc::JSON_OBJECT, NULL ),
             &dev::rpc::DebugFace::debug_traceBlockByHashI );
         this->bindAndAddMethod( jsonrpc::Procedure( "debug_traceCall", jsonrpc::PARAMS_BY_POSITION,
                                     jsonrpc::JSON_OBJECT, "param1", jsonrpc::JSON_OBJECT, "param2",
@@ -103,10 +106,25 @@ public:
         response = this->debug_accountRangeAt( request[0u].asString(), request[1u].asInt(),
             request[2u].asString(), request[3u].asInt() );
     }
-    inline virtual void debug_traceTransactionI(
-        const Json::Value& request, Json::Value& response ) {
-        response = this->debug_traceTransaction( request[0u].asString(), request[1u] );
+
+    inline virtual Json::Value getTracer( const Json::Value& request ) {
+        if ( !request.isArray() || request.empty() || request.size() > 2 ) {
+            BOOST_THROW_EXCEPTION(
+                jsonrpc::JsonRpcException( jsonrpc::Errors::ERROR_RPC_INVALID_PARAMS ) );
+        }
+        if ( request.size() == 2 ) {
+            if ( !request[1u].isObject() ) {
+                BOOST_THROW_EXCEPTION(
+                    jsonrpc::JsonRpcException( jsonrpc::Errors::ERROR_RPC_INVALID_PARAMS ) );
+            }
+            return request[1u];
+
+        } else {
+            return { Json::objectValue };
+        }
     }
+
+
     inline virtual void debug_storageRangeAtI( const Json::Value& request, Json::Value& response ) {
         response = this->debug_storageRangeAt( request[0u].asString(), request[1u].asInt(),
             request[2u].asString(), request[3u].asString(), request[4u].asInt() );
@@ -114,13 +132,19 @@ public:
     inline virtual void debug_preimageI( const Json::Value& request, Json::Value& response ) {
         response = this->debug_preimage( request[0u].asString() );
     }
+
+    inline virtual void debug_traceTransactionI(
+        const Json::Value& request, Json::Value& response ) {
+        response = this->debug_traceTransaction( request[0u].asString(), getTracer( request ) );
+    }
+
     inline virtual void debug_traceBlockByNumberI(
         const Json::Value& request, Json::Value& response ) {
-        response = this->debug_traceBlockByNumber( request[0u].asString(), request[1u] );
+        response = this->debug_traceBlockByNumber( request[0u].asString(), getTracer( request ) );
     }
     inline virtual void debug_traceBlockByHashI(
         const Json::Value& request, Json::Value& response ) {
-        response = this->debug_traceBlockByHash( request[0u].asString(), request[1u] );
+        response = this->debug_traceBlockByHash( request[0u].asString(), getTracer(request) );
     }
     inline virtual void debug_traceCallI( const Json::Value& request, Json::Value& response ) {
         response = this->debug_traceCall( request[0u], request[1u].asString(), request[2u] );

--- a/libweb3jsonrpc/DebugFace.h
+++ b/libweb3jsonrpc/DebugFace.h
@@ -20,9 +20,8 @@ public:
             &dev::rpc::DebugFace::debug_accountRangeAtI );
 
 
-        this->bindAndAddMethod(
-            jsonrpc::Procedure( "debug_traceTransaction", jsonrpc::PARAMS_BY_POSITION,
-                jsonrpc::JSON_OBJECT, NULL ),
+        this->bindAndAddMethod( jsonrpc::Procedure( "debug_traceTransaction",
+                                    jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, NULL ),
             &dev::rpc::DebugFace::debug_traceTransactionI );
         this->bindAndAddMethod(
             jsonrpc::Procedure( "debug_storageRangeAt", jsonrpc::PARAMS_BY_POSITION,
@@ -33,13 +32,11 @@ public:
         this->bindAndAddMethod( jsonrpc::Procedure( "debug_preimage", jsonrpc::PARAMS_BY_POSITION,
                                     jsonrpc::JSON_OBJECT, "param1", jsonrpc::JSON_STRING, NULL ),
             &dev::rpc::DebugFace::debug_preimageI );
-        this->bindAndAddMethod(
-            jsonrpc::Procedure( "debug_traceBlockByNumber", jsonrpc::PARAMS_BY_POSITION,
-                jsonrpc::JSON_OBJECT, NULL ),
+        this->bindAndAddMethod( jsonrpc::Procedure( "debug_traceBlockByNumber",
+                                    jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, NULL ),
             &dev::rpc::DebugFace::debug_traceBlockByNumberI );
-        this->bindAndAddMethod(
-            jsonrpc::Procedure( "debug_traceBlockByHash", jsonrpc::PARAMS_BY_POSITION,
-                jsonrpc::JSON_OBJECT, NULL ),
+        this->bindAndAddMethod( jsonrpc::Procedure( "debug_traceBlockByHash",
+                                    jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, NULL ),
             &dev::rpc::DebugFace::debug_traceBlockByHashI );
         this->bindAndAddMethod( jsonrpc::Procedure( "debug_traceCall", jsonrpc::PARAMS_BY_POSITION,
                                     jsonrpc::JSON_OBJECT, "param1", jsonrpc::JSON_OBJECT, "param2",
@@ -144,7 +141,7 @@ public:
     }
     inline virtual void debug_traceBlockByHashI(
         const Json::Value& request, Json::Value& response ) {
-        response = this->debug_traceBlockByHash( request[0u].asString(), getTracer(request) );
+        response = this->debug_traceBlockByHash( request[0u].asString(), getTracer( request ) );
     }
     inline virtual void debug_traceCallI( const Json::Value& request, Json::Value& response ) {
         response = this->debug_traceCall( request[0u], request[1u].asString(), request[2u] );

--- a/test/historicstate/hardhat/scripts/trace.ts
+++ b/test/historicstate/hardhat/scripts/trace.ts
@@ -66,6 +66,8 @@ const TEST_CONTRACT_CALL_FOURBYTETRACER_FILE_NAME = TEST_CONTRACT_NAME + "." + C
 const TEST_CONTRACT_CALL_REPLAYTRACER_FILE_NAME = TEST_CONTRACT_NAME + "." + CALL_FUNCTION_NAME + ".replayTracer.json";
 
 var DEPLOYED_CONTRACT_ADDRESS_LOWER_CASE: string = "";
+var globalCallCount = 0;
+
 
 async function replaceAddressesWithSymbolicNames(_traceFileName: string) {
 
@@ -194,7 +196,9 @@ function CHECK(result: any): void {
 async function getBlockTrace(blockNumber: number): Promise<String> {
 
     const blockStr = "0x" + blockNumber.toString(16);
-    const trace = await ethers.provider.send('debug_traceBlockByNumber', [blockStr, {}]);
+    //trace both empty tracer and no tracer
+    let trace = await ethers.provider.send('debug_traceBlockByNumber', [blockStr]);
+    trace = await ethers.provider.send('debug_traceBlockByNumber', [blockStr, {}]);
 
     0// console.log(JSON.stringify(trace, null, 4));
     return trace;
@@ -369,6 +373,7 @@ async function callDebugTraceCall(_deployedContract: any, _tracer: string, _trac
 
 
 async function getAndPrintCommittedTransactionTrace(hash: string, _tracer: string, _skaleFileName: string): Promise<String> {
+    globalCallCount++;
 
     let traceOptions = await getTraceJsonOptions(_tracer);
 
@@ -376,9 +381,15 @@ async function getAndPrintCommittedTransactionTrace(hash: string, _tracer: strin
 
     let trace;
 
+
+
     if (_tracer == DEFAULT_TRACER) {
-        trace = await ethers.provider.send('debug_traceTransaction', [hash]);
-        trace = await ethers.provider.send('debug_traceTransaction', [hash, traceOptions]);
+        // test both empty tracer and now tracer
+        if (globalCallCount % 2 === 0) {
+            trace = await ethers.provider.send('debug_traceTransaction', [hash]);
+        } else {
+            trace = await ethers.provider.send('debug_traceTransaction', [hash, traceOptions]);
+        }
     } else {
         trace = await ethers.provider.send('debug_traceTransaction', [hash, traceOptions]);
     }

--- a/test/historicstate/hardhat/scripts/trace.ts
+++ b/test/historicstate/hardhat/scripts/trace.ts
@@ -373,7 +373,14 @@ async function getAndPrintCommittedTransactionTrace(hash: string, _tracer: strin
 
     console.log("Calling debug_traceTransaction to generate " + _skaleFileName);
 
-    const trace = await ethers.provider.send('debug_traceTransaction', [hash, traceOptions]);
+    let trace;
+
+    if (_tracer == DEFAULT_TRACER) {
+        trace = await ethers.provider.send('debug_traceTransaction', [hash]);
+        trace = await ethers.provider.send('debug_traceTransaction', [hash, traceOptions]);
+    } else {
+        trace = await ethers.provider.send('debug_traceTransaction', [hash, traceOptions]);
+    }
 
     const result = JSON.stringify(trace, null, 4);
 

--- a/test/historicstate/hardhat/scripts/trace.ts
+++ b/test/historicstate/hardhat/scripts/trace.ts
@@ -200,7 +200,6 @@ async function getBlockTrace(blockNumber: number): Promise<String> {
     let trace = await ethers.provider.send('debug_traceBlockByNumber', [blockStr]);
     trace = await ethers.provider.send('debug_traceBlockByNumber', [blockStr, {}]);
 
-    0// console.log(JSON.stringify(trace, null, 4));
     return trace;
 }
 

--- a/test/historicstate/hardhat/scripts/trace.ts
+++ b/test/historicstate/hardhat/scripts/trace.ts
@@ -367,6 +367,7 @@ async function callDebugTraceCall(_deployedContract: any, _tracer: string, _trac
 }
 
 
+
 async function getAndPrintCommittedTransactionTrace(hash: string, _tracer: string, _skaleFileName: string): Promise<String> {
 
     let traceOptions = await getTraceJsonOptions(_tracer);


### PR DESCRIPTION
Geth accepts both empty parameter and "{}" parameter in debug_trace* requests

Since json-rpc library used in skaled  does not support variable number of parameters,
I added code that adds "{}" to to the parameters if a user submitted to last parameter

A corresponding test has been added to tracer.ts and runs as part of github actions

Also removed some dead code as a part of the pull request

Note - this pull request needs to go in after the previous one in tracing is accepted since it includes changes from the previous one