### PR TITLE
1850 historic node reset db

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,8 +170,7 @@ jobs:
           cd build/test
           export NO_NTP_CHECK=1
           export NO_ULIMIT_CHECK=1          
-          function run_test() { ./testeth --report_level=detailed -t "$1" -- --express && touch "/tmp/tests/${1}Passed"; }          
-          function run_test_sudo() { sudo ./testeth --report_level=detailed -t "$1" -- --express && touch "/tmp/tests/${1}Passed"; }
+          function run_test() { ./testeth --report_level=detailed -t "$1" -- --express && touch "/tmp/tests/${1}Passed"; }                    
           run_test TransitionTests 
           run_test TransactionTests 
           run_test VMTests 
@@ -212,9 +211,9 @@ jobs:
           run_test JsonRpcSuite   
           run_test SingleConsensusTests  
           run_test ConsensusTests
-          run_test_sudo BtrfsTestSuite
-          run_test_sudo HashSnapshotTestSuite
-          run_test_sudo ClientSnapshotsSuite          
+          sudo ./testeth -t BtrfsTestSuite -- --all && touch /tmp/tests/BtrfsTestSuitePassed
+          sudo ./testeth -t HashSnapshotTestSuite -- --all && touch /tmp/tests/HashSnapshotTestSuitePassed
+          sudo ./testeth -t ClientSnapshotsSuite -- --all && touch /tmp/tests/ClientSnapshotsSuitePassed
           cd ..
       - name: Testeth verbosity 4
         run : |
@@ -222,8 +221,7 @@ jobs:
           cd build/test      
           export NO_NTP_CHECK=1
           export NO_ULIMIT_CHECK=1          
-          function rerun_test() { ls "/tmp/tests/${1}Passed" 2>/dev/null || ./testeth --report_level=detailed -t "$1" -- --express --verbosity 4; }  
-          function rerun_test_sudo() { ls "/tmp/tests/${1}Passed" 2>/dev/null || sudo NO_ULIMIT_CHECK=1 NO_NTP_CHECK=1 ./testeth --report_level=detailed -t "$1" -- --express --verbosity 4; }          
+          function rerun_test() { ls "/tmp/tests/${1}Passed" 2>/dev/null || ./testeth --report_level=detailed -t "$1" -- --express --verbosity 4; }                      
           rerun_test TransitionTests 
           rerun_test TransactionTests 
           rerun_test VMTests 
@@ -264,9 +262,9 @@ jobs:
           rerun_test JsonRpcSuite   
           rerun_test SingleConsensusTests  
           rerun_test ConsensusTests
-          rerun_test_sudo BtrfsTestSuite
-          rerun_test_sudo HashSnapshot
-          rerun_test_sudo ClientSnapshot
+          ls /tmp/tests/BtrfsTestSuitePassed || sudo NO_ULIMIT_CHECK=1 NO_NTP_CHECK=1 ./testeth -t BtrfsTestSuite -- --all --verbosity 4
+          ls /tmp/tests/HashSnapshotTestSuitePassed || sudo NO_ULIMIT_CHECK=1 NO_NTP_CHECK=1 ./testeth -t HashSnapshotTestSuite -- --all --verbosity 4
+          ls /tmp/tests/ClientSnapshotsSuitePassed || sudo NO_ULIMIT_CHECK=1 NO_NTP_CHECK=1 ./testeth -t ClientSnapshotsSuite -- --all --verbosity 4
           cd ..
 
       - name: Configure all as historic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,6 +171,7 @@ jobs:
           export NO_NTP_CHECK=1
           export NO_ULIMIT_CHECK=1          
           function run_test() { ./testeth --report_level=detailed -t "$1" -- --express && touch "/tmp/tests/${1}Passed"; }          
+          function run_test_sudo() { sudo ./testeth --report_level=detailed -t "$1" -- --express && touch "/tmp/tests/${1}Passed"; }
           run_test TransitionTests 
           run_test TransactionTests 
           run_test VMTests 
@@ -210,10 +211,10 @@ jobs:
           run_test ClientTests 
           run_test JsonRpcSuite   
           run_test SingleConsensusTests  
-          run_test ConsensusTests  
-          sudo ./testeth -t BtrfsTestSuite -- --all && touch /tmp/tests/BtrfsTestSuitePassed
-          sudo ./testeth -t HashSnapshotTestSuite -- --all && touch /tmp/tests/HashSnapshotTestSuitePassed
-          sudo ./testeth -t ClientSnapshotsSuite -- --all && touch /tmp/tests/ClientSnapshotsSuitePassed
+          run_test ConsensusTests
+          run_test_sudo BtrfsTestSuite
+          run_test_sudo HashSnapshotTestSuite
+          run_test_sudo ClientSnapshotsSuite          
           cd ..
       - name: Testeth verbosity 4
         run : |
@@ -221,7 +222,8 @@ jobs:
           cd build/test      
           export NO_NTP_CHECK=1
           export NO_ULIMIT_CHECK=1          
-          function rerun_test() { ls "/tmp/tests/${1}Passed" 2>/dev/null || ./testeth --report_level=detailed -t "$1" -- --express --verbosity 4; }
+          function rerun_test() { ls "/tmp/tests/${1}Passed" 2>/dev/null || ./testeth --report_level=detailed -t "$1" -- --express --verbosity 4; }  
+          function rerun_test_sudo() { ls "/tmp/tests/${1}Passed" 2>/dev/null || sudo NO_ULIMIT_CHECK=1 NO_NTP_CHECK=1 ./testeth --report_level=detailed -t "$1" -- --express --verbosity 4; }          
           rerun_test TransitionTests 
           rerun_test TransactionTests 
           rerun_test VMTests 
@@ -261,10 +263,10 @@ jobs:
           rerun_test ClientTests 
           rerun_test JsonRpcSuite   
           rerun_test SingleConsensusTests  
-          rerun_test ConsensusTests                  
-          ls /tmp/tests/BtrfsTestSuitePassed || sudo NO_ULIMIT_CHECK=1 NO_NTP_CHECK=1 ./testeth -t BtrfsTestSuite -- --all --verbosity 4
-          ls /tmp/tests/HashSnapshotTestSuitePassed || sudo NO_ULIMIT_CHECK=1 NO_NTP_CHECK=1 ./testeth -t HashSnapshotTestSuite -- --all --verbosity 4
-          ls /tmp/tests/ClientSnapshotsSuitePassed || sudo NO_ULIMIT_CHECK=1 NO_NTP_CHECK=1 ./testeth -t ClientSnapshotsSuite -- --all --verbosity 4
+          rerun_test ConsensusTests
+          rerun_test_sudo BtrfsTestSuite
+          rerun_test_sudo HashSnapshot
+          rerun_test_sudo ClientSnapshot
           cd ..
 
       - name: Configure all as historic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,8 +169,8 @@ jobs:
           sudo rm -rf /tmp/tests/*
           cd build/test
           export NO_NTP_CHECK=1
-          export NO_ULIMIT_CHECK=1
-          run_test() {./testeth --report_level=detailed -t "$1" -- --express && touch "/tmp/tests/${1}Passed"}        
+          export NO_ULIMIT_CHECK=1          
+          function run_test() { ./testeth --report_level=detailed -t "$1" -- --express && touch "/tmp/tests/${1}Passed"; }          
           run_test TransitionTests 
           run_test TransactionTests 
           run_test VMTests 
@@ -221,7 +221,7 @@ jobs:
           cd build/test      
           export NO_NTP_CHECK=1
           export NO_ULIMIT_CHECK=1          
-          rerun_test() {ls "/tmp/tests/${1}Passed" || ./testeth --report_level=detailed -t "$1" -- --express --verbosity 4 }
+          function rerun_test() { ls "/tmp/tests/${1}Passed" 2>/dev/null || ./testeth --report_level=detailed -t "$1" -- --express --verbosity 4; }
           rerun_test TransitionTests 
           rerun_test TransactionTests 
           rerun_test VMTests 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,56 +161,56 @@ jobs:
       - name: Print ccache stats after full build
         run : |
           ccache --show-stats
+      # first run with verbosity 1. If test fails, rerun with verbosity 4
+      # we specifically run each test for easier log review
       - name: Testeth verbosity 1
         run : |
           mkdir -p /tmp/tests/
           sudo rm -rf /tmp/tests/*
-          #first run with verbosity 1. If test fails, rerun with verbosity 4
           cd build/test
           export NO_NTP_CHECK=1
           export NO_ULIMIT_CHECK=1
-          # we specifically run each test for easier log review          
-          ./testeth -t BlockchainTests -- --express && touch /tmp/tests/BlockchainTestsPassed
-          ./testeth -t TransitionTests  -- --express && touch /tmp/tests/TransitionTestsPassed
-          ./testeth -t TransactionTests -- --express && touch /tmp/tests/TransactionTestsPassed
-          ./testeth -t VMTests -- --express && touch /tmp/tests/VMTestsPassed
-          ./testeth -t LevelDBTests -- --express && touch /tmp/tests/LevelDBTestsPassed
-          ./testeth -t CoreLibTests -- --express && touch /tmp/tests/CoreLibTestsPassed
-          ./testeth -t RlpTests -- --express && touch /tmp/tests/RlpTestsPassed
-          ./testeth -t SharedSpaceTests -- --express && touch /tmp/tests/SharedSpaceTestsPassed
-          ./testeth -t EthashTests -- --express && touch /tmp/tests/EthashTestsPassed
-          ./testeth -t SealEngineTests -- --express && touch /tmp/tests/SealEngineTestsPassed
-          ./testeth -t DifficultyTests -- --express && touch /tmp/tests/DifficultyTestsPassed
-          ./testeth -t BlockSuite -- --express && touch /tmp/tests/BlockSuitePassed
-          ./testeth -t BlockChainMainNetworkSuite -- --express && touch /tmp/tests/BlockChainMainNetworkSuitePassed
-          ./testeth -t BlockChainFrontierSuite -- --express && touch /tmp/tests/BlockChainFrontierSuitePassed
-          ./testeth -t BlockQueueSuite -- --express && touch /tmp/tests/BlockQueueSuitePassed
-          ./testeth -t ClientBase -- --express && touch /tmp/tests/ClientBasePassed
-          ./testeth -t EstimateGas -- --express && touch /tmp/tests/EstimateGasPassed
-          ./testeth -t getHistoricNodesData -- --express && touch /tmp/tests/getHistoricNodesDataPassed
-          ./testeth -t ExtVmSuite -- --express && touch /tmp/tests/ExtVmSuitePassed
-          ./testeth -t GasPricer -- --express && touch /tmp/tests/GasPricerPassed
-          ./testeth -t BasicTests -- --express && touch /tmp/tests/BasicTestsPassed
-          ./testeth -t InstanceMonitorSuite -- --express && touch /tmp/tests/InstanceMonitorSuitePassed
-          ./testeth -t PrecompiledTests -- --express && touch /tmp/tests/PrecompiledTestsPassed
-          ./testeth -t SkaleHostSuite -- --express && touch /tmp/tests/SkaleHostSuitePassed
-          ./testeth -t StateUnitTests -- --express && touch /tmp/tests/StateUnitTestsPassed
-          ./testeth -t libethereum -- --express && touch /tmp/tests/libethereumPassed
-          ./testeth -t TransactionQueueSuite -- --express && touch /tmp/tests/TransactionQueueSuitePassed
-          ./testeth -t LegacyVMSuite -- --express && touch /tmp/tests/LegacyVMSuitePassed
-          ./testeth -t SkaleInterpreterSuite -- --express && touch /tmp/tests/SkaleInterpreterSuitePassed
-          ./testeth -t SnapshotSigningTestSuite -- --express && touch /tmp/tests/SnapshotSigningTestSuitePassed
-          ./testeth -t SkUtils -- --express && touch /tmp/tests/SkUtilsPassed
-          ./testeth -t BlockChainTestSuite -- --express && touch /tmp/tests/BlockChainTestSuitePassed
-          ./testeth -t TestHelperSuite -- --express && touch /tmp/tests/TestHelperSuitePassed
-          ./testeth -t LevelDBHashBase -- --express && touch /tmp/tests/LevelDBHashBasePassed
-          ./testeth -t memDB -- --express && touch /tmp/tests/memDBPassed
-          ./testeth -t OverlayDBTests -- --express && touch /tmp/tests/OverlayDBTestsPassed
-          ./testeth -t AccountHolderTest -- --express && touch /tmp/tests/AccountHolderTestPassed
-          ./testeth -t ClientTests -- --express && touch /tmp/tests/ClientTestsPassed
-          ./testeth -t JsonRpcSuite  -- --express && touch /tmp/tests/JsonRpcSuitePassed 
-          ./testeth -t SingleConsensusTests  -- --express && touch /tmp/tests/SingleConsensusTestsPassed
-          ./testeth -t ConsensusTests  -- --express && touch /tmp/tests/ConsensusTestsPassed
+          run_test() {./testeth --report_level=detailed -t "$1" -- --express && touch "/tmp/tests/${1}Passed"}        
+          run_test TransitionTests 
+          run_test TransactionTests 
+          run_test VMTests 
+          run_test LevelDBTests 
+          run_test CoreLibTests 
+          run_test RlpTests 
+          run_test SharedSpaceTests 
+          run_test EthashTests 
+          run_test SealEngineTests 
+          run_test DifficultyTests 
+          run_test BlockSuite
+          run_test BlockChainMainNetworkSuite
+          run_test BlockChainFrontierSuite
+          run_test BlockQueueSuite 
+          run_test ClientBase
+          run_test EstimateGas 
+          run_test getHistoricNodesData
+          run_test ExtVmSuite
+          run_test GasPricer
+          run_test BasicTests
+          run_test InstanceMonitorSuite
+          run_test PrecompiledTests 
+          run_test SkaleHostSuite 
+          run_test -t StateUnitTests 
+          run_test -t libethereum 
+          run_test -t TransactionQueueSuite 
+          run_test -t LegacyVMSuite 
+          run_test -t SkaleInterpreterSuite 
+          run_test -t SnapshotSigningTestSuite 
+          run_test -t SkUtils 
+          run_test -t BlockChainTestSuite 
+          run_test -t TestHelperSuite 
+          run_test -t LevelDBHashBase 
+          run_test -t memDB 
+          run_test -t OverlayDBTests 
+          run_test -t AccountHolderTest 
+          run_test -t ClientTests 
+          run_test -t JsonRpcSuite   
+          run_test -t SingleConsensusTests  
+          run_test -t ConsensusTests  
           sudo ./testeth -t BtrfsTestSuite -- --all && touch /tmp/tests/BtrfsTestSuitePassed
           sudo ./testeth -t HashSnapshotTestSuite -- --all && touch /tmp/tests/HashSnapshotTestSuitePassed
           sudo ./testeth -t ClientSnapshotsSuite -- --all && touch /tmp/tests/ClientSnapshotsSuitePassed
@@ -221,47 +221,47 @@ jobs:
           cd build/test      
           export NO_NTP_CHECK=1
           export NO_ULIMIT_CHECK=1          
-          ls /tmp/tests/BlockchainTestsPassed || ./testeth -t BlockchainTests -- --express --verbosity 4
-          ls /tmp/tests/TransitionTestsPassed || ./testeth -t TransitionTests -- --express --verbosity 4
-          ls /tmp/tests/TransactionTestsPassed || ./testeth -t TransactionTests -- --express --verbosity 4
-          ls /tmp/tests/VMTestsPassed || ./testeth -t VMTests -- --express --verbosity 4
-          ls /tmp/tests/LevelDBTestsPassed || ./testeth -t LevelDBTests -- --express --verbosity 4
-          ls /tmp/tests/CoreLibTestsPassed || ./testeth -t CoreLibTests -- --express --verbosity 4
-          ls /tmp/tests/RlpTestsPassed || ./testeth -t RlpTests -- --express --verbosity 4
-          ls /tmp/tests/SharedSpaceTestsPassed || ./testeth -t SharedSpaceTests -- --express --verbosity 4
-          ls /tmp/tests/EthashTestsPassed || ./testeth -t EthashTests -- --express --verbosity 4
-          ls /tmp/tests/SealEngineTestsPassed || ./testeth -t SealEngineTests -- --express --verbosity 4
-          ls /tmp/tests/DifficultyTestsPassed || ./testeth -t DifficultyTests -- --express --verbosity 4
-          ls /tmp/tests/BlockSuitePassed || ./testeth -t BlockSuite -- --express --verbosity 4
-          ls /tmp/tests/BlockChainMainNetworkSuitePassed || ./testeth -t BlockChainMainNetworkSuite -- --express --verbosity 4
-          ls /tmp/tests/BlockChainFrontierSuitePassed || ./testeth -t BlockChainFrontierSuite -- --express --verbosity 4
-          ls /tmp/tests/BlockQueueSuitePassed || ./testeth -t BlockQueueSuite -- --express --verbosity 4
-          ls /tmp/tests/ClientBasePassed || ./testeth -t ClientBase -- --express --verbosity 4
-          ls /tmp/tests/EstimateGasPassed || ./testeth -t EstimateGas -- --express --verbosity 4
-          ls /tmp/tests/getHistoricNodesDataPassed || ./testeth -t getHistoricNodesData -- --express --verbosity 4
-          ls /tmp/tests/ExtVmSuitePassed || ./testeth -t ExtVmSuite -- --express --verbosity 4
-          ls /tmp/tests/GasPricerPassed || ./testeth -t GasPricer -- --express --verbosity 4
-          ls /tmp/tests/BasicTestsPassed || ./testeth -t BasicTests -- --express --verbosity 4
-          ls /tmp/tests/InstanceMonitorSuitePassed || ./testeth -t InstanceMonitorSuite -- --express --verbosity 4
-          ls /tmp/tests/PrecompiledTestsPassed || ./testeth -t PrecompiledTests -- --express --verbosity 4
-          ls /tmp/tests/SkaleHostSuitePassed || ./testeth -t SkaleHostSuite -- --express --verbosity 4
-          ls /tmp/tests/StateUnitTestsPassed || ./testeth -t StateUnitTests -- --express --verbosity 4
-          ls /tmp/tests/libethereumPassed || ./testeth -t libethereum -- --express --verbosity 4
-          ls /tmp/tests/TransactionQueueSuitePassed || ./testeth -t TransactionQueueSuite -- --express --verbosity 4
-          ls /tmp/tests/LegacyVMSuitePassed || ./testeth -t LegacyVMSuite -- --express --verbosity 4
-          ls /tmp/tests/SkaleInterpreterSuitePassed || ./testeth -t SkaleInterpreterSuite -- --express --verbosity 4
-          ls /tmp/tests/SnapshotSigningTestSuitePassed || ./testeth -t SnapshotSigningTestSuite -- --express --verbosity 4
-          ls /tmp/tests/SkUtilsPassed || ./testeth -t SkUtils -- --express --verbosity 4
-          ls /tmp/tests/BlockChainTestSuitePassed || ./testeth -t BlockChainTestSuite -- --express --verbosity 4
-          ls /tmp/tests/TestHelperSuitePassed || ./testeth -t TestHelperSuite -- --express --verbosity 4
-          ls /tmp/tests/LevelDBHashBasePassed || ./testeth -t LevelDBHashBase -- --express --verbosity 4
-          ls /tmp/tests/memDBPassed || ./testeth -t memDB -- --express --verbosity 4
-          ls /tmp/tests/OverlayDBTestsPassed || ./testeth -t OverlayDBTests -- --express --verbosity 4
-          ls /tmp/tests/AccountHolderTestPassed || ./testeth -t AccountHolderTest -- --express --verbosity 4
-          ls /tmp/tests/ClientTestsPassed || ./testeth -t ClientTests -- --express --verbosity 4
-          ls /tmp/tests/JsonRpcSuitePassed || ./testeth -t JsonRpcSuite  -- --express --verbosity 4 
-          ls /tmp/tests/SingleConsensusTestsPassed || ./testeth -t SingleConsensusTests  -- --express --verbosity 4
-          ls /tmp/tests/ConsensusTestsPassed || ./testeth -t ConsensusTests  -- --express --verbosity 4
+          rerun_test() {ls "/tmp/tests/${1}Passed" || ./testeth --report_level=detailed -t "$1" -- --express --verbosity 4 }
+          rerun_test TransitionTests 
+          rerun_test TransactionTests 
+          rerun_test VMTests 
+          rerun_test LevelDBTests 
+          rerun_test CoreLibTests 
+          rerun_test RlpTests 
+          rerun_test SharedSpaceTests 
+          rerun_test EthashTests 
+          rerun_test SealEngineTests 
+          rerun_test DifficultyTests 
+          rerun_test BlockSuite
+          rerun_test BlockChainMainNetworkSuite
+          rerun_test BlockChainFrontierSuite
+          rerun_test BlockQueueSuite 
+          rerun_test ClientBase
+          rerun_test EstimateGas 
+          rerun_test getHistoricNodesData
+          rerun_test ExtVmSuite
+          rerun_test GasPricer
+          rerun_test BasicTests
+          rerun_test InstanceMonitorSuite
+          rerun_test PrecompiledTests 
+          rerun_test SkaleHostSuite 
+          rerun_test -t StateUnitTests 
+          rerun_test -t libethereum 
+          rerun_test -t TransactionQueueSuite 
+          rerun_test -t LegacyVMSuite 
+          rerun_test -t SkaleInterpreterSuite 
+          rerun_test -t SnapshotSigningTestSuite 
+          rerun_test -t SkUtils 
+          rerun_test -t BlockChainTestSuite 
+          rerun_test -t TestHelperSuite 
+          rerun_test -t LevelDBHashBase 
+          rerun_test -t memDB 
+          rerun_test -t OverlayDBTests 
+          rerun_test -t AccountHolderTest 
+          rerun_test -t ClientTests 
+          rerun_test -t JsonRpcSuite   
+          rerun_test -t SingleConsensusTests  
+          rerun_test -t ConsensusTests                  
           ls /tmp/tests/BtrfsTestSuitePassed || sudo NO_ULIMIT_CHECK=1 NO_NTP_CHECK=1 ./testeth -t BtrfsTestSuite -- --all --verbosity 4
           ls /tmp/tests/HashSnapshotTestSuitePassed || sudo NO_ULIMIT_CHECK=1 NO_NTP_CHECK=1 ./testeth -t HashSnapshotTestSuite -- --all --verbosity 4
           ls /tmp/tests/ClientSnapshotsSuitePassed || sudo NO_ULIMIT_CHECK=1 NO_NTP_CHECK=1 ./testeth -t ClientSnapshotsSuite -- --all --verbosity 4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,23 +194,23 @@ jobs:
           run_test InstanceMonitorSuite
           run_test PrecompiledTests 
           run_test SkaleHostSuite 
-          run_test -t StateUnitTests 
-          run_test -t libethereum 
-          run_test -t TransactionQueueSuite 
-          run_test -t LegacyVMSuite 
-          run_test -t SkaleInterpreterSuite 
-          run_test -t SnapshotSigningTestSuite 
-          run_test -t SkUtils 
-          run_test -t BlockChainTestSuite 
-          run_test -t TestHelperSuite 
-          run_test -t LevelDBHashBase 
-          run_test -t memDB 
-          run_test -t OverlayDBTests 
-          run_test -t AccountHolderTest 
-          run_test -t ClientTests 
-          run_test -t JsonRpcSuite   
-          run_test -t SingleConsensusTests  
-          run_test -t ConsensusTests  
+          run_test StateUnitTests 
+          run_test libethereum 
+          run_test TransactionQueueSuite 
+          run_test LegacyVMSuite 
+          run_test SkaleInterpreterSuite 
+          run_test SnapshotSigningTestSuite 
+          run_test SkUtils 
+          run_test BlockChainTestSuite 
+          run_test TestHelperSuite 
+          run_test LevelDBHashBase 
+          run_test memDB 
+          run_test OverlayDBTests 
+          run_test AccountHolderTest 
+          run_test ClientTests 
+          run_test JsonRpcSuite   
+          run_test SingleConsensusTests  
+          run_test ConsensusTests  
           sudo ./testeth -t BtrfsTestSuite -- --all && touch /tmp/tests/BtrfsTestSuitePassed
           sudo ./testeth -t HashSnapshotTestSuite -- --all && touch /tmp/tests/HashSnapshotTestSuitePassed
           sudo ./testeth -t ClientSnapshotsSuite -- --all && touch /tmp/tests/ClientSnapshotsSuitePassed
@@ -245,23 +245,23 @@ jobs:
           rerun_test InstanceMonitorSuite
           rerun_test PrecompiledTests 
           rerun_test SkaleHostSuite 
-          rerun_test -t StateUnitTests 
-          rerun_test -t libethereum 
-          rerun_test -t TransactionQueueSuite 
-          rerun_test -t LegacyVMSuite 
-          rerun_test -t SkaleInterpreterSuite 
-          rerun_test -t SnapshotSigningTestSuite 
-          rerun_test -t SkUtils 
-          rerun_test -t BlockChainTestSuite 
-          rerun_test -t TestHelperSuite 
-          rerun_test -t LevelDBHashBase 
-          rerun_test -t memDB 
-          rerun_test -t OverlayDBTests 
-          rerun_test -t AccountHolderTest 
-          rerun_test -t ClientTests 
-          rerun_test -t JsonRpcSuite   
-          rerun_test -t SingleConsensusTests  
-          rerun_test -t ConsensusTests                  
+          rerun_test StateUnitTests 
+          rerun_test libethereum 
+          rerun_test TransactionQueueSuite 
+          rerun_test LegacyVMSuite 
+          rerun_test SkaleInterpreterSuite 
+          rerun_test SnapshotSigningTestSuite 
+          rerun_test SkUtils 
+          rerun_test BlockChainTestSuite 
+          rerun_test TestHelperSuite 
+          rerun_test LevelDBHashBase 
+          rerun_test memDB 
+          rerun_test OverlayDBTests 
+          rerun_test AccountHolderTest 
+          rerun_test ClientTests 
+          rerun_test JsonRpcSuite   
+          rerun_test SingleConsensusTests  
+          rerun_test ConsensusTests                  
           ls /tmp/tests/BtrfsTestSuitePassed || sudo NO_ULIMIT_CHECK=1 NO_NTP_CHECK=1 ./testeth -t BtrfsTestSuite -- --all --verbosity 4
           ls /tmp/tests/HashSnapshotTestSuitePassed || sudo NO_ULIMIT_CHECK=1 NO_NTP_CHECK=1 ./testeth -t HashSnapshotTestSuite -- --all --verbosity 4
           ls /tmp/tests/ClientSnapshotsSuitePassed || sudo NO_ULIMIT_CHECK=1 NO_NTP_CHECK=1 ./testeth -t ClientSnapshotsSuite -- --all --verbosity 4

--- a/libdevcore/DBFactory.cpp
+++ b/libdevcore/DBFactory.cpp
@@ -134,7 +134,19 @@ std::unique_ptr< DatabaseFace > DBFactory::create( DatabaseKind _kind, fs::path 
         return std::unique_ptr< DatabaseFace >( new LevelDB( _path ) );
         break;
         // this is currently used by the historic state
-    case DatabaseKind::LevelDBHistoricState:
+        return std::unique_ptr< DatabaseFace >( new LevelDB( _path,
+            LevelDB::defaultReadOptions(), LevelDB::defaultWriteOptions(),
+            LevelDB::defaultDBOptions(), 1) );
+        break;
+    default:
+        assert( false );
+        return {};
+    }
+}
+
+std::unique_ptr< DatabaseFace > DBFactory::createHistoric( DatabaseKind _kind, fs::path const& _path ) {
+    switch ( _kind ) {
+    case DatabaseKind::LevelDB:
         return std::unique_ptr< DatabaseFace >( new LevelDB( _path,
             LevelDB::defaultReadOptions(), LevelDB::defaultWriteOptions(),
             LevelDB::defaultDBOptions(), 1) );

--- a/libdevcore/DBFactory.cpp
+++ b/libdevcore/DBFactory.cpp
@@ -136,15 +136,15 @@ std::unique_ptr< DatabaseFace > DBFactory::create( DatabaseKind _kind, fs::path 
     }
 }
 
-std::unique_ptr< DatabaseFace > DBFactory::createHistoric( DatabaseKind _kind, fs::path const& _path ) {
-    if (!s_isInited) {
-        throw std::runtime_error("DB factory not inited");
+std::unique_ptr< DatabaseFace > DBFactory::createHistoric(
+    DatabaseKind _kind, fs::path const& _path ) {
+    if ( !s_isInited ) {
+        throw std::runtime_error( "DB factory not inited" );
     }
     switch ( _kind ) {
     case DatabaseKind::LevelDB:
-        return std::unique_ptr< DatabaseFace >( new LevelDB( _path,
-            LevelDB::defaultReadOptions(), LevelDB::defaultWriteOptions(),
-            LevelDB::defaultDBOptions(), s_isInited) );
+        return std::unique_ptr< DatabaseFace >( new LevelDB( _path, LevelDB::defaultReadOptions(),
+            LevelDB::defaultWriteOptions(), LevelDB::defaultDBOptions(), s_isInited ) );
         break;
     default:
         assert( false );
@@ -153,8 +153,7 @@ std::unique_ptr< DatabaseFace > DBFactory::createHistoric( DatabaseKind _kind, f
 }
 
 
-std::atomic<bool> DBFactory::s_isInited = false;
-std::atomic<int64_t> DBFactory::s_reopenPeriodMs = -1;
+std::atomic< bool > DBFactory::s_isInited = false;
+std::atomic< int64_t > DBFactory::s_reopenPeriodMs = -1;
 
 }  // namespace dev::db
-

--- a/libdevcore/DBFactory.cpp
+++ b/libdevcore/DBFactory.cpp
@@ -133,6 +133,12 @@ std::unique_ptr< DatabaseFace > DBFactory::create( DatabaseKind _kind, fs::path 
     case DatabaseKind::LevelDB:
         return std::unique_ptr< DatabaseFace >( new LevelDB( _path ) );
         break;
+        // this is currently used by the historic state
+    case DatabaseKind::LevelDBHistoricState:
+        return std::unique_ptr< DatabaseFace >( new LevelDB( _path,
+            LevelDB::defaultReadOptions(), LevelDB::defaultWriteOptions(),
+            LevelDB::defaultDBOptions(), 1) );
+        break;
     default:
         assert( false );
         return {};

--- a/libdevcore/DBFactory.cpp
+++ b/libdevcore/DBFactory.cpp
@@ -138,13 +138,10 @@ std::unique_ptr< DatabaseFace > DBFactory::create( DatabaseKind _kind, fs::path 
 
 std::unique_ptr< DatabaseFace > DBFactory::createHistoric(
     DatabaseKind _kind, fs::path const& _path ) {
-    if ( !s_isInited ) {
-        throw std::runtime_error( "DB factory not inited" );
-    }
     switch ( _kind ) {
     case DatabaseKind::LevelDB:
         return std::unique_ptr< DatabaseFace >( new LevelDB( _path, LevelDB::defaultReadOptions(),
-            LevelDB::defaultWriteOptions(), LevelDB::defaultDBOptions(), s_isInited ) );
+            LevelDB::defaultWriteOptions(), LevelDB::defaultDBOptions(), s_reopenPeriodMs ) );
         break;
     default:
         assert( false );
@@ -153,7 +150,6 @@ std::unique_ptr< DatabaseFace > DBFactory::createHistoric(
 }
 
 
-std::atomic< bool > DBFactory::s_isInited = false;
 std::atomic< int64_t > DBFactory::s_reopenPeriodMs = -1;
 
 }  // namespace dev::db

--- a/libdevcore/DBFactory.h
+++ b/libdevcore/DBFactory.h
@@ -27,7 +27,7 @@
 
 namespace dev {
 namespace db {
-enum class DatabaseKind { LevelDB, LevelDBPeriodicRestart };
+enum class DatabaseKind { LevelDB, LevelDBHistoricState };
 
 /// Provide a set of program options related to databases
 ///

--- a/libdevcore/DBFactory.h
+++ b/libdevcore/DBFactory.h
@@ -27,7 +27,7 @@
 
 namespace dev {
 namespace db {
-enum class DatabaseKind { LevelDB };
+enum class DatabaseKind { LevelDB, LevelDBPeriodicRestart };
 
 /// Provide a set of program options related to databases
 ///

--- a/libdevcore/DBFactory.h
+++ b/libdevcore/DBFactory.h
@@ -27,7 +27,7 @@
 
 namespace dev {
 namespace db {
-enum class DatabaseKind { LevelDB, LevelDBHistoricState };
+enum class DatabaseKind { LevelDB };
 
 /// Provide a set of program options related to databases
 ///
@@ -51,6 +51,8 @@ public:
     static std::unique_ptr< DatabaseFace > create( boost::filesystem::path const& _path );
     static std::unique_ptr< DatabaseFace > create( DatabaseKind _kind );
     static std::unique_ptr< DatabaseFace > create(
+        DatabaseKind _kind, boost::filesystem::path const& _path );
+    static std::unique_ptr< DatabaseFace > createHistoric(
         DatabaseKind _kind, boost::filesystem::path const& _path );
 
 private:

--- a/libdevcore/DBFactory.h
+++ b/libdevcore/DBFactory.h
@@ -25,8 +25,8 @@
 #include <boost/filesystem.hpp>
 #include <boost/program_options/options_description.hpp>
 
-namespace dev {
-namespace db {
+namespace dev::db {
+
 enum class DatabaseKind { LevelDB };
 
 /// Provide a set of program options related to databases
@@ -55,14 +55,12 @@ public:
     static std::unique_ptr< DatabaseFace > createHistoric(
         DatabaseKind _kind, boost::filesystem::path const& _path );
 
-    static void init( int64_t _reopenPeriodMs ) {
+    static void setReopenPeriodMs( int64_t _reopenPeriodMs ) {
         s_reopenPeriodMs = _reopenPeriodMs;
-        s_isInited = true;
     }
 
 private:
-    static std::atomic< bool > s_isInited;
     static std::atomic< int64_t > s_reopenPeriodMs;
 };
-}  // namespace db
-}  // namespace dev
+}  // namespace dev::db
+

--- a/libdevcore/DBFactory.h
+++ b/libdevcore/DBFactory.h
@@ -55,7 +55,15 @@ public:
     static std::unique_ptr< DatabaseFace > createHistoric(
         DatabaseKind _kind, boost::filesystem::path const& _path );
 
+    static void init(int64_t _reopenPeriodMs) {
+        s_reopenPeriodMs = _reopenPeriodMs;
+        s_isInited = true;
+    }
+
 private:
+
+    static std::atomic<bool> s_isInited;
+    static std::atomic<int64_t> s_reopenPeriodMs;
 };
 }  // namespace db
 }  // namespace dev

--- a/libdevcore/DBFactory.h
+++ b/libdevcore/DBFactory.h
@@ -55,12 +55,9 @@ public:
     static std::unique_ptr< DatabaseFace > createHistoric(
         DatabaseKind _kind, boost::filesystem::path const& _path );
 
-    static void setReopenPeriodMs( int64_t _reopenPeriodMs ) {
-        s_reopenPeriodMs = _reopenPeriodMs;
-    }
+    static void setReopenPeriodMs( int64_t _reopenPeriodMs ) { s_reopenPeriodMs = _reopenPeriodMs; }
 
 private:
     static std::atomic< int64_t > s_reopenPeriodMs;
 };
 }  // namespace dev::db
-

--- a/libdevcore/DBFactory.h
+++ b/libdevcore/DBFactory.h
@@ -55,15 +55,14 @@ public:
     static std::unique_ptr< DatabaseFace > createHistoric(
         DatabaseKind _kind, boost::filesystem::path const& _path );
 
-    static void init(int64_t _reopenPeriodMs) {
+    static void init( int64_t _reopenPeriodMs ) {
         s_reopenPeriodMs = _reopenPeriodMs;
         s_isInited = true;
     }
 
 private:
-
-    static std::atomic<bool> s_isInited;
-    static std::atomic<int64_t> s_reopenPeriodMs;
+    static std::atomic< bool > s_isInited;
+    static std::atomic< int64_t > s_reopenPeriodMs;
 };
 }  // namespace db
 }  // namespace dev

--- a/libdevcore/LevelDB.cpp
+++ b/libdevcore/LevelDB.cpp
@@ -138,17 +138,17 @@ void LevelDB::openDBInstanceUnsafe() {
     auto const status = leveldb::DB::Open( m_options, m_path.string(), &db );
     checkStatus( status, m_path );
 
-    if (!db) {
-        BOOST_THROW_EXCEPTION(runtime_error(string("Null db in ") + __FUNCTION__ ));
+    if ( !db ) {
+        BOOST_THROW_EXCEPTION( runtime_error( string( "Null db in " ) + __FUNCTION__ ) );
     }
 
     m_db.reset( db );
     m_lastDBOpenTimeMs = getCurrentTimeMs();
-    cnote <<"LEVELDB_OPENED:TIME_MS:" << m_lastDBOpenTimeMs - startTimeMs;
+    cnote << "LEVELDB_OPENED:TIME_MS:" << m_lastDBOpenTimeMs - startTimeMs;
 }
 uint64_t LevelDB::getCurrentTimeMs() {
     auto currentTime = std::chrono::system_clock::now().time_since_epoch();
-    return std::chrono::duration_cast<std::chrono::milliseconds>(currentTime).count();
+    return std::chrono::duration_cast< std::chrono::milliseconds >( currentTime ).count();
 }
 
 LevelDB::~LevelDB() {
@@ -239,24 +239,20 @@ void LevelDB::commit( std::unique_ptr< WriteBatchFace > _batch ) {
     reopenDataBaseIfNeeded();
 }
 void LevelDB::reopenDataBaseIfNeeded() {
-
-    if ( m_reopenPeriodMs < 0) {
+    if ( m_reopenPeriodMs < 0 ) {
         // restarts not enabled
         return;
     }
 
     auto currentTimeMs = getCurrentTimeMs();
 
-    if ( currentTimeMs - m_lastDBOpenTimeMs >= (uint64_t ) m_reopenPeriodMs ) {
-
-        ExclusiveDBGuard lock(*this);
+    if ( currentTimeMs - m_lastDBOpenTimeMs >= ( uint64_t ) m_reopenPeriodMs ) {
+        ExclusiveDBGuard lock( *this );
         // releasing unique pointer will cause database destructor to be called that will close db
         m_db.reset();
         // now open db while holding the exclusive lock
         openDBInstanceUnsafe();
     }
-
-
 }
 
 void LevelDB::forEach( std::function< bool( Slice, Slice ) > f ) const {
@@ -395,4 +391,3 @@ uint64_t LevelDB::getKeyDeletesStats() {
 }
 
 }  // namespace dev::db
-

--- a/libdevcore/LevelDB.cpp
+++ b/libdevcore/LevelDB.cpp
@@ -118,12 +118,12 @@ leveldb::Options LevelDB::defaultSnapshotDBOptions() {
 }
 
 LevelDB::LevelDB( boost::filesystem::path const& _path, leveldb::ReadOptions _readOptions,
-    leveldb::WriteOptions _writeOptions, leveldb::Options _dbOptions )
+    leveldb::WriteOptions _writeOptions, leveldb::Options _dbOptions, uint64_t _restartPeriodS )
     : m_db( nullptr ),
       m_readOptions( std::move( _readOptions ) ),
       m_writeOptions( std::move( _writeOptions ) ),
       m_options( std::move( _dbOptions ) ),
-      m_path( _path ) {
+      m_path( _path ), m_restartPeriodS( _restartPeriodS) {
     auto db = static_cast< leveldb::DB* >( nullptr );
     auto const status = leveldb::DB::Open( m_options, _path.string(), &db );
     checkStatus( status, _path );

--- a/libdevcore/LevelDB.h
+++ b/libdevcore/LevelDB.h
@@ -41,7 +41,7 @@ public:
     explicit LevelDB( boost::filesystem::path const& _path,
         leveldb::ReadOptions _readOptions = defaultReadOptions(),
         leveldb::WriteOptions _writeOptions = defaultWriteOptions(),
-        leveldb::Options _dbOptions = defaultDBOptions() );
+        leveldb::Options _dbOptions = defaultDBOptions(), uint64_t _restartPeriodS = 0 );
 
     ~LevelDB();
 
@@ -78,6 +78,7 @@ private:
     leveldb::WriteOptions const m_writeOptions;
     leveldb::Options m_options;
     boost::filesystem::path const m_path;
+    uint64_t m_restartPeriodS;
 
     static const size_t BATCH_CHUNK_SIZE;
 };

--- a/libdevcore/LevelDB.h
+++ b/libdevcore/LevelDB.h
@@ -30,101 +30,101 @@
 #include <secp256k1_sha256.h>
 
 namespace dev::db {
-    class LevelDB : public DatabaseFace {
+class LevelDB : public DatabaseFace {
+public:
+    static leveldb::ReadOptions defaultReadOptions();
+    static leveldb::WriteOptions defaultWriteOptions();
+    static leveldb::Options defaultDBOptions();
+    static leveldb::ReadOptions defaultSnapshotReadOptions();
+    static leveldb::Options defaultSnapshotDBOptions();
+
+    explicit LevelDB( boost::filesystem::path const& _path,
+        leveldb::ReadOptions _readOptions = defaultReadOptions(),
+        leveldb::WriteOptions _writeOptions = defaultWriteOptions(),
+        leveldb::Options _dbOptions = defaultDBOptions(), int64_t _reopenPeriodMs = -1 );
+
+    ~LevelDB();
+
+    std::string lookup( Slice _key ) const override;
+    bool exists( Slice _key ) const override;
+    void insert( Slice _key, Slice _value ) override;
+    void kill( Slice _key ) override;
+
+    std::unique_ptr< WriteBatchFace > createWriteBatch() const override;
+    void commit( std::unique_ptr< WriteBatchFace > _batch ) override;
+
+    void forEach( std::function< bool( Slice, Slice ) > f ) const override;
+
+    void forEachWithPrefix(
+        std::string& _prefix, std::function< bool( Slice, Slice ) > f ) const override;
+
+    h256 hashBase() const override;
+    h256 hashBaseWithPrefix( char _prefix ) const;
+
+    bool hashBasePartially( secp256k1_sha256_t* ctx, std::string& lastHashedKey ) const;
+
+    void doCompaction() const;
+
+    // Return the total count of key deletes  since the start
+    static uint64_t getKeyDeletesStats();
+    // count of the keys that were deleted since the start of skaled
+    static std::atomic< uint64_t > g_keyDeletesStats;
+    // count of the keys that are scheduled to be deleted but are not yet deleted
+    static std::atomic< uint64_t > g_keysToBeDeletedStats;
+
+private:
+    std::unique_ptr< leveldb::DB > m_db;
+    leveldb::ReadOptions const m_readOptions;
+    leveldb::WriteOptions const m_writeOptions;
+    leveldb::Options m_options;
+    boost::filesystem::path const m_path;
+
+    // periodic reopen is disabled by default
+    int64_t m_reopenPeriodMs = -1;
+    uint64_t m_lastDBOpenTimeMs;
+    mutable std::shared_mutex m_dbMutex;
+
+
+    static const size_t BATCH_CHUNK_SIZE;
+
+    class SharedDBGuard {
+        const LevelDB& m_levedlDB;
+
+
     public:
-        static leveldb::ReadOptions defaultReadOptions();
-        static leveldb::WriteOptions defaultWriteOptions();
-        static leveldb::Options defaultDBOptions();
-        static leveldb::ReadOptions defaultSnapshotReadOptions();
-        static leveldb::Options defaultSnapshotDBOptions();
-
-        explicit LevelDB( boost::filesystem::path const& _path,
-            leveldb::ReadOptions _readOptions = defaultReadOptions(),
-            leveldb::WriteOptions _writeOptions = defaultWriteOptions(),
-            leveldb::Options _dbOptions = defaultDBOptions(), int64_t _reopenPeriodMs = -1 );
-
-        ~LevelDB();
-
-        std::string lookup( Slice _key ) const override;
-        bool exists( Slice _key ) const override;
-        void insert( Slice _key, Slice _value ) override;
-        void kill( Slice _key ) override;
-
-        std::unique_ptr< WriteBatchFace > createWriteBatch() const override;
-        void commit( std::unique_ptr< WriteBatchFace > _batch ) override;
-
-        void forEach( std::function< bool( Slice, Slice ) > f ) const override;
-
-        void forEachWithPrefix(
-            std::string& _prefix, std::function< bool( Slice, Slice ) > f ) const override;
-
-        h256 hashBase() const override;
-        h256 hashBaseWithPrefix( char _prefix ) const;
-
-        bool hashBasePartially( secp256k1_sha256_t* ctx, std::string& lastHashedKey ) const;
-
-        void doCompaction() const;
-
-        // Return the total count of key deletes  since the start
-        static uint64_t getKeyDeletesStats();
-        // count of the keys that were deleted since the start of skaled
-        static std::atomic< uint64_t > g_keyDeletesStats;
-        // count of the keys that are scheduled to be deleted but are not yet deleted
-        static std::atomic< uint64_t > g_keysToBeDeletedStats;
-
-    private:
-        std::unique_ptr< leveldb::DB > m_db;
-        leveldb::ReadOptions const m_readOptions;
-        leveldb::WriteOptions const m_writeOptions;
-        leveldb::Options m_options;
-        boost::filesystem::path const m_path;
-
-        // periodic reopen is disabled by default
-        int64_t m_reopenPeriodMs = -1;
-        uint64_t m_lastDBOpenTimeMs;
-        mutable std::shared_mutex m_dbMutex;
+        explicit SharedDBGuard( const LevelDB& _levedDB ) : m_levedlDB( _levedDB ) {
+            if ( m_levedlDB.m_reopenPeriodMs < 0 )
+                return;
+            m_levedlDB.m_dbMutex.lock_shared();
+        }
 
 
-        static const size_t BATCH_CHUNK_SIZE;
-
-        class SharedDBGuard {
-            const LevelDB& m_levedlDB;
-
-
-        public:
-            explicit SharedDBGuard( const LevelDB& _levedDB ) : m_levedlDB( _levedDB ) {
-                if ( m_levedlDB.m_reopenPeriodMs < 0 )
-                    return;
-                m_levedlDB.m_dbMutex.lock_shared();
-            }
-
-
-            ~SharedDBGuard() {
-                if ( m_levedlDB.m_reopenPeriodMs < 0 )
-                    return;
-                m_levedlDB.m_dbMutex.unlock_shared();
-            }
-        };
-
-        class ExclusiveDBGuard {
-            LevelDB& m_levedlDB;
-
-        public:
-            ExclusiveDBGuard( LevelDB& _levedDB ) : m_levedlDB( _levedDB ) {
-                if ( m_levedlDB.m_reopenPeriodMs < 0 )
-                    return;
-                m_levedlDB.m_dbMutex.lock();
-            }
-
-            ~ExclusiveDBGuard() {
-                if ( m_levedlDB.m_reopenPeriodMs < 0 )
-                    return;
-                m_levedlDB.m_dbMutex.unlock();
-            }
-        };
-        void openDBInstanceUnsafe();
-        uint64_t getCurrentTimeMs();
-        void reopenDataBaseIfNeeded();
+        ~SharedDBGuard() {
+            if ( m_levedlDB.m_reopenPeriodMs < 0 )
+                return;
+            m_levedlDB.m_dbMutex.unlock_shared();
+        }
     };
 
-}  // namespace dev: db
+    class ExclusiveDBGuard {
+        LevelDB& m_levedlDB;
+
+    public:
+        ExclusiveDBGuard( LevelDB& _levedDB ) : m_levedlDB( _levedDB ) {
+            if ( m_levedlDB.m_reopenPeriodMs < 0 )
+                return;
+            m_levedlDB.m_dbMutex.lock();
+        }
+
+        ~ExclusiveDBGuard() {
+            if ( m_levedlDB.m_reopenPeriodMs < 0 )
+                return;
+            m_levedlDB.m_dbMutex.unlock();
+        }
+    };
+    void openDBInstanceUnsafe();
+    uint64_t getCurrentTimeMs();
+    void reopenDataBaseIfNeeded();
+};
+
+}  // namespace dev::db

--- a/libdevcore/LevelDB.h
+++ b/libdevcore/LevelDB.h
@@ -29,103 +29,102 @@
 #include "shared_mutex"
 #include <secp256k1_sha256.h>
 
-namespace dev {
-namespace db {
-class LevelDB : public DatabaseFace {
-public:
-    static leveldb::ReadOptions defaultReadOptions();
-    static leveldb::WriteOptions defaultWriteOptions();
-    static leveldb::Options defaultDBOptions();
-    static leveldb::ReadOptions defaultSnapshotReadOptions();
-    static leveldb::Options defaultSnapshotDBOptions();
-
-    explicit LevelDB( boost::filesystem::path const& _path,
-        leveldb::ReadOptions _readOptions = defaultReadOptions(),
-        leveldb::WriteOptions _writeOptions = defaultWriteOptions(),
-        leveldb::Options _dbOptions = defaultDBOptions(), uint64_t _restartPeriodMs = 0 );
-
-    ~LevelDB();
-
-    std::string lookup( Slice _key ) const override;
-    bool exists( Slice _key ) const override;
-    void insert( Slice _key, Slice _value ) override;
-    void kill( Slice _key ) override;
-
-    std::unique_ptr< WriteBatchFace > createWriteBatch() const override;
-    void commit( std::unique_ptr< WriteBatchFace > _batch ) override;
-
-    void forEach( std::function< bool( Slice, Slice ) > f ) const override;
-
-    void forEachWithPrefix(
-        std::string& _prefix, std::function< bool( Slice, Slice ) > f ) const override;
-
-    h256 hashBase() const override;
-    h256 hashBaseWithPrefix( char _prefix ) const;
-
-    bool hashBasePartially( secp256k1_sha256_t* ctx, std::string& lastHashedKey ) const;
-
-    void doCompaction() const;
-
-    // Return the total count of key deletes  since the start
-    static uint64_t getKeyDeletesStats();
-    // count of the keys that were deleted since the start of skaled
-    static std::atomic< uint64_t > g_keyDeletesStats;
-    // count of the keys that are scheduled to be deleted but are not yet deleted
-    static std::atomic< uint64_t > g_keysToBeDeletedStats;
-
-private:
-    std::unique_ptr< leveldb::DB > m_db;
-    leveldb::ReadOptions const m_readOptions;
-    leveldb::WriteOptions const m_writeOptions;
-    leveldb::Options m_options;
-    boost::filesystem::path const m_path;
-    uint64_t m_restartPeriodMs;
-    uint64_t m_lastDBOpenTimeMs;
-    mutable std::shared_mutex m_dbMutex;
-
-
-    static const size_t BATCH_CHUNK_SIZE;
-
-    class SharedDBGuard {
-        const LevelDB& m_levedlDB;
-
-
+namespace dev : db {
+    class LevelDB : public DatabaseFace {
     public:
-        explicit SharedDBGuard( const LevelDB& _levedDB ) : m_levedlDB( _levedDB ) {
-            if ( m_levedlDB.m_restartPeriodMs == 0 )
-                return;
-            m_levedlDB.m_dbMutex.lock_shared();
-        }
+        static leveldb::ReadOptions defaultReadOptions();
+        static leveldb::WriteOptions defaultWriteOptions();
+        static leveldb::Options defaultDBOptions();
+        static leveldb::ReadOptions defaultSnapshotReadOptions();
+        static leveldb::Options defaultSnapshotDBOptions();
+
+        explicit LevelDB( boost::filesystem::path const& _path,
+            leveldb::ReadOptions _readOptions = defaultReadOptions(),
+            leveldb::WriteOptions _writeOptions = defaultWriteOptions(),
+            leveldb::Options _dbOptions = defaultDBOptions(), int64_t _reopenPeriodMs = -1 );
+
+        ~LevelDB();
+
+        std::string lookup( Slice _key ) const override;
+        bool exists( Slice _key ) const override;
+        void insert( Slice _key, Slice _value ) override;
+        void kill( Slice _key ) override;
+
+        std::unique_ptr< WriteBatchFace > createWriteBatch() const override;
+        void commit( std::unique_ptr< WriteBatchFace > _batch ) override;
+
+        void forEach( std::function< bool( Slice, Slice ) > f ) const override;
+
+        void forEachWithPrefix(
+            std::string& _prefix, std::function< bool( Slice, Slice ) > f ) const override;
+
+        h256 hashBase() const override;
+        h256 hashBaseWithPrefix( char _prefix ) const;
+
+        bool hashBasePartially( secp256k1_sha256_t* ctx, std::string& lastHashedKey ) const;
+
+        void doCompaction() const;
+
+        // Return the total count of key deletes  since the start
+        static uint64_t getKeyDeletesStats();
+        // count of the keys that were deleted since the start of skaled
+        static std::atomic< uint64_t > g_keyDeletesStats;
+        // count of the keys that are scheduled to be deleted but are not yet deleted
+        static std::atomic< uint64_t > g_keysToBeDeletedStats;
+
+    private:
+        std::unique_ptr< leveldb::DB > m_db;
+        leveldb::ReadOptions const m_readOptions;
+        leveldb::WriteOptions const m_writeOptions;
+        leveldb::Options m_options;
+        boost::filesystem::path const m_path;
+
+        // periodic reopen is disabled by default
+        int64_t m_reopenPeriodMs = -1;
+        uint64_t m_lastDBOpenTimeMs;
+        mutable std::shared_mutex m_dbMutex;
 
 
-        ~SharedDBGuard() {
-            if ( m_levedlDB.m_restartPeriodMs == 0 )
-                return;
-            m_levedlDB.m_dbMutex.unlock_shared();
-        }
+        static const size_t BATCH_CHUNK_SIZE;
+
+        class SharedDBGuard {
+            const LevelDB& m_levedlDB;
+
+
+        public:
+            explicit SharedDBGuard( const LevelDB& _levedDB ) : m_levedlDB( _levedDB ) {
+                if ( m_levedlDB.m_reopenPeriodMs < 0 )
+                    return;
+                m_levedlDB.m_dbMutex.lock_shared();
+            }
+
+
+            ~SharedDBGuard() {
+                if ( m_levedlDB.m_reopenPeriodMs < 0 )
+                    return;
+                m_levedlDB.m_dbMutex.unlock_shared();
+            }
+        };
+
+        class ExclusiveDBGuard {
+            LevelDB& m_levedlDB;
+
+        public:
+            ExclusiveDBGuard( LevelDB& _levedDB ) : m_levedlDB( _levedDB ) {
+                if ( m_levedlDB.m_reopenPeriodMs < 0 )
+                    return;
+                m_levedlDB.m_dbMutex.lock();
+            }
+
+            ~ExclusiveDBGuard() {
+                if ( m_levedlDB.m_reopenPeriodMs < 0 )
+                    return;
+                m_levedlDB.m_dbMutex.unlock();
+            }
+        };
+        void openDBInstanceUnsafe();
+        uint64_t getCurrentTimeMs();
+        void reopenDataBaseIfNeeded();
     };
 
-    class ExclusiveDBGuard {
-        LevelDB& m_levedlDB;
-
-    public:
-
-        ExclusiveDBGuard( LevelDB& _levedDB ) : m_levedlDB( _levedDB ) {
-            if ( m_levedlDB.m_restartPeriodMs == 0 )
-                return;
-            m_levedlDB.m_dbMutex.lock();
-        }
-
-        ~ExclusiveDBGuard() {
-            if ( m_levedlDB.m_restartPeriodMs == 0 )
-                return;
-            m_levedlDB.m_dbMutex.unlock();
-        }
-    };
-    void openDBInstanceUnsafe();
-    uint64_t getCurrentTimeMs();
-    void reopenDataBaseIfNeeded();
-};
-
-}  // namespace db
-}  // namespace dev
+}  // namespace dev: db

--- a/libdevcore/LevelDB.h
+++ b/libdevcore/LevelDB.h
@@ -29,7 +29,7 @@
 #include "shared_mutex"
 #include <secp256k1_sha256.h>
 
-namespace dev : db {
+namespace dev::db {
     class LevelDB : public DatabaseFace {
     public:
         static leveldb::ReadOptions defaultReadOptions();

--- a/libdevcore/LevelDB.h
+++ b/libdevcore/LevelDB.h
@@ -42,7 +42,7 @@ public:
     explicit LevelDB( boost::filesystem::path const& _path,
         leveldb::ReadOptions _readOptions = defaultReadOptions(),
         leveldb::WriteOptions _writeOptions = defaultWriteOptions(),
-        leveldb::Options _dbOptions = defaultDBOptions(), uint64_t _restartPeriodS = 0 );
+        leveldb::Options _dbOptions = defaultDBOptions(), uint64_t _restartPeriodMs = 0 );
 
     ~LevelDB();
 
@@ -79,8 +79,8 @@ private:
     leveldb::WriteOptions const m_writeOptions;
     leveldb::Options m_options;
     boost::filesystem::path const m_path;
-    uint64_t m_restartPeriodS;
-    uint64_t m_lastDBOpenTimeS;
+    uint64_t m_restartPeriodMs;
+    uint64_t m_lastDBOpenTimeMs;
     mutable std::shared_mutex m_dbMutex;
 
 
@@ -92,14 +92,14 @@ private:
 
     public:
         explicit SharedDBGuard( const LevelDB& _levedDB ) : m_levedlDB( _levedDB ) {
-            if ( m_levedlDB.m_restartPeriodS == 0 )
+            if ( m_levedlDB.m_restartPeriodMs == 0 )
                 return;
             m_levedlDB.m_dbMutex.lock_shared();
         }
 
 
         ~SharedDBGuard() {
-            if ( m_levedlDB.m_restartPeriodS == 0 )
+            if ( m_levedlDB.m_restartPeriodMs == 0 )
                 return;
             m_levedlDB.m_dbMutex.unlock_shared();
         }
@@ -111,19 +111,19 @@ private:
     public:
 
         ExclusiveDBGuard( LevelDB& _levedDB ) : m_levedlDB( _levedDB ) {
-            if ( m_levedlDB.m_restartPeriodS == 0 )
+            if ( m_levedlDB.m_restartPeriodMs == 0 )
                 return;
             m_levedlDB.m_dbMutex.lock();
         }
 
         ~ExclusiveDBGuard() {
-            if ( m_levedlDB.m_restartPeriodS == 0 )
+            if ( m_levedlDB.m_restartPeriodMs == 0 )
                 return;
             m_levedlDB.m_dbMutex.unlock();
         }
     };
     void openDBInstanceUnsafe();
-    uint64_t getCurrentTimeS();
+    uint64_t getCurrentTimeMs();
     void reopenDataBaseIfNeeded();
 };
 

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -68,6 +68,9 @@ private:
 };
 
 static constexpr int64_t c_infiniteBlockNumber = std::numeric_limits< int64_t >::max();
+// default value for leveldbReopenIntervalMs is 1 day
+// negative value means reopenings are disabled
+static constexpr int64_t c_defaultLevelDBReopenIntervalMs = 24 * 60 * 60 * 1000;
 
 /// skale
 struct NodeInfo {
@@ -168,6 +171,7 @@ public:
     bool freeContractDeployment = false;
     bool multiTransactionMode = false;
     int emptyBlockIntervalMs = -1;
+    int64_t levelDBReopenIntervalMs = -1;
     size_t t = 1;
     time_t revertableFSPatchTimestamp = 0;
     time_t contractStoragePatchTimestamp = 0;

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -165,8 +165,7 @@ ChainParams ChainParams::loadConfig(
 
     return cp;
 }
-void ChainParams::processSkaleConfigItems(
-    ChainParams& cp, json_spirit::mObject& obj ) {
+void ChainParams::processSkaleConfigItems( ChainParams& cp, json_spirit::mObject& obj ) {
     auto skaleObj = obj[c_skaleConfig].get_obj();
 
     auto infoObj = skaleObj.at( "nodeInfo" ).get_obj();
@@ -184,267 +183,266 @@ void ChainParams::processSkaleConfigItems(
     } catch ( ... ) {
     }
     try {
-            port = infoObj.at( "basePort" ).get_int();
-        } catch ( ... ) {
-        }
-        try {
-            ip6 = infoObj.at( "bindIP6" ).get_str();
-        } catch ( ... ) {
-        }
-        try {
-            port6 = infoObj.at( "basePort6" ).get_int();
-        } catch ( ... ) {
-        }
-        try {
-            syncNode = infoObj.at( "syncNode" ).get_bool();
-        } catch ( ... ) {
-        }
-        try {
-            archiveMode = infoObj.at( "archiveMode" ).get_bool();
-        } catch ( ... ) {
-        }
-        try {
-            syncFromCatchup = infoObj.at( "syncFromCatchup" ).get_bool();
-        } catch ( ... ) {
-        }
+        port = infoObj.at( "basePort" ).get_int();
+    } catch ( ... ) {
+    }
+    try {
+        ip6 = infoObj.at( "bindIP6" ).get_str();
+    } catch ( ... ) {
+    }
+    try {
+        port6 = infoObj.at( "basePort6" ).get_int();
+    } catch ( ... ) {
+    }
+    try {
+        syncNode = infoObj.at( "syncNode" ).get_bool();
+    } catch ( ... ) {
+    }
+    try {
+        archiveMode = infoObj.at( "archiveMode" ).get_bool();
+    } catch ( ... ) {
+    }
+    try {
+        syncFromCatchup = infoObj.at( "syncFromCatchup" ).get_bool();
+    } catch ( ... ) {
+    }
 
-        try {
-            cp.rotateAfterBlock_ = infoObj.at( "rotateAfterBlock" ).get_int();
-        } catch ( ... ) {
-        }
-        if ( cp.rotateAfterBlock_ < 0 )
-            cp.rotateAfterBlock_ = 0;
+    try {
+        cp.rotateAfterBlock_ = infoObj.at( "rotateAfterBlock" ).get_int();
+    } catch ( ... ) {
+    }
+    if ( cp.rotateAfterBlock_ < 0 )
+        cp.rotateAfterBlock_ = 0;
 
-        string ecdsaKeyName;
-        try {
-            ecdsaKeyName = infoObj.at( "ecdsaKeyName" ).get_str();
-        } catch ( ... ) {
-        }
+    string ecdsaKeyName;
+    try {
+        ecdsaKeyName = infoObj.at( "ecdsaKeyName" ).get_str();
+    } catch ( ... ) {
+    }
 
-        array< string, 4 > BLSPublicKeys;
-        array< string, 4 > commonBLSPublicKeys;
+    array< string, 4 > BLSPublicKeys;
+    array< string, 4 > commonBLSPublicKeys;
 
-        try {
-            js::mObject ima = infoObj.at( "wallets" ).get_obj().at( "ima" ).get_obj();
+    try {
+        js::mObject ima = infoObj.at( "wallets" ).get_obj().at( "ima" ).get_obj();
 
-            keyShareName = ima.at( "keyShareName" ).get_str();
+        keyShareName = ima.at( "keyShareName" ).get_str();
 
-            t = ima.at( "t" ).get_int();
+        t = ima.at( "t" ).get_int();
 
-            BLSPublicKeys[0] = ima["BLSPublicKey0"].get_str();
-            BLSPublicKeys[1] = ima["BLSPublicKey1"].get_str();
-            BLSPublicKeys[2] = ima["BLSPublicKey2"].get_str();
-            BLSPublicKeys[3] = ima["BLSPublicKey3"].get_str();
+        BLSPublicKeys[0] = ima["BLSPublicKey0"].get_str();
+        BLSPublicKeys[1] = ima["BLSPublicKey1"].get_str();
+        BLSPublicKeys[2] = ima["BLSPublicKey2"].get_str();
+        BLSPublicKeys[3] = ima["BLSPublicKey3"].get_str();
 
-            commonBLSPublicKeys[0] = ima["commonBLSPublicKey0"].get_str();
-            commonBLSPublicKeys[1] = ima["commonBLSPublicKey1"].get_str();
-            commonBLSPublicKeys[2] = ima["commonBLSPublicKey2"].get_str();
-            commonBLSPublicKeys[3] = ima["commonBLSPublicKey3"].get_str();
-        } catch ( ... ) {
-            // all or nothing
-            if ( !keyShareName.empty() )
-                throw;
-        }
+        commonBLSPublicKeys[0] = ima["commonBLSPublicKey0"].get_str();
+        commonBLSPublicKeys[1] = ima["commonBLSPublicKey1"].get_str();
+        commonBLSPublicKeys[2] = ima["commonBLSPublicKey2"].get_str();
+        commonBLSPublicKeys[3] = ima["commonBLSPublicKey3"].get_str();
+    } catch ( ... ) {
+        // all or nothing
+        if ( !keyShareName.empty() )
+            throw;
+    }
 
-        cp.nodeInfo = { nodeName, nodeID, ip, static_cast< uint16_t >( port ), ip6,
-            static_cast< uint16_t >( port6 ), sgxServerUrl, ecdsaKeyName, keyShareName,
-            BLSPublicKeys, commonBLSPublicKeys, syncNode, archiveMode, syncFromCatchup };
+    cp.nodeInfo = { nodeName, nodeID, ip, static_cast< uint16_t >( port ), ip6,
+        static_cast< uint16_t >( port6 ), sgxServerUrl, ecdsaKeyName, keyShareName, BLSPublicKeys,
+        commonBLSPublicKeys, syncNode, archiveMode, syncFromCatchup };
 
-        auto sChainObj = skaleObj.at( "sChain" ).get_obj();
-        SChain s{};
-        s.nodes.clear();
+    auto sChainObj = skaleObj.at( "sChain" ).get_obj();
+    SChain s{};
+    s.nodes.clear();
 
-        s.name = sChainObj.at( "schainName" ).get_str();
-        s.id = sChainObj.at( "schainID" ).get_uint64();
-        s.t = t;
-        if ( sChainObj.count( "schainOwner" ) ) {
-            s.owner = jsToAddress( sChainObj.at( "schainOwner" ).get_str() );
-            s.blockAuthor = jsToAddress( sChainObj.at( "schainOwner" ).get_str() );
-        }
-        if ( sChainObj.count( "blockAuthor" ) )
-            s.blockAuthor = jsToAddress( sChainObj.at( "blockAuthor" ).get_str() );
+    s.name = sChainObj.at( "schainName" ).get_str();
+    s.id = sChainObj.at( "schainID" ).get_uint64();
+    s.t = t;
+    if ( sChainObj.count( "schainOwner" ) ) {
+        s.owner = jsToAddress( sChainObj.at( "schainOwner" ).get_str() );
+        s.blockAuthor = jsToAddress( sChainObj.at( "schainOwner" ).get_str() );
+    }
+    if ( sChainObj.count( "blockAuthor" ) )
+        s.blockAuthor = jsToAddress( sChainObj.at( "blockAuthor" ).get_str() );
 
-        s.snapshotIntervalSec = sChainObj.count( "snapshotIntervalSec" ) ?
-                                    sChainObj.at( "snapshotIntervalSec" ).get_int() :
-                                    0;
+    s.snapshotIntervalSec = sChainObj.count( "snapshotIntervalSec" ) ?
+                                sChainObj.at( "snapshotIntervalSec" ).get_int() :
+                                0;
 
-        s.snapshotDownloadTimeout = sChainObj.count( "snapshotDownloadTimeout" ) ?
-                                        sChainObj.at( "snapshotDownloadTimeout" ).get_int() :
-                                        3600;
+    s.snapshotDownloadTimeout = sChainObj.count( "snapshotDownloadTimeout" ) ?
+                                    sChainObj.at( "snapshotDownloadTimeout" ).get_int() :
+                                    3600;
 
-        s.snapshotDownloadInactiveTimeout =
-            sChainObj.count( "snapshotDownloadInactiveTimeout" ) ?
-                sChainObj.at( "snapshotDownloadInactiveTimeout" ).get_int() :
-                3600;
+    s.snapshotDownloadInactiveTimeout =
+        sChainObj.count( "snapshotDownloadInactiveTimeout" ) ?
+            sChainObj.at( "snapshotDownloadInactiveTimeout" ).get_int() :
+            3600;
 
-        s.emptyBlockIntervalMs = sChainObj.count( "emptyBlockIntervalMs" ) ?
-                                     sChainObj.at( "emptyBlockIntervalMs" ).get_int() :
-                                     0;
+    s.emptyBlockIntervalMs = sChainObj.count( "emptyBlockIntervalMs" ) ?
+                                 sChainObj.at( "emptyBlockIntervalMs" ).get_int() :
+                                 0;
 
-        // negative levelDBReopenIntervalMs means restarts are disabled
-        s.levelDBReopenIntervalMs = sChainObj.count( "levelDBReopenIntervalMs" ) ?
-                                        sChainObj.at( "levelDBReopenIntervalMs" ).get_int64() :
-                                        c_defaultLevelDBReopenIntervalMs;
+    // negative levelDBReopenIntervalMs means restarts are disabled
+    s.levelDBReopenIntervalMs = sChainObj.count( "levelDBReopenIntervalMs" ) ?
+                                    sChainObj.at( "levelDBReopenIntervalMs" ).get_int64() :
+                                    c_defaultLevelDBReopenIntervalMs;
 
-        s.contractStorageLimit = sChainObj.count( "contractStorageLimit" ) ?
-                                     sChainObj.at( "contractStorageLimit" ).get_int64() :
-                                     0;
+    s.contractStorageLimit = sChainObj.count( "contractStorageLimit" ) ?
+                                 sChainObj.at( "contractStorageLimit" ).get_int64() :
+                                 0;
 
-        s.dbStorageLimit =
-            sChainObj.count( "dbStorageLimit" ) ? sChainObj.at( "dbStorageLimit" ).get_int64() : 0;
+    s.dbStorageLimit =
+        sChainObj.count( "dbStorageLimit" ) ? sChainObj.at( "dbStorageLimit" ).get_int64() : 0;
 
 
-        if ( sChainObj.count( "maxConsensusStorageBytes" ) ) {
-            s.consensusStorageLimit = sChainObj.at( "maxConsensusStorageBytes" ).get_int64();
-        }
+    if ( sChainObj.count( "maxConsensusStorageBytes" ) ) {
+        s.consensusStorageLimit = sChainObj.at( "maxConsensusStorageBytes" ).get_int64();
+    }
 
-        if ( sChainObj.count( "freeContractDeployment" ) )
-            s.freeContractDeployment = sChainObj.at( "freeContractDeployment" ).get_bool();
+    if ( sChainObj.count( "freeContractDeployment" ) )
+        s.freeContractDeployment = sChainObj.at( "freeContractDeployment" ).get_bool();
 
-        if ( sChainObj.count( "multiTransactionMode" ) )
-            s.multiTransactionMode = sChainObj.at( "multiTransactionMode" ).get_bool();
+    if ( sChainObj.count( "multiTransactionMode" ) )
+        s.multiTransactionMode = sChainObj.at( "multiTransactionMode" ).get_bool();
 
-        if ( sChainObj.count( "revertableFSPatchTimestamp" ) )
-            s.revertableFSPatchTimestamp = sChainObj.at( "revertableFSPatchTimestamp" ).get_int64();
+    if ( sChainObj.count( "revertableFSPatchTimestamp" ) )
+        s.revertableFSPatchTimestamp = sChainObj.at( "revertableFSPatchTimestamp" ).get_int64();
 
-        s.contractStoragePatchTimestamp =
-            sChainObj.count( "contractStoragePatchTimestamp" ) ?
-                sChainObj.at( "contractStoragePatchTimestamp" ).get_int64() :
-                0;
+    s.contractStoragePatchTimestamp =
+        sChainObj.count( "contractStoragePatchTimestamp" ) ?
+            sChainObj.at( "contractStoragePatchTimestamp" ).get_int64() :
+            0;
 
-        s.contractStorageZeroValuePatchTimestamp =
-            sChainObj.count( "contractStorageZeroValuePatchTimestamp" ) ?
-                sChainObj.at( "contractStorageZeroValuePatchTimestamp" ).get_int64() :
-                0;
+    s.contractStorageZeroValuePatchTimestamp =
+        sChainObj.count( "contractStorageZeroValuePatchTimestamp" ) ?
+            sChainObj.at( "contractStorageZeroValuePatchTimestamp" ).get_int64() :
+            0;
 
-        s.verifyDaSigsPatchTimestamp =
-            sChainObj.count( "verifyDaSigsPatchTimestamp" ) ?
-                sChainObj.at( "verifyDaSigsPatchTimestamp" ).get_int64() :
-                0;
-
-        s.storageDestructionPatchTimestamp =
-            sChainObj.count( "storageDestructionPatchTimestamp" ) ?
-                sChainObj.at( "storageDestructionPatchTimestamp" ).get_int64() :
-                0;
-
-        s.powCheckPatchTimestamp = sChainObj.count( "powCheckPatchTimestamp" ) ?
-                                       sChainObj.at( "powCheckPatchTimestamp" ).get_int64() :
+    s.verifyDaSigsPatchTimestamp = sChainObj.count( "verifyDaSigsPatchTimestamp" ) ?
+                                       sChainObj.at( "verifyDaSigsPatchTimestamp" ).get_int64() :
                                        0;
 
-        s.precompiledConfigPatchTimestamp =
-            sChainObj.count( "precompiledConfigPatchTimestamp" ) ?
-                sChainObj.at( "precompiledConfigPatchTimestamp" ).get_int64() :
-                0;
+    s.storageDestructionPatchTimestamp =
+        sChainObj.count( "storageDestructionPatchTimestamp" ) ?
+            sChainObj.at( "storageDestructionPatchTimestamp" ).get_int64() :
+            0;
 
-        s.pushZeroPatchTimestamp = sChainObj.count( "pushZeroPatchTimestamp" ) ?
-                                       sChainObj.at( "pushZeroPatchTimestamp" ).get_int64() :
-                                       0;
+    s.powCheckPatchTimestamp = sChainObj.count( "powCheckPatchTimestamp" ) ?
+                                   sChainObj.at( "powCheckPatchTimestamp" ).get_int64() :
+                                   0;
 
-        s.skipInvalidTransactionsPatchTimestamp =
-            sChainObj.count( "skipInvalidTransactionsPatchTimestamp" ) ?
-                sChainObj.at( "skipInvalidTransactionsPatchTimestamp" ).get_int64() :
-                0;
+    s.precompiledConfigPatchTimestamp =
+        sChainObj.count( "precompiledConfigPatchTimestamp" ) ?
+            sChainObj.at( "precompiledConfigPatchTimestamp" ).get_int64() :
+            0;
 
-        s.correctForkInPowPatchTimestamp =
-            sChainObj.count( "correctForkInPowPatchTimestamp" ) ?
-                sChainObj.at( "correctForkInPowPatchTimestamp" ).get_int64() :
-                0;
+    s.pushZeroPatchTimestamp = sChainObj.count( "pushZeroPatchTimestamp" ) ?
+                                   sChainObj.at( "pushZeroPatchTimestamp" ).get_int64() :
+                                   0;
 
-        if ( sChainObj.count( "nodeGroups" ) ) {
-            vector< NodeGroup > nodeGroups;
-            for ( const auto& nodeGroupConf : sChainObj["nodeGroups"].get_obj() ) {
-                NodeGroup nodeGroup;
-                auto nodeGroupObj = nodeGroupConf.second.get_obj();
-                if ( nodeGroupObj["bls_public_key"].is_null() )
-                    // failed dkg, skip it
-                    continue;
+    s.skipInvalidTransactionsPatchTimestamp =
+        sChainObj.count( "skipInvalidTransactionsPatchTimestamp" ) ?
+            sChainObj.at( "skipInvalidTransactionsPatchTimestamp" ).get_int64() :
+            0;
 
-                vector< GroupNode > groupNodes;
-                auto groupNodesObj = nodeGroupObj["nodes"].get_obj();
-                for ( const auto& groupNodeConf : groupNodesObj ) {
-                    auto groupNodeConfObj = groupNodeConf.second.get_array();
-                    u256 sChainIndex = groupNodeConfObj.at( 0 ).get_uint64();
-                    u256 id = groupNodeConfObj.at( 1 ).get_uint64();
-                    string publicKey = groupNodeConfObj.at( 2 ).get_str();
-                    if ( publicKey.empty() ) {
-                        BOOST_THROW_EXCEPTION( runtime_error( "Empty public key in config" ) );
-                    }
-                    groupNodes.push_back( { id, sChainIndex, publicKey } );
+    s.correctForkInPowPatchTimestamp =
+        sChainObj.count( "correctForkInPowPatchTimestamp" ) ?
+            sChainObj.at( "correctForkInPowPatchTimestamp" ).get_int64() :
+            0;
+
+    if ( sChainObj.count( "nodeGroups" ) ) {
+        vector< NodeGroup > nodeGroups;
+        for ( const auto& nodeGroupConf : sChainObj["nodeGroups"].get_obj() ) {
+            NodeGroup nodeGroup;
+            auto nodeGroupObj = nodeGroupConf.second.get_obj();
+            if ( nodeGroupObj["bls_public_key"].is_null() )
+                // failed dkg, skip it
+                continue;
+
+            vector< GroupNode > groupNodes;
+            auto groupNodesObj = nodeGroupObj["nodes"].get_obj();
+            for ( const auto& groupNodeConf : groupNodesObj ) {
+                auto groupNodeConfObj = groupNodeConf.second.get_array();
+                u256 sChainIndex = groupNodeConfObj.at( 0 ).get_uint64();
+                u256 id = groupNodeConfObj.at( 1 ).get_uint64();
+                string publicKey = groupNodeConfObj.at( 2 ).get_str();
+                if ( publicKey.empty() ) {
+                    BOOST_THROW_EXCEPTION( runtime_error( "Empty public key in config" ) );
                 }
-                sort( groupNodes.begin(), groupNodes.end(),
-                    []( const GroupNode& lhs, const GroupNode& rhs ) {
-                        return lhs.schainIndex < rhs.schainIndex;
-                    } );
-                nodeGroup.nodes = groupNodes;
-
-                array< string, 4 > nodeGroupBlsPublicKey;
-                auto nodeGroupBlsPublicKeyObj = nodeGroupObj["bls_public_key"].get_obj();
-                nodeGroupBlsPublicKey[0] = nodeGroupBlsPublicKeyObj["blsPublicKey0"].get_str();
-                nodeGroupBlsPublicKey[1] = nodeGroupBlsPublicKeyObj["blsPublicKey1"].get_str();
-                nodeGroupBlsPublicKey[2] = nodeGroupBlsPublicKeyObj["blsPublicKey2"].get_str();
-                nodeGroupBlsPublicKey[3] = nodeGroupBlsPublicKeyObj["blsPublicKey3"].get_str();
-                nodeGroup.blsPublicKey = nodeGroupBlsPublicKey;
-
-                if ( !nodeGroupObj["finish_ts"].is_null() )
-                    nodeGroup.finishTs = nodeGroupObj["finish_ts"].get_uint64();
-                else
-                    nodeGroup.finishTs = uint64_t( -1 );
-                nodeGroups.push_back( nodeGroup );
+                groupNodes.push_back( { id, sChainIndex, publicKey } );
             }
-            sort( nodeGroups.begin(), nodeGroups.end(),
-                []( const NodeGroup& lhs, const NodeGroup& rhs ) {
-                    return lhs.finishTs < rhs.finishTs;
+            sort( groupNodes.begin(), groupNodes.end(),
+                []( const GroupNode& lhs, const GroupNode& rhs ) {
+                    return lhs.schainIndex < rhs.schainIndex;
                 } );
-            s.nodeGroups = nodeGroups;
-        }
+            nodeGroup.nodes = groupNodes;
 
-        for ( auto nodeConf : sChainObj.at( "nodes" ).get_array() ) {
-            auto nodeConfObj = nodeConf.get_obj();
-            sChainNode node{};
-            node.id = nodeConfObj.at( "nodeID" ).get_uint64();
-            node.ip = nodeConfObj.at( "ip" ).get_str();
-            node.port = nodeConfObj.at( "basePort" ).get_uint64();
-            try {
-                node.ip6 = nodeConfObj.at( "ip6" ).get_str();
-            } catch ( ... ) {
-                node.ip6 = "";
-            }
-            try {
-                node.port6 = nodeConfObj.at( "basePort6" ).get_uint64();
-            } catch ( ... ) {
-                node.port6 = 0;
-            }
-            node.sChainIndex = nodeConfObj.at( "schainIndex" ).get_uint64();
-            try {
-                node.publicKey = nodeConfObj.at( "publicKey" ).get_str();
-            } catch ( ... ) {
-            }
-            if ( !keyShareName.empty() ) {
-                try {
-                    node.blsPublicKey[0] = nodeConfObj.at( "blsPublicKey0" ).get_str();
-                    node.blsPublicKey[1] = nodeConfObj.at( "blsPublicKey1" ).get_str();
-                    node.blsPublicKey[2] = nodeConfObj.at( "blsPublicKey2" ).get_str();
-                    node.blsPublicKey[3] = nodeConfObj.at( "blsPublicKey3" ).get_str();
-                } catch ( ... ) {
-                    node.blsPublicKey[0] = "";
-                    node.blsPublicKey[1] = "";
-                    node.blsPublicKey[2] = "";
-                    node.blsPublicKey[3] = "";
-                }
-            }
-            s.nodes.push_back( node );
-        }
-        cp.sChain = s;
+            array< string, 4 > nodeGroupBlsPublicKey;
+            auto nodeGroupBlsPublicKeyObj = nodeGroupObj["bls_public_key"].get_obj();
+            nodeGroupBlsPublicKey[0] = nodeGroupBlsPublicKeyObj["blsPublicKey0"].get_str();
+            nodeGroupBlsPublicKey[1] = nodeGroupBlsPublicKeyObj["blsPublicKey1"].get_str();
+            nodeGroupBlsPublicKey[2] = nodeGroupBlsPublicKeyObj["blsPublicKey2"].get_str();
+            nodeGroupBlsPublicKey[3] = nodeGroupBlsPublicKeyObj["blsPublicKey3"].get_str();
+            nodeGroup.blsPublicKey = nodeGroupBlsPublicKey;
 
-        cp.vecAdminOrigins.clear();
-        if ( infoObj.count( "adminOrigins" ) ) {
-            for ( auto nodeOrigun : infoObj.at( "adminOrigins" ).get_array() ) {
-                string strOriginWildcardFilter = nodeOrigun.get_str();
-                cp.vecAdminOrigins.push_back( strOriginWildcardFilter );
-            }
-        } else {
-            cp.vecAdminOrigins.push_back( "*" );
+            if ( !nodeGroupObj["finish_ts"].is_null() )
+                nodeGroup.finishTs = nodeGroupObj["finish_ts"].get_uint64();
+            else
+                nodeGroup.finishTs = uint64_t( -1 );
+            nodeGroups.push_back( nodeGroup );
         }
+        sort(
+            nodeGroups.begin(), nodeGroups.end(), []( const NodeGroup& lhs, const NodeGroup& rhs ) {
+                return lhs.finishTs < rhs.finishTs;
+            } );
+        s.nodeGroups = nodeGroups;
+    }
+
+    for ( auto nodeConf : sChainObj.at( "nodes" ).get_array() ) {
+        auto nodeConfObj = nodeConf.get_obj();
+        sChainNode node{};
+        node.id = nodeConfObj.at( "nodeID" ).get_uint64();
+        node.ip = nodeConfObj.at( "ip" ).get_str();
+        node.port = nodeConfObj.at( "basePort" ).get_uint64();
+        try {
+            node.ip6 = nodeConfObj.at( "ip6" ).get_str();
+        } catch ( ... ) {
+            node.ip6 = "";
+        }
+        try {
+            node.port6 = nodeConfObj.at( "basePort6" ).get_uint64();
+        } catch ( ... ) {
+            node.port6 = 0;
+        }
+        node.sChainIndex = nodeConfObj.at( "schainIndex" ).get_uint64();
+        try {
+            node.publicKey = nodeConfObj.at( "publicKey" ).get_str();
+        } catch ( ... ) {
+        }
+        if ( !keyShareName.empty() ) {
+            try {
+                node.blsPublicKey[0] = nodeConfObj.at( "blsPublicKey0" ).get_str();
+                node.blsPublicKey[1] = nodeConfObj.at( "blsPublicKey1" ).get_str();
+                node.blsPublicKey[2] = nodeConfObj.at( "blsPublicKey2" ).get_str();
+                node.blsPublicKey[3] = nodeConfObj.at( "blsPublicKey3" ).get_str();
+            } catch ( ... ) {
+                node.blsPublicKey[0] = "";
+                node.blsPublicKey[1] = "";
+                node.blsPublicKey[2] = "";
+                node.blsPublicKey[3] = "";
+            }
+        }
+        s.nodes.push_back( node );
+    }
+    cp.sChain = s;
+
+    cp.vecAdminOrigins.clear();
+    if ( infoObj.count( "adminOrigins" ) ) {
+        for ( auto nodeOrigun : infoObj.at( "adminOrigins" ).get_array() ) {
+            string strOriginWildcardFilter = nodeOrigun.get_str();
+            cp.vecAdminOrigins.push_back( strOriginWildcardFilter );
+        }
+    } else {
+        cp.vecAdminOrigins.push_back( "*" );
+    }
 }
 
 ChainParams ChainParams::loadGenesis( string const& _json ) const {

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -221,6 +221,11 @@ ChainParams ChainParams::loadConfig(
                                      sChainObj.at( "emptyBlockIntervalMs" ).get_int() :
                                      0;
 
+        // negative levelDBReopenIntervalMs means restarts are disabled
+        s.levelDBReopenIntervalMs = sChainObj.count( "levelDBReopenIntervalMs" ) ?
+                                        sChainObj.at( "levelDBReopenIntervalMs" ).get_int64() :
+                                        c_defaultLevelDBReopenIntervalMs;
+
         s.contractStorageLimit = sChainObj.count( "contractStorageLimit" ) ?
                                      sChainObj.at( "contractStorageLimit" ).get_int64() :
                                      0;

--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -24,12 +24,11 @@
 #pragma once
 
 #include "Account.h"
-#include "json_spirit/json_spirit_value.h"
 #include <libdevcore/Common.h>
 #include <libethcore/BlockHeader.h>
 #include <libethcore/ChainOperationParams.h>
 #include <libethcore/Common.h>
-
+#include <json_spirit/json_spirit.h>
 
 namespace dev::eth {
 class SealEngineFace;

--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -24,11 +24,11 @@
 #pragma once
 
 #include "Account.h"
+#include <json_spirit/json_spirit.h>
 #include <libdevcore/Common.h>
 #include <libethcore/BlockHeader.h>
 #include <libethcore/ChainOperationParams.h>
 #include <libethcore/Common.h>
-#include <json_spirit/json_spirit.h>
 
 namespace dev::eth {
 class SealEngineFace;

--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -28,9 +28,10 @@
 #include <libethcore/BlockHeader.h>
 #include <libethcore/ChainOperationParams.h>
 #include <libethcore/Common.h>
+#include "json_spirit/json_spirit_value.h"
 
-namespace dev {
-namespace eth {
+
+namespace dev::eth {
 class SealEngineFace;
 
 struct ChainParams : public ChainOperationParams {
@@ -74,6 +75,9 @@ struct ChainParams : public ChainOperationParams {
     const std::string& getOriginalJson() const;
     void resetJson() { originalJSON = ""; }
 
+    bool checkAdminOriginAllowed( const std::string& origin ) const;
+    static void processSkaleConfigItems( ChainParams& _cp, json_spirit::mObject& _obj ) ;
+
 private:
     void populateFromGenesis( bytes const& _genesisRLP, AccountMap const& _state );
 
@@ -82,9 +86,8 @@ private:
 
     mutable std::string originalJSON;
 
-public:
-    bool checkAdminOriginAllowed( const std::string& origin ) const;
+
 };
 
-}  // namespace eth
-}  // namespace dev
+}  // namespace dev::eth
+

--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -24,11 +24,11 @@
 #pragma once
 
 #include "Account.h"
+#include "json_spirit/json_spirit_value.h"
 #include <libdevcore/Common.h>
 #include <libethcore/BlockHeader.h>
 #include <libethcore/ChainOperationParams.h>
 #include <libethcore/Common.h>
-#include "json_spirit/json_spirit_value.h"
 
 
 namespace dev::eth {
@@ -76,7 +76,7 @@ struct ChainParams : public ChainOperationParams {
     void resetJson() { originalJSON = ""; }
 
     bool checkAdminOriginAllowed( const std::string& origin ) const;
-    static void processSkaleConfigItems( ChainParams& _cp, json_spirit::mObject& _obj ) ;
+    static void processSkaleConfigItems( ChainParams& _cp, json_spirit::mObject& _obj );
 
 private:
     void populateFromGenesis( bytes const& _genesisRLP, AccountMap const& _state );
@@ -85,9 +85,6 @@ private:
     ChainParams loadGenesis( std::string const& _json ) const;
 
     mutable std::string originalJSON;
-
-
 };
 
 }  // namespace dev::eth
-

--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -247,6 +247,7 @@ void validateConfigJson( js::mObject const& _obj ) {
             { "emptyBlockIntervalMs", { { js::int_type }, JsonFieldPresence::Optional } },
             { "emptyBlockIntervalAfterCatchupMs",
                 { { js::int_type }, JsonFieldPresence::Optional } },
+            { "levelDBReopenIntervalMs", { { js::int_type }, JsonFieldPresence::Optional } },
             { "snapshotIntervalSec", { { js::int_type }, JsonFieldPresence::Optional } },
             { "snapshotDownloadTimeout", { { js::int_type }, JsonFieldPresence::Optional } },
             { "snapshotDownloadInactiveTimeout",

--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -154,6 +154,7 @@ void validateConfigJson( js::mObject const& _obj ) {
             { "emptyBlockIntervalMs", { { js::int_type }, JsonFieldPresence::Optional } },
             { "emptyBlockIntervalAfterCatchupMs",
                 { { js::int_type }, JsonFieldPresence::Optional } },
+            { "leveldbReopenIntervalMs", { { js::int_type }, JsonFieldPresence::Optional } },
             { "snapshotIntervalSec", { { js::int_type }, JsonFieldPresence::Optional } },
             { "rotateAfterBlock", { { js::int_type }, JsonFieldPresence::Optional } },
             { "wallets", { { js::obj_type }, JsonFieldPresence::Optional } },

--- a/libhistoric/HistoricState.cpp
+++ b/libhistoric/HistoricState.cpp
@@ -65,7 +65,8 @@ OverlayDB HistoricState::openDB(
 
     try {
         clog( VerbosityTrace, "statedb" ) << "Opening state database";
-        std::unique_ptr< db::DatabaseFace > db = db::DBFactory::create( dbPaths.statePath() );
+        std::unique_ptr< db::DatabaseFace > db =
+            db::DBFactory::create( db::DatabaseKind::LevelDBHistoricState, dbPaths.statePath() );
         return OverlayDB( std::move( db ) );
     } catch ( boost::exception const& ex ) {
         if ( db::isDiskDatabase() ) {

--- a/libhistoric/HistoricState.cpp
+++ b/libhistoric/HistoricState.cpp
@@ -66,7 +66,7 @@ OverlayDB HistoricState::openDB(
     try {
         clog( VerbosityTrace, "statedb" ) << "Opening state database";
         std::unique_ptr< db::DatabaseFace > db =
-            db::DBFactory::create( db::DatabaseKind::LevelDBHistoricState, dbPaths.statePath() );
+            db::DBFactory::createHistoric( db::DatabaseKind::LevelDB, dbPaths.statePath() );
         return OverlayDB( std::move( db ) );
     } catch ( boost::exception const& ex ) {
         if ( db::isDiskDatabase() ) {

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1078,7 +1078,7 @@ int main( int argc, char** argv ) try {
             chainConfigParsed = true;
             dev::eth::g_configAccesssor.reset(
                 new skutils::json_config_file_accessor( configPath.string() ) );
-            dev::db::DBFactory::init( chainParams.sChain.levelDBReopenIntervalMs );
+            dev::db::DBFactory::setReopenPeriodMs( chainParams.sChain.levelDBReopenIntervalMs );
         } catch ( const char* str ) {
             clog( VerbosityError, "main" ) << "Error: " << str << ": " << configPath;
             return EX_USAGE;

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -47,6 +47,7 @@
 #include <libdevcore/LevelDB.h>
 #include <libdevcore/LoggingProgramOptions.h>
 #include <libdevcore/SharedSpace.h>
+#include <libdevcore/DBFactory.h>
 #include <libdevcore/StatusAndControl.h>
 #include <libethashseal/EthashClient.h>
 #include <libethashseal/GenesisInfo.h>
@@ -1077,6 +1078,7 @@ int main( int argc, char** argv ) try {
             chainConfigParsed = true;
             dev::eth::g_configAccesssor.reset(
                 new skutils::json_config_file_accessor( configPath.string() ) );
+            dev::db::DBFactory::init(chainParams.sChain.levelDBReopenIntervalMs);
         } catch ( const char* str ) {
             clog( VerbosityError, "main" ) << "Error: " << str << ": " << configPath;
             return EX_USAGE;

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1066,33 +1066,32 @@ int main( int argc, char** argv ) try {
         try {
             configPath = vm["config"].as< string >();
             if ( !fs::is_regular_file( configPath.string() ) )
-                throw "Bad config file path";
+                throw std::runtime_error("Bad config file path");
             configJSON = contentsString( configPath.string() );
             if ( configJSON.empty() )
-                throw "Config file probably not found";
+                throw std::runtime_error("Config file probably not found");
             chainParams = chainParams.loadConfig( configJSON, configPath );
             chainConfigIsSet = true;
-            // TODO avoid double-parse!!
+            // TODO avoid double-parse
             joConfig = nlohmann::json::parse( configJSON );
             chainConfigParsed = true;
             dev::eth::g_configAccesssor.reset(
                 new skutils::json_config_file_accessor( configPath.string() ) );
         } catch ( const char* str ) {
-            clog( VerbosityError, "main" ) << "Error: " << str << ": " << configPath << "\n";
+            clog( VerbosityError, "main" ) << "Error: " << str << ": " << configPath;
             return EX_USAGE;
         } catch ( const json_spirit::Error_position& err ) {
-            clog( VerbosityError, "main" ) << "error in parsing config json:\n";
+            clog( VerbosityError, "main" ) << "error in parsing config json:";
             clog( VerbosityError, "main" ) << configJSON;
             clog( VerbosityError, "main" ) << err.reason_ << " line " << err.line_;
             return EX_CONFIG;
         } catch ( const std::exception& ex ) {
-            clog( VerbosityError, "main" ) << "provided configuration is incorrect\n";
+            clog( VerbosityError, "main" ) << "provided configuration is incorrect";
             clog( VerbosityError, "main" ) << configJSON;
             clog( VerbosityError, "main" ) << nested_exception_what( ex );
             return EX_CONFIG;
         } catch ( ... ) {
-            clog( VerbosityError, "main" ) << "provided configuration is incorrect\n";
-            // cerr << "sample: \n" << genesisInfo(eth::Network::MainNetworkTest) << "\n";
+            clog( VerbosityError, "main" ) << "provided configuration is incorrect";
             clog( VerbosityError, "main" ) << configJSON;
             return EX_CONFIG;
         }

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -43,11 +43,11 @@
 
 #include <json_spirit/JsonSpiritHeaders.h>
 
+#include <libdevcore/DBFactory.h>
 #include <libdevcore/FileSystem.h>
 #include <libdevcore/LevelDB.h>
 #include <libdevcore/LoggingProgramOptions.h>
 #include <libdevcore/SharedSpace.h>
-#include <libdevcore/DBFactory.h>
 #include <libdevcore/StatusAndControl.h>
 #include <libethashseal/EthashClient.h>
 #include <libethashseal/GenesisInfo.h>
@@ -1067,10 +1067,10 @@ int main( int argc, char** argv ) try {
         try {
             configPath = vm["config"].as< string >();
             if ( !fs::is_regular_file( configPath.string() ) )
-                throw std::runtime_error("Bad config file path");
+                throw std::runtime_error( "Bad config file path" );
             configJSON = contentsString( configPath.string() );
             if ( configJSON.empty() )
-                throw std::runtime_error("Config file probably not found");
+                throw std::runtime_error( "Config file probably not found" );
             chainParams = chainParams.loadConfig( configJSON, configPath );
             chainConfigIsSet = true;
             // TODO avoid double-parse
@@ -1078,7 +1078,7 @@ int main( int argc, char** argv ) try {
             chainConfigParsed = true;
             dev::eth::g_configAccesssor.reset(
                 new skutils::json_config_file_accessor( configPath.string() ) );
-            dev::db::DBFactory::init(chainParams.sChain.levelDBReopenIntervalMs);
+            dev::db::DBFactory::init( chainParams.sChain.levelDBReopenIntervalMs );
         } catch ( const char* str ) {
             clog( VerbosityError, "main" ) << "Error: " << str << ": " << configPath;
             return EX_USAGE;

--- a/storage_benchmark/CMakeLists.txt
+++ b/storage_benchmark/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(
         "${DEPS_INSTALL_ROOT}/lib/liblzma.a"
     )
 
-#target_include_directories(evm_benchmark PRIVATE ../utils)
+target_include_directories(${executable_name} PRIVATE ../utils ${SKUTILS_INCLUDE_DIRS})
 
 #if(MINIUPNPC)
 #    target_compile_definitions(evm_benchmark PRIVATE ETH_MINIUPNPC)

--- a/test/historicstate/configs/basic_config.json
+++ b/test/historicstate/configs/basic_config.json
@@ -328,6 +328,7 @@
       "emptyBlockIntervalMs": 10000,
       "pushZeroPatchTimestamp": 1,
       "multiTransactionMode": true,
+      "levelDBReopenIntervalMs": 1,
       "nodes": [
         { "nodeID": 1112, "ip": "127.0.0.1", "basePort": 1231, "schainIndex" : 1, "publicKey":""}
       ]

--- a/test/historicstate/hardhat/scripts/infinite_transaction_loop_test.ts
+++ b/test/historicstate/hardhat/scripts/infinite_transaction_loop_test.ts
@@ -1,0 +1,419 @@
+import {mkdir, readdir, writeFileSync, readFile, unlink} from "fs";
+
+const fs = require('fs');
+import {existsSync} from "fs";
+import deepDiff, {diff} from 'deep-diff';
+import {expect} from "chai";
+import * as path from 'path';
+import {int, string} from "hardhat/internal/core/params/argumentTypes";
+import internal from "node:stream";
+
+const OWNER_ADDRESS: string = "0x907cd0881E50d359bb9Fd120B1A5A143b1C97De6";
+const CALL_ADDRESS: string = "0xCe5c7ca85F8cB94FA284a303348ef42ADD23f5e7";
+
+const ZERO_ADDRESS: string = '0x0000000000000000000000000000000000000000';
+const INITIAL_MINT: bigint = 10000000000000000000000000000000000000000n;
+const TEST_CONTRACT_NAME = "Tracer";
+const EXECUTE_FUNCTION_NAME = "mint";
+const EXECUTE2_FUNCTION_NAME = "mint2";
+const EXECUTE3_FUNCTION_NAME = "readableRevert";
+const CALL_FUNCTION_NAME = "getBalance";
+
+
+
+
+
+var DEPLOYED_CONTRACT_ADDRESS_LOWER_CASE: string = "";
+var globalCallCount = 0;
+
+
+async function replaceAddressesWithSymbolicNames(_traceFileName: string) {
+
+    let callAddressLowerCase = CALL_ADDRESS.toLowerCase();
+
+    await replaceStringInFile(SKALE_TRACES_DIR + _traceFileName,
+        callAddressLowerCase, "CALL.address");
+
+    let ownerAddressLowerCase = OWNER_ADDRESS.toLowerCase();
+
+    await replaceStringInFile(SKALE_TRACES_DIR + _traceFileName,
+        ownerAddressLowerCase, "OWNER.address");
+
+    // if the contract has been deployed, also replace contract address
+
+    if (DEPLOYED_CONTRACT_ADDRESS_LOWER_CASE.length > 0) {
+        await replaceStringInFile(SKALE_TRACES_DIR + _traceFileName,
+            DEPLOYED_CONTRACT_ADDRESS_LOWER_CASE, TEST_CONTRACT_NAME + ".address");
+
+    }
+
+
+}
+
+async function getTraceJsonOptions(_tracer: string): Promise<object> {
+    if (_tracer == DEFAULT_TRACER) {
+        return {};
+    }
+
+    if (_tracer == PRESTATEDIFF_TRACER) {
+        return {"tracer": PRESTATE_TRACER, "tracerConfig": {diffMode: true}};
+    }
+
+    return {"tracer": _tracer}
+}
+
+
+async function deleteAndRecreateDirectory(dirPath: string): Promise<void> {
+    try {
+        // Remove the directory and its contents
+        await deleteDirectory(dirPath);
+    } catch (error) {
+    }
+    try {
+
+        // Recreate the directory
+
+        if (!fs.existsSync(dirPath)) {
+            fs.mkdirSync(dirPath);
+        }
+        console.log(`Directory recreated: ${dirPath}`);
+    } catch (error) {
+        console.error('An error occurred:', error);
+    }
+}
+
+async function deleteDirectory(dirPath: string): Promise<void> {
+    if (!fs.existsSync(dirPath))
+        return;
+    const entries = fs.readdirSync(dirPath);
+
+    // Iterate over directory contents
+    for (const entry of entries) {
+        const entryPath = path.join(dirPath, entry.name);
+
+        if (entry.isDirectory()) {
+            // Recursive call for nested directories
+            await deleteDirectory(entryPath);
+        } else {
+            // Delete file
+            await fs.unlink(entryPath);
+        }
+    }
+
+    // Delete the now-empty directory
+    await fs.rmdir(dirPath);
+}
+
+
+/**
+ * Replaces a string in a file.
+ * @param {string} _filePath - The path to the file.
+ * @param {string} _str1 - The string to be replaced.
+ * @param {string} _str2 - The string to replace with.
+ */
+async function replaceStringInFile(_filePath, _str1, _str2) {
+    // Read the file
+
+    let data = fs.readFileSync(_filePath, 'utf8');
+
+    // Replace the string
+    const transformedFile = data.replace(new RegExp(_str1, 'g'), _str2);
+
+    // Write the file
+    fs.writeFileSync(_filePath, transformedFile, 'utf8');
+
+}
+
+
+async function waitUntilNextBlock() {
+
+    const current = await hre.ethers.provider.getBlockNumber();
+    let newBlock = current;
+    console.log(`BLOCK_NUMBER ${current}`);
+
+    while (newBlock == current) {
+        newBlock = await hre.ethers.provider.getBlockNumber();
+    }
+
+    console.log(`BLOCK_NUMBER ${newBlock}`);
+
+    return current;
+
+}
+
+function CHECK(result: any): void {
+    if (!result) {
+        const message: string = `Check failed ${result}`
+        console.log(message);
+        throw message;
+    }
+
+
+}
+
+async function getBlockTrace(blockNumber: number): Promise<String> {
+
+    const blockStr = "0x" + blockNumber.toString(16);
+    //trace both empty tracer and no tracer
+    let trace = await ethers.provider.send('debug_traceBlockByNumber', [blockStr]);
+    trace = await ethers.provider.send('debug_traceBlockByNumber', [blockStr, {}]);
+
+    return trace;
+}
+
+
+async function deployTestContract(): Promise<object> {
+
+    console.log(`Deploying ` + TEST_CONTRACT_NAME);
+
+    const factory = await ethers.getContractFactory(TEST_CONTRACT_NAME);
+    const testContractName = await factory.deploy({
+        gasLimit: 2100000, // this is just an example value; you'll need to set an appropriate gas limit for your specific function call
+    });
+    const deployedTestContract = await testContractName.deployed();
+
+    const deployReceipt = await ethers.provider.getTransactionReceipt(deployedTestContract.deployTransaction.hash)
+    const deployBlockNumber: number = deployReceipt.blockNumber;
+
+    const hash = deployedTestContract.deployTransaction.hash;
+    console.log(`Contract deployed to ${deployedTestContract.address} at block ${deployBlockNumber.toString(16)} tx hash ${hash}`);
+
+    return deployedTestContract;
+
+}
+
+
+function generateNewWallet() {
+    const wallet = hre.ethers.Wallet.createRandom();
+    console.log("Address:", wallet.address);
+    return wallet;
+}
+
+function sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+
+async function sendMoneyWithoutConfirmation(): Promise<int> {
+    // Generate a new wallet
+    const newWallet = generateNewWallet();
+
+    await sleep(3000);  // Sleep for 1000 milliseconds (1 second)
+
+    // Get the first signer from Hardhat's local network
+    const [signer] = await hre.ethers.getSigners();
+
+    const currentNonce = await signer.getTransactionCount();
+
+    // Define the transaction
+    const tx = {
+        to: newWallet.address,
+        value: hre.ethers.utils.parseEther("0.1"),
+        nonce: currentNonce
+    };
+
+    // Send the transaction and wait until it is submitted ot the queue
+    const txResponse = signer.sendTransaction(tx);
+
+    if (hre.network.name == "geth") {
+        await txResponse;
+    }
+
+    console.log(`Submitted a tx to send 0.1 ETH to ${newWallet.address}`);
+
+    return currentNonce;
+}
+
+async function sendTransferWithConfirmation(): Promise<string> {
+    // Generate a new wallet
+    const newWallet = generateNewWallet();
+
+    await sleep(3000);  // Sleep for 1000 milliseconds (1 second)
+
+    // Get the first signer from Hardhat's local network
+    const [signer] = await hre.ethers.getSigners();
+
+    const currentNonce = await signer.getTransactionCount();
+
+    // Define the transaction
+    const tx = {
+        to: "0x388C818CA8B9251b393131C08a736A67ccB19297",
+        value: hre.ethers.utils.parseEther("0.1"),
+    };
+
+    // Send the transaction and wait until it is submitted ot the queue
+    const txResponse = await signer.sendTransaction(tx);
+    const txReceipt = await txResponse.wait();
+
+    console.log(`Submitted a tx to send 0.1 ETH to ${newWallet.address}`);
+
+    return txReceipt.transactionHash!;
+}
+
+
+async function executeTransferAndThenTestContractMintInSingleBlock(deployedContract: any): Promise<string> {
+
+    let currentNonce: int = await sendMoneyWithoutConfirmation();
+
+    const mintReceipt = await deployedContract[EXECUTE_FUNCTION_NAME](1000, {
+        gasLimit: 2100000, // this is just an example value; you'll need to set an appropriate gas limit for your specific function call
+        nonce: currentNonce + 1,
+    });
+
+    expect(mintReceipt.blockNumber).not.to.be.null;
+
+
+    const trace: string = await getBlockTrace(mintReceipt.blockNumber);
+
+
+    expect(Array.isArray(trace));
+
+    // the array should have two elements
+    if (hre.network.name != "geth") {
+        expect(trace.length == 2);
+    }
+
+    return mintReceipt.hash!;
+
+}
+
+async function executeMint2(deployedContract: any): Promise<string> {
+
+
+    const mint2Receipt = await deployedContract[EXECUTE2_FUNCTION_NAME](1000, {
+        gasLimit: 2100000, // this is just an example value; you'll need to set an appropriate gas limit for your specific function call,
+    });
+
+    expect(mint2Receipt.blockNumber).not.to.be.null;
+
+
+    return mint2Receipt.hash!;
+
+}
+
+
+async function executeRevert(deployedContract: any): Promise<string> {
+
+    const revertReceipt = await deployedContract[EXECUTE3_FUNCTION_NAME](1000, {
+        gasLimit: 2100000, // this is just an example value; you'll need to set an appropriate gas limit for your specific function call,
+    });
+
+    expect(revertReceipt.blockNumber).not.to.be.null;
+
+
+    return revertReceipt.hash!;
+
+}
+
+
+async function writeTraceFileReplacingAddressesWithSymbolicNames(_traceFileName: string, traceResult: string) {
+    writeFileSync(SKALE_TRACES_DIR + _traceFileName, traceResult);
+    await replaceAddressesWithSymbolicNames(_traceFileName);
+}
+
+async function callDebugTraceCall(_deployedContract: any, _tracer: string, _traceFileName: string): Promise<void> {
+
+    // first call function using eth_call
+
+    const currentBlock = await hre.ethers.provider.getBlockNumber();
+
+    const transaction = {
+        from: CALL_ADDRESS,
+        to: _deployedContract.address,
+        data: _deployedContract.interface.encodeFunctionData("getBalance", [])
+    };
+
+    const returnData = await ethers.provider.call(transaction, currentBlock - 1);
+
+    const result = _deployedContract.interface.decodeFunctionResult("getBalance", returnData);
+
+
+    console.log("Calling debug_traceCall to generate  " + _traceFileName);
+
+    let traceOptions = await getTraceJsonOptions(_tracer);
+
+    const trace = await ethers.provider.send('debug_traceCall', [transaction, "latest", traceOptions]);
+
+    const traceResult = JSON.stringify(trace, null, 4);
+    await writeTraceFileReplacingAddressesWithSymbolicNames(_traceFileName, traceResult);
+
+}
+
+
+
+async function getAndPrintCommittedTransactionTrace(hash: string, _tracer: string, _skaleFileName: string): Promise<String> {
+    globalCallCount++;
+
+    let traceOptions = await getTraceJsonOptions(_tracer);
+
+    console.log("Calling debug_traceTransaction to generate " + _skaleFileName);
+
+    let trace;
+
+
+    if (_tracer == DEFAULT_TRACER) {
+        // test both empty tracer and now tracer
+        if (globalCallCount % 2 === 0) {
+            trace = await ethers.provider.send('debug_traceTransaction', [hash]);
+        } else {
+            trace = await ethers.provider.send('debug_traceTransaction', [hash, traceOptions]);
+        }
+    } else {
+        trace = await ethers.provider.send('debug_traceTransaction', [hash, traceOptions]);
+    }
+
+    const result = JSON.stringify(trace, null, 4);
+
+    await writeTraceFileReplacingAddressesWithSymbolicNames(_skaleFileName, result);
+
+    return trace;
+}
+
+async function readJSONFile(fileName: string): Promise<object> {
+    return new Promise((resolve, reject) => {
+        readFile(fileName, 'utf8', (err, data) => {
+            if (err) {
+                reject(`An error occurred while reading the file: ${err.message}`);
+                return;
+            }
+            try {
+                const obj: object = JSON.parse(data);
+                resolve(obj);
+            } catch (parseError: any) {
+                reject(`Error parsing JSON: ${parseError.message}`);
+            }
+        });
+    });
+}
+
+
+
+
+
+async function main(): Promise<void> {
+
+    let deployedContract = await deployTestContract();
+    DEPLOYED_CONTRACT_ADDRESS_LOWER_CASE = deployedContract.address.toString().toLowerCase();
+
+    while (true) {
+
+        const firstMintHash: string = await executeTransferAndThenTestContractMintInSingleBlock(deployedContract);
+
+        const secondTransferHash: string = await sendTransferWithConfirmation();
+
+
+        const secondMintHash: string = await executeMint2(deployedContract);
+
+
+        const revertHash: string = await executeRevert(deployedContract);
+    }
+
+}
+
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main().catch((error: any) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -383,11 +383,16 @@ JsonRpcFixture( const std::string& _config = "", bool _owner = true,
         client->SetTimeout(1000000000);
 
         rpcClient = unique_ptr< WebThreeStubClient >( new WebThreeStubClient( *client ) );
+
+
+        BOOST_TEST_MESSAGE("Constructed JsonRpcFixture");
+
     }
 
     ~JsonRpcFixture() {
         if ( skale_server_connector )
             skale_server_connector->StopListening();
+        BOOST_TEST_MESSAGE("Destructed JsonRpcFixture");
     }
 
     string sendingRawShouldFail( string const& _t ) {


### PR DESCRIPTION





The problem was that `MANIFEST`  file of historic state LevelDB was growing indefinitely.

Since during restart `MANIFEST` file is read and processed, it led to extremely long opening times.

1. A new config parameter has been added

leveldbReopenIntervalMs

The default value of `leveldbReopenIntervalMs` is one day or 24 * 60 * 60 * 1000 microseconds.

If leveldbReopenIntervalMs is negative (like -1) than the features is disabled

2. Everytime there is a write batch to LevelDB (this typically happens after block processing) there is a check for the 
   age of LevelDB descriptor. If the descriptor age is more than `leveldbReopenIntervalMs`, the descriptor is closed and opened again.


3. Reopen of the descriptor happens while holding write lock (inclusive lock)  Use of the descriptor happens while holding read lock. 


4.  A new test `infinite_loop_test` is used to test the functionality. During the test, transactions are generated in the blockchain, while  `leveldbReopenIntervalMs`is set to 1ms.  Manifest file of leveldb is observed to see that it does not grow.

5. Also readability of github tests were improved by adding --report_level=detailed options to testheth.
    Now if one of test_eth tests fails, it is way faster to understand which test fails and get the error message