### PR TITLE
SKALED-1811 Fix net_version call error

### DIFF
--- a/libweb3jsonrpc/Net.h
+++ b/libweb3jsonrpc/Net.h
@@ -44,7 +44,7 @@ public:
     virtual bool net_listening() override;
 
 private:
-    const dev::eth::ChainParams& m_chainParams;
+    const dev::eth::ChainParams m_chainParams;
 };
 
 }  // namespace rpc


### PR DESCRIPTION
Unit test jsonrpc_netVersion was failing, not it works.
Root cause: ChainParams was held by reference in class Net, it caused it to point to freed memory. Now it's held by value.