### PR TITLE
Bump node.js for github runner

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -29,7 +29,7 @@
     - name: Set up Node 
       uses: actions/setup-node@v3.4.0
       with:
-        node-version: 16
+        node-version: 18
     - name: Install packages
       run: |
         sudo apt-get update


### PR DESCRIPTION
## Description

Bumping node.js version for `functional-tests` github runner 

## Tests

Test run: https://github.com/skalenetwork/skaled/actions/runs/7921219562

## Performance Impact

No impact
