### PR TITLE
SKALED-1812 Use _enablePrivilegedApis in jsonrpc's Debug

### DIFF
--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -345,7 +345,7 @@ struct JsonRpcFixture : public TestOutputHelperFixture {
 
         rpcServer.reset( new FullServer( ethFace , new rpc::Net( chainParams ),
             new rpc::Web3(),  // TODO Add version parameter here?
-            new rpc::AdminEth( *client, *gasPricer, keyManager, *sessionManager.get() ),
+            new rpc::AdminEth( *client, *gasPricer, keyManager, *sessionManager ),
             new rpc::Debug( *client, nullptr, "", true),
             new rpc::Test( *client ) ) );
 

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -344,9 +344,9 @@ struct JsonRpcFixture : public TestOutputHelperFixture {
         gasPricer = make_shared< eth::TrivialGasPricer >( 0, DefaultGasPrice );
 
         rpcServer.reset( new FullServer( ethFace , new rpc::Net( chainParams ),
-            new rpc::Web3( /*web3->clientVersion()*/ ),  // TODO Add real version?
+            new rpc::Web3(),  // TODO Add version parameter here?
             new rpc::AdminEth( *client, *gasPricer, keyManager, *sessionManager.get() ),
-          /*new rpc::AdminNet(*web3, *sessionManager), */ new rpc::Debug( *client, nullptr, "", true),
+            new rpc::Debug( *client, nullptr, "", true),
             new rpc::Test( *client ) ) );
 
         //

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -346,7 +346,7 @@ struct JsonRpcFixture : public TestOutputHelperFixture {
         rpcServer.reset( new FullServer( ethFace , new rpc::Net( chainParams ),
             new rpc::Web3( /*web3->clientVersion()*/ ),  // TODO Add real version?
             new rpc::AdminEth( *client, *gasPricer, keyManager, *sessionManager.get() ),
-            /*new rpc::AdminNet(*web3, *sessionManager), */ new rpc::Debug( *client ),
+          /*new rpc::AdminNet(*web3, *sessionManager), */ new rpc::Debug( *client, nullptr, "", true),
             new rpc::Test( *client ) ) );
 
         //


### PR DESCRIPTION
Tests' fixture now uses _enablePrivilegedApis=true in Debug class.
Before that, test was failing because of disabled privileged access.