### PR TITLE
1856_checkout_external_gas

### DIFF
--- a/libethereum/Transaction.cpp
+++ b/libethereum/Transaction.cpp
@@ -210,7 +210,7 @@ void Transaction::checkOutExternalGas( const ChainParams& _cp, uint64_t _bn, boo
             scheduleForUse = _cp.scheduleForBlockNumber( _bn );
 
 
-#ifndef HISTORIC_STATE // FIX FOR 2.3.1. Will not be needed in 2.4
+#ifndef HISTORIC_STATE  // FIX FOR 2.3.1. Will not be needed in 2.4
         // never call checkOutExternalGas with non-last block
         if ( _bn != CorrectForkInPowPatch::getLastBlockNumber() ) {
             ctrace << _bn << " != " << CorrectForkInPowPatch::getLastBlockNumber();

--- a/libethereum/Transaction.cpp
+++ b/libethereum/Transaction.cpp
@@ -209,12 +209,15 @@ void Transaction::checkOutExternalGas( const ChainParams& _cp, uint64_t _bn, boo
         if ( CorrectForkInPowPatch::isEnabled() )
             scheduleForUse = _cp.scheduleForBlockNumber( _bn );
 
+
+#ifndef HISTORIC_STATE // FIX FOR 2.3.1. Will not be needed in 2.4
         // never call checkOutExternalGas with non-last block
         if ( _bn != CorrectForkInPowPatch::getLastBlockNumber() ) {
             ctrace << _bn << " != " << CorrectForkInPowPatch::getLastBlockNumber();
             BOOST_THROW_EXCEPTION( std::runtime_error(
                 "Internal error: checkOutExternalGas() has invalid block number" ) );
         }
+#endif
 
         if ( externalGas >= baseGasRequired( scheduleForUse ) )
             m_externalGas = externalGas;


### PR DESCRIPTION
Added ifndef HISTORIC_STATE to checkoutExternal gas as a fix for 2.3.1, in 2.4 we will not need this fix due to patch 
architecture

Testing:

Tested using 

npx hardhat run test/historicstate/scripts/trace.ts  --network skaled

The call trace test was failing before, it is passing now
