### PR TITLE
#1774 change hwm limits for zmq broadcast

### DIFF
--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -132,7 +132,7 @@ void* ZmqBroadcaster::client_socket() const {
         value = 300;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_INTVL, &value, sizeof( value ) );
 
-        value = 16;
+        value = 0;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_RCVHWM, &value, sizeof( value ) );
 
         const dev::eth::ChainParams& ch = m_client.chainParams();

--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -97,10 +97,8 @@ void* ZmqBroadcaster::server_socket() const {
         val = 60000;
         zmq_setsockopt( m_zmq_server_socket, ZMQ_HEARTBEAT_TTL, &val, sizeof( val ) );
 
-
-        val = 16;
-        zmq_setsockopt( m_zmq_server_socket, ZMQ_RCVHWM, &val, sizeof( val ) );
-        val = 16;
+        // remove limits to prevent txns from being dropped out
+        val = 0;
         zmq_setsockopt( m_zmq_server_socket, ZMQ_SNDHWM, &val, sizeof( val ) );
 
 
@@ -136,9 +134,6 @@ void* ZmqBroadcaster::client_socket() const {
 
         value = 16;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_RCVHWM, &value, sizeof( value ) );
-        value = 16;
-        zmq_setsockopt( m_zmq_client_socket, ZMQ_SNDHWM, &value, sizeof( value ) );
-
 
         const dev::eth::ChainParams& ch = m_client.chainParams();
 
@@ -254,6 +249,8 @@ void ZmqBroadcaster::broadcast( const std::string& _rlp ) {
 
     int res = zmq_send( server_socket(), const_cast< char* >( _rlp.c_str() ), _rlp.size(), 0 );
     if ( res <= 0 ) {
+        clog( dev::VerbosityWarning, "zmq-broadcaster" )
+            << "Got error " << res << " in zmq_send: " << zmq_strerror( res );
         throw std::runtime_error( "Zmq can't send data" );
     }
 }


### PR DESCRIPTION
fixes #1774 

## Description

Set ZMQ sockets hard limits to 0 to avoid messages being dropped out from the buffer.

## Tests

Tested on the network with historic node and 7 core nodes:

run load test and send all transactions to the historic node
wait for some time (30 min is enough)
stop the load
there will be transactions in transaction queue on the historic node (version 3.18) that stuck there. Wait for 5 more minutes and ensure that those transactions will still be there. it means that these transactions were marked as broadcasted but were dropped out of the socket's buffer and therefore weren't received by other nodes.
there will be no stuck transactions on the historic node built on this branch

## Performance Impact

Tested on the network with historic node and 7 core nodes:

run load test for ~2 hours on both new and current versions
ram usage on the new version will not be higher than ram usage on the current version (current version - 500 mb usage, new version - 350-400 mb)
Tested on the devnet - 4-node chain

run load test for 24 hours
ram usage is normal, no swap growth

results verified by @oleksandrSydorenkoJ

![image](https://github.com/skalenetwork/skaled/assets/42572817/10798dc5-4248-4085-b55b-5d4812b0b94c)
![image](https://github.com/skalenetwork/skaled/assets/42572817/aef133de-a839-4a09-bd5d-fc6cbe4dfa31)
