### PR TITLE
Bug/1774 txns not broadcasted

### DIFF
--- a/deps/build.sh
+++ b/deps/build.sh
@@ -1383,7 +1383,8 @@ then
 			if [ ! -f "boost_1_68_0.tar.bz2" ];
 			then
 				echo -e "${COLOR_INFO}downloading it${COLOR_DOTS}...${COLOR_RESET}"
-				eval "$WGET" https://sourceforge.net/projects/boost/files/boost/1.68.0/boost_1_68_0.tar.bz2
+#				eval "$WGET" https://sourceforge.net/projects/boost/files/boost/1.68.0/boost_1_68_0.tar.bz2
+                                eval "$WGET" https://boostorg.jfrog.io/artifactory/main/release/1.68.0/source/boost_1_68_0.tar.bz2
 			fi
 			echo -e "${COLOR_INFO}unpacking it${COLOR_DOTS}...${COLOR_RESET}"
                         eval tar -xf boost_1_68_0.tar.bz2

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -878,6 +878,9 @@ void SkaleHost::broadcastFunc() {
 
             boost::chrono::high_resolution_clock::time_point txnProccessingTimeFinish =
                 boost::chrono::high_resolution_clock::now();
+            if ( txns.empty() )  // means timeout
+                continue;
+
             totalExecutionTimeSnd += boost::chrono::duration_cast< boost::chrono::milliseconds >(
                 txnProccessingTimeFinish - txnProccessingTimeStart );
             ++txnsCounterSnd;
@@ -893,8 +896,6 @@ void SkaleHost::broadcastFunc() {
                 clog( dev::VerbosityWarning, "skale-host" )
                     << "Average time to prepare txn for broadcast is " << avrgTST << " ms";
             }
-            if ( txns.empty() )  // means timeout
-                continue;
 
             this->logState();
 

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -866,36 +866,12 @@ void SkaleHost::broadcastFunc() {
     size_t nBroadcastTaskNumber = 0;
     while ( !m_exitNeeded ) {
         try {
-            static uint64_t txnsCounterSnd = 0;
-            static boost::chrono::milliseconds totalExecutionTimeSnd =
-                boost::chrono::milliseconds( 0 );
             m_broadcaster->broadcast( "" );  // HACK this is just to initialize sockets
-
-            boost::chrono::high_resolution_clock::time_point txnProccessingTimeStart =
-                boost::chrono::high_resolution_clock::now();
 
             dev::eth::Transactions txns = m_tq.topTransactionsSync( 1, 0, 1 );
 
-            boost::chrono::high_resolution_clock::time_point txnProccessingTimeFinish =
-                boost::chrono::high_resolution_clock::now();
             if ( txns.empty() )  // means timeout
                 continue;
-
-            totalExecutionTimeSnd += boost::chrono::duration_cast< boost::chrono::milliseconds >(
-                txnProccessingTimeFinish - txnProccessingTimeStart );
-            ++txnsCounterSnd;
-            auto t = boost::chrono::duration_cast< boost::chrono::milliseconds >(
-                txnProccessingTimeFinish - txnProccessingTimeStart )
-                         .count();
-            if ( t > 1000 ) {
-                clog( dev::VerbosityWarning, "skale-host" )
-                    << "Took " << t << " ms to get txn from TQ before broadcast";
-            }
-            if ( txnsCounterSnd % 1000 == 0 ) {
-                auto avrgTST = totalExecutionTimeSnd / txnsCounterSnd;
-                clog( dev::VerbosityWarning, "skale-host" )
-                    << "Average time to prepare txn for broadcast is " << avrgTST << " ms";
-            }
 
             this->logState();
 

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -866,9 +866,33 @@ void SkaleHost::broadcastFunc() {
     size_t nBroadcastTaskNumber = 0;
     while ( !m_exitNeeded ) {
         try {
+            static uint64_t txnsCounterSnd = 0;
+            static boost::chrono::milliseconds totalExecutionTimeSnd =
+                boost::chrono::milliseconds( 0 );
             m_broadcaster->broadcast( "" );  // HACK this is just to initialize sockets
 
+            boost::chrono::high_resolution_clock::time_point txnProccessingTimeStart =
+                boost::chrono::high_resolution_clock::now();
+
             dev::eth::Transactions txns = m_tq.topTransactionsSync( 1, 0, 1 );
+
+            boost::chrono::high_resolution_clock::time_point txnProccessingTimeFinish =
+                boost::chrono::high_resolution_clock::now();
+            totalExecutionTimeSnd += boost::chrono::duration_cast< boost::chrono::milliseconds >(
+                txnProccessingTimeFinish - txnProccessingTimeStart );
+            ++txnsCounterSnd;
+            auto t = boost::chrono::duration_cast< boost::chrono::milliseconds >(
+                txnProccessingTimeFinish - txnProccessingTimeStart )
+                         .count();
+            if ( t > 1000 ) {
+                clog( dev::VerbosityWarning, "skale-host" )
+                    << "Took " << t << " ms to get txn from TQ before broadcast";
+            }
+            if ( txnsCounterSnd % 1000 == 0 ) {
+                auto avrgTST = totalExecutionTimeSnd / txnsCounterSnd;
+                clog( dev::VerbosityWarning, "skale-host" )
+                    << "Average time to prepare txn for broadcast is " << avrgTST << " ms";
+            }
             if ( txns.empty() )  // means timeout
                 continue;
 

--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -176,11 +176,6 @@ void ZmqBroadcaster::startService() {
             zmq_msg_t msg;
 
             try {
-                static uint64_t txnsCounterRcv = 0;
-                static boost::chrono::milliseconds totalExecutionTimeRcv =
-                    boost::chrono::milliseconds( 0 );
-                boost::chrono::high_resolution_clock::time_point txnProccessingTimeStart =
-                    boost::chrono::high_resolution_clock::now();
                 int res = zmq_msg_init( &msg );
                 assert( res == 0 );
                 res = zmq_msg_recv( &msg, client_socket(), 0 );
@@ -211,24 +206,6 @@ void ZmqBroadcaster::startService() {
 
                 try {
                     m_skaleHost.receiveTransaction( str );
-                    boost::chrono::high_resolution_clock::time_point txnProccessingTimeFinish =
-                        boost::chrono::high_resolution_clock::now();
-                    totalExecutionTimeRcv +=
-                        boost::chrono::duration_cast< boost::chrono::milliseconds >(
-                            txnProccessingTimeFinish - txnProccessingTimeStart );
-                    ++txnsCounterRcv;
-                    auto t = boost::chrono::duration_cast< boost::chrono::milliseconds >(
-                        txnProccessingTimeFinish - txnProccessingTimeStart )
-                                 .count();
-                    if ( t > 1000 ) {
-                        clog( dev::VerbosityWarning, "skale-host" )
-                            << "Took " << t << " ms to receive txn via broadcast";
-                    }
-                    if ( txnsCounterRcv % 1000 == 0 ) {
-                        auto avrgTRT = totalExecutionTimeRcv / txnsCounterRcv;
-                        clog( dev::VerbosityWarning, "skale-host" )
-                            << "Average txn receiving time via broadcast is " << avrgTRT << " ms";
-                    }
                 } catch ( const std::exception& ex ) {
                     clog( dev::VerbosityDebug, "skale-host" )
                         << "Received bad transaction through broadcast: " << ex.what();

--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -98,7 +98,7 @@ void* ZmqBroadcaster::server_socket() const {
         zmq_setsockopt( m_zmq_server_socket, ZMQ_HEARTBEAT_TTL, &val, sizeof( val ) );
 
         // remove limits to prevent txns from being dropped out
-        val = 16;
+        val = 0;
         zmq_setsockopt( m_zmq_server_socket, ZMQ_SNDHWM, &val, sizeof( val ) );
 
 
@@ -133,7 +133,7 @@ void* ZmqBroadcaster::client_socket() const {
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_INTVL, &value, sizeof( value ) );
 
         // remove limits to prevent txns from being dropped out
-        value = 0;
+        value = 16;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_RCVHWM, &value, sizeof( value ) );
 
         const dev::eth::ChainParams& ch = m_client.chainParams();

--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -133,7 +133,7 @@ void* ZmqBroadcaster::client_socket() const {
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_INTVL, &value, sizeof( value ) );
 
         // remove limits to prevent txns from being dropped out
-        value = 16;
+        value = 0;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_RCVHWM, &value, sizeof( value ) );
 
         const dev::eth::ChainParams& ch = m_client.chainParams();

--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -98,7 +98,7 @@ void* ZmqBroadcaster::server_socket() const {
         zmq_setsockopt( m_zmq_server_socket, ZMQ_HEARTBEAT_TTL, &val, sizeof( val ) );
 
         // remove limits to prevent txns from being dropped out
-        val = 16;
+        val = 64000;
         zmq_setsockopt( m_zmq_server_socket, ZMQ_SNDHWM, &val, sizeof( val ) );
 
 
@@ -273,6 +273,8 @@ void ZmqBroadcaster::broadcast( const std::string& _rlp ) {
 
     int res = zmq_send( server_socket(), const_cast< char* >( _rlp.c_str() ), _rlp.size(), 0 );
     if ( res <= 0 ) {
+        clog( dev::VerbosityWarning, "zmq-broadcaster" )
+            << "Got error " << res << " in zmq_send: " << zmq_strerror( res );
         throw std::runtime_error( "Zmq can't send data" );
     }
 }

--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -98,9 +98,11 @@ void* ZmqBroadcaster::server_socket() const {
         zmq_setsockopt( m_zmq_server_socket, ZMQ_HEARTBEAT_TTL, &val, sizeof( val ) );
 
 
-        val = 16;
-        zmq_setsockopt( m_zmq_server_socket, ZMQ_RCVHWM, &val, sizeof( val ) );
-        val = 16;
+        // ZMQ_PUB socket doesn't support zmq_rcv
+        //        val = 16;
+        //        zmq_setsockopt( m_zmq_server_socket, ZMQ_RCVHWM, &val, sizeof( val ) );
+        // remove limits
+        val = 0;
         zmq_setsockopt( m_zmq_server_socket, ZMQ_SNDHWM, &val, sizeof( val ) );
 
 
@@ -134,10 +136,13 @@ void* ZmqBroadcaster::client_socket() const {
         value = 300;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_INTVL, &value, sizeof( value ) );
 
-        value = 16;
+        // remove limits
+        value = 0;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_RCVHWM, &value, sizeof( value ) );
-        value = 16;
-        zmq_setsockopt( m_zmq_client_socket, ZMQ_SNDHWM, &value, sizeof( value ) );
+
+        // ZMQ_SUB doesn't support zmq_snd
+        //        value = 16;
+        //        zmq_setsockopt( m_zmq_client_socket, ZMQ_SNDHWM, &value, sizeof( value ) );
 
 
         const dev::eth::ChainParams& ch = m_client.chainParams();

--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -97,11 +97,7 @@ void* ZmqBroadcaster::server_socket() const {
         val = 60000;
         zmq_setsockopt( m_zmq_server_socket, ZMQ_HEARTBEAT_TTL, &val, sizeof( val ) );
 
-
-        // ZMQ_PUB socket doesn't support zmq_rcv
-        //        val = 16;
-        //        zmq_setsockopt( m_zmq_server_socket, ZMQ_RCVHWM, &val, sizeof( val ) );
-        // remove limits
+        // remove limits to prevent txns from being dropped out
         val = 0;
         zmq_setsockopt( m_zmq_server_socket, ZMQ_SNDHWM, &val, sizeof( val ) );
 
@@ -136,14 +132,9 @@ void* ZmqBroadcaster::client_socket() const {
         value = 300;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_INTVL, &value, sizeof( value ) );
 
-        // remove limits
+        // remove limits to prevent txns from being dropped out
         value = 0;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_RCVHWM, &value, sizeof( value ) );
-
-        // ZMQ_SUB doesn't support zmq_snd
-        //        value = 16;
-        //        zmq_setsockopt( m_zmq_client_socket, ZMQ_SNDHWM, &value, sizeof( value ) );
-
 
         const dev::eth::ChainParams& ch = m_client.chainParams();
 

--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -98,7 +98,7 @@ void* ZmqBroadcaster::server_socket() const {
         zmq_setsockopt( m_zmq_server_socket, ZMQ_HEARTBEAT_TTL, &val, sizeof( val ) );
 
         // remove limits to prevent txns from being dropped out
-        val = 64000;
+        val = 16;
         zmq_setsockopt( m_zmq_server_socket, ZMQ_SNDHWM, &val, sizeof( val ) );
 
 
@@ -133,7 +133,7 @@ void* ZmqBroadcaster::client_socket() const {
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_INTVL, &value, sizeof( value ) );
 
         // remove limits to prevent txns from being dropped out
-        value = 64000;
+        value = 0;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_RCVHWM, &value, sizeof( value ) );
 
         const dev::eth::ChainParams& ch = m_client.chainParams();


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skaled/issues/1774

## Description

Set ZMQ sockets hard limits to 0 to avoid messages being dropped out from the buffer.

## Tests

Tested on the network with historic node and 7 core nodes:
- run load test and send all transactions to the historic node
- wait for some time (30 min is enough)
- stop the load
- there will be transactions in transaction queue on the historic node (version 3.18) that stuck there. Wait for 5 more minutes and ensure that those transactions will still be there. it means that these transactions were marked as broadcasted but were dropped out of the socket's buffer and therefore weren't received by other nodes. 
- there will be no stuck transactions on the historic node built on this branch


## Performance Impact

Tested on the network with historic node and 7 core nodes:
- run load test for ~2 hours on both new and current versions
- ram usage on the new version will not be higher than ram usage on the current version (current version - 500 mb usage, new version - 350-400 mb)

Tested on the devnet - 4-node chain

- run load test for 24 hours
- ram usage is normal, no swap growth
<img width="843" alt="Знімок екрана 2024-03-05 о 10 37 54" src="https://github.com/skalenetwork/skaled/assets/42572817/a8fe67e7-9151-4e06-bad6-3f55fcc08713">

results verified by @oleksandrSydorenkoJ 

<img width="839" alt="Знімок екрана 2024-03-05 о 10 41 46" src="https://github.com/skalenetwork/skaled/assets/42572817/75a27883-ba7e-4fb6-a170-d5126cf4df97">
