### PR TITLE
Bug/is 833 selfdestruct rebased

### DIFF
--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -256,6 +256,7 @@ public:
     u256 externalGasDifficulty = ~u256( 0 );
     typedef std::vector< std::string > vecAdminOrigins_t;
     vecAdminOrigins_t vecAdminOrigins;  // wildcard based folters for IP addresses
+    int64_t maxStorageForSelfdestruct = -1;
 
     time_t getPatchTimestamp( SchainPatchEnum _patchEnum ) const;
 

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -258,7 +258,6 @@ public:
     vecAdminOrigins_t vecAdminOrigins;  // wildcard based folters for IP addresses
     int64_t maxStorageForSelfdestruct = -1;
     int getLogsBlocksLimit = -1;
-    int getLogsRecordsLimit = -1;
 
     time_t getPatchTimestamp( SchainPatchEnum _patchEnum ) const;
 

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -257,6 +257,8 @@ public:
     typedef std::vector< std::string > vecAdminOrigins_t;
     vecAdminOrigins_t vecAdminOrigins;  // wildcard based folters for IP addresses
     int64_t maxStorageForSelfdestruct = -1;
+    int getLogsBlocksLimit = -1;
+    int getLogsRecordsLimit = -1;
 
     time_t getPatchTimestamp( SchainPatchEnum _patchEnum ) const;
 

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -107,5 +107,7 @@ DEV_SIMPLE_EXCEPTION( FailedToDownloadDaoForkBlockHeader );
 DEV_SIMPLE_EXCEPTION( AccountLocked );
 DEV_SIMPLE_EXCEPTION( TransactionRefused );
 DEV_SIMPLE_EXCEPTION( UnknownAccount );
+
+DEV_SIMPLE_EXCEPTION( TooBigResponse );
 }  // namespace eth
 }  // namespace dev

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -109,6 +109,10 @@ ChainParams ChainParams::loadConfig(
     cp.maxStorageForSelfdestruct = params.count( "maxStorageForSelfdestruct" ) ?
                                        params.at( "maxStorageForSelfdestruct" ).get_int64() :
                                        -1;
+    cp.getLogsBlocksLimit =
+        params.count( "getLogsBlocksLimit" ) ? params.at( "getLogsBlocksLimit" ).get_int() : -1;
+    cp.getLogsRecordsLimit =
+        params.count( "getLogsRecordsLimit" ) ? params.at( "getLogsRecordsLimit" ).get_int() : -1;
 
     if ( obj.count( c_skaleConfig ) ) {
         processSkaleConfigItems( cp, obj );

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -106,6 +106,9 @@ ChainParams ChainParams::loadConfig(
     cp.skaleDisableChainIdCheck = params.count( c_skaleDisableChainIdCheck ) ?
                                       params[c_skaleDisableChainIdCheck].get_bool() :
                                       false;
+    cp.maxStorageForSelfdestruct = params.count( "maxStorageForSelfdestruct" ) ?
+                                       params.at( "maxStorageForSelfdestruct" ).get_int64() :
+                                       -1;
 
     if ( obj.count( c_skaleConfig ) ) {
         processSkaleConfigItems( cp, obj );

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -111,8 +111,6 @@ ChainParams ChainParams::loadConfig(
                                        -1;
     cp.getLogsBlocksLimit =
         params.count( "getLogsBlocksLimit" ) ? params.at( "getLogsBlocksLimit" ).get_int() : -1;
-    cp.getLogsRecordsLimit =
-        params.count( "getLogsRecordsLimit" ) ? params.at( "getLogsRecordsLimit" ).get_int() : -1;
 
     if ( obj.count( c_skaleConfig ) ) {
         processSkaleConfigItems( cp, obj );

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -219,7 +219,7 @@ LocalisedLogEntries ClientBase::logs( LogFilter const& _f ) const {
     unsigned begin = min( bc().number() + 1, ( unsigned ) _f.latest() );
     unsigned end = min( bc().number(), min( begin, ( unsigned ) _f.earliest() ) );
 
-    if ( begin >= end && begin - end >= bc().chainParams().getLogsBlocksLimit )
+    if ( begin >= end && begin - end > bc().chainParams().getLogsBlocksLimit )
         BOOST_THROW_EXCEPTION( TooBigResponse() );
 
     // Handle pending transactions differently as they're not on the block chain.

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -355,18 +355,6 @@ bool ClientBase::uninstallWatch( unsigned _i ) {
     return true;
 }
 
-LocalisedLogEntries ClientBase::peekWatch( unsigned _watchId ) const {
-    Guard l( x_filtersWatches );
-
-    //	LOG(m_loggerWatch) << "peekWatch" << _watchId;
-    auto& w = m_watches.at( _watchId );
-    //	LOG(m_loggerWatch) << "lastPoll updated to " <<
-    // chrono::duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count();
-    if ( w.lastPoll != chrono::system_clock::time_point::max() )
-        w.lastPoll = chrono::system_clock::now();
-    return w.get_changes();
-}
-
 LocalisedLogEntries ClientBase::checkWatch( unsigned _watchId ) {
     Guard l( x_filtersWatches );
     LocalisedLogEntries ret;

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -241,15 +241,16 @@ LocalisedLogEntries ClientBase::logs( LogFilter const& _f ) const {
         }
     else {
         // if it is a range filter, we want to get all logs from all blocks in given range
-        if ( end >= begin && end - begin >= 2000 )
+        if ( begin >= end && begin - end >= bc().chainParams().getLogsBlocksLimit )
             BOOST_THROW_EXCEPTION( TooBigResponse() );
         for ( unsigned i = end; i <= begin; i++ )
             matchingBlocks.insert( i );
     }
 
+    int recordsLimit = bc().chainParams().getLogsRecordsLimit;
     for ( auto n : matchingBlocks ) {
         prependLogsFromBlock( _f, bc().numberHash( n ), BlockPolarity::Live, ret );
-        if ( ret.size() > 10000 && !_f.isRangeFilter() )
+        if ( ret.size() > recordsLimit && !_f.isRangeFilter() )
             BOOST_THROW_EXCEPTION( TooBigResponse() );
     }
 

--- a/libethereum/ClientBase.h
+++ b/libethereum/ClientBase.h
@@ -114,7 +114,6 @@ public:
         fnClientWatchHandlerMulti_t fnOnNewChanges = fnClientWatchHandlerMulti_t(),
         bool isWS = false ) override;
     bool uninstallWatch( unsigned _watchId ) override;
-    LocalisedLogEntries peekWatch( unsigned _watchId ) const override;
     LocalisedLogEntries checkWatch( unsigned _watchId ) override;
 
     using Interface::blockDetails;

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -23,7 +23,7 @@
 
 #include "ExtVM.h"
 
-#include <exception>
+#include <libethereum/SchainPatch.h>
 
 #include <boost/thread.hpp>
 
@@ -170,7 +170,9 @@ CreateResult ExtVM::create( u256 _endowment, u256& io_gas, bytesConstRef _code, 
 }
 
 void ExtVM::suicide( Address _a ) {
-    if ( m_chainParams.maxStorageForSelfdestruct >= 0 &&
+    if ( SelfdestructStorageLimitPatch::isEnabledWhen(
+             this->envInfo().committedBlockTimestamp() ) &&
+         m_chainParams.maxStorageForSelfdestruct >= 0 &&
          m_s.storageUsed( this->myAddress ) > m_chainParams.maxStorageForSelfdestruct ) {
         BOOST_THROW_EXCEPTION( TooBigForSelfdestruct() );
     }

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -170,6 +170,12 @@ CreateResult ExtVM::create( u256 _endowment, u256& io_gas, bytesConstRef _code, 
 }
 
 void ExtVM::suicide( Address _a ) {
+    if ( m_sealEngine.chainParams().maxStorageForSelfdestruct >= 0 &&
+         m_s.storageUsed( this->myAddress ) >
+             m_sealEngine.chainParams().maxStorageForSelfdestruct ) {
+        BOOST_THROW_EXCEPTION( TooBigForSelfdestruct() );
+    }
+
     // Why transfer is not used here? That caused a consensus issue before (see Quirk #2 in
     // http://martin.swende.se/blog/Ethereum_quirks_and_vulns.html). There is one test case
     // witnessing the current consensus

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -170,9 +170,8 @@ CreateResult ExtVM::create( u256 _endowment, u256& io_gas, bytesConstRef _code, 
 }
 
 void ExtVM::suicide( Address _a ) {
-    if ( m_sealEngine.chainParams().maxStorageForSelfdestruct >= 0 &&
-         m_s.storageUsed( this->myAddress ) >
-             m_sealEngine.chainParams().maxStorageForSelfdestruct ) {
+    if ( m_chainParams.maxStorageForSelfdestruct >= 0 &&
+         m_s.storageUsed( this->myAddress ) > m_chainParams.maxStorageForSelfdestruct ) {
         BOOST_THROW_EXCEPTION( TooBigForSelfdestruct() );
     }
 

--- a/libethereum/Interface.h
+++ b/libethereum/Interface.h
@@ -154,13 +154,6 @@ public:
         fnClientWatchHandlerMulti_t fnOnNewChanges = fnClientWatchHandlerMulti_t(),
         bool isWS = false ) = 0;
     virtual bool uninstallWatch( unsigned _watchId ) = 0;
-    LocalisedLogEntries peekWatchSafe( unsigned _watchId ) const {
-        try {
-            return peekWatch( _watchId );
-        } catch ( ... ) {
-            return LocalisedLogEntries();
-        }
-    }
     LocalisedLogEntries checkWatchSafe( unsigned _watchId ) {
         try {
             return checkWatch( _watchId );
@@ -168,7 +161,6 @@ public:
             return LocalisedLogEntries();
         }
     }
-    virtual LocalisedLogEntries peekWatch( unsigned _watchId ) const = 0;
     virtual LocalisedLogEntries checkWatch( unsigned _watchId ) = 0;
 
     // [BLOCK QUERY API]
@@ -328,7 +320,6 @@ public:
     }
 
     LocalisedLogEntries check() { return m_c ? m_c->checkWatch( m_id ) : LocalisedLogEntries(); }
-    LocalisedLogEntries peek() { return m_c ? m_c->peekWatch( m_id ) : LocalisedLogEntries(); }
     LocalisedLogEntries logs() const { return m_c->logs( m_id ); }
 
 private:

--- a/libevm/VMFace.h
+++ b/libevm/VMFace.h
@@ -38,6 +38,7 @@ ETH_SIMPLE_EXCEPTION_VM( DisallowedStateChange );
 ETH_SIMPLE_EXCEPTION_VM( BufferOverrun );
 ETH_SIMPLE_EXCEPTION_VM( StorageOverflow );
 ETH_SIMPLE_EXCEPTION_VM( InvalidContractDeployer );
+ETH_SIMPLE_EXCEPTION_VM( TooBigForSelfdestruct );
 
 /// Reports VM internal error. This is not based on VMException because it must be handled
 /// differently than defined consensus exceptions.

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -820,6 +820,10 @@ Json::Value Eth::eth_getFilterChangesEx( string const& _filterId ) {
 Json::Value Eth::eth_getFilterLogs( string const& _filterId ) {
     try {
         return toJson( client()->logs( static_cast< unsigned int >( jsToInt( _filterId ) ) ) );
+    } catch ( const TooBigResponse& ) {
+        BOOST_THROW_EXCEPTION( JsonRpcException( Errors::ERROR_RPC_INVALID_PARAMS,
+            "Log response size exceeded. Maximum allowed number of requested blocks is " +
+                to_string( this->client()->chainParams().getLogsBlocksLimit ) ) );
     } catch ( ... ) {
         BOOST_THROW_EXCEPTION( JsonRpcException( Errors::ERROR_RPC_INVALID_PARAMS ) );
     }
@@ -837,6 +841,10 @@ Json::Value Eth::eth_getFilterLogs( string const& _filterId ) {
 Json::Value Eth::eth_getLogs( Json::Value const& _json ) {
     try {
         return toJson( client()->logs( toLogFilter( _json ) ) );
+    } catch ( const TooBigResponse& ) {
+        BOOST_THROW_EXCEPTION( JsonRpcException( Errors::ERROR_RPC_INVALID_PARAMS,
+            "Log response size exceeded. Maximum allowed number of requested blocks is " +
+                to_string( this->client()->chainParams().getLogsBlocksLimit ) ) );
     } catch ( ... ) {
         BOOST_THROW_EXCEPTION( JsonRpcException( Errors::ERROR_RPC_INVALID_PARAMS ) );
     }

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -318,8 +318,6 @@ ChainParams chainParams;
             chainParams.sChain._patchTimestamps[static_cast<size_t>(SchainPatchEnum::SelfdestructStorageLimitPatch)] = stoi( params.at( "selfdestructStorageLimitPatchTimestamp" ) );
         if( params.count("getLogsBlocksLimit") && stoi( params.at( "getLogsBlocksLimit" ) ) )
             chainParams.getLogsBlocksLimit = stoi( params.at( "getLogsBlocksLimit" ) );
-        if( params.count("getLogsRecordsLimit") && stoi( params.at( "getLogsRecordsLimit" ) ) )
-            chainParams.getLogsRecordsLimit = stoi( params.at( "getLogsRecordsLimit" ) );
 
         //        web3.reset( new WebThreeDirect(
         //            "eth tests", tempDir.path(), "", chainParams, WithExisting::Kill, {"eth"},
@@ -2123,8 +2121,7 @@ contract Logger{
 // limit on getLogs output
 BOOST_AUTO_TEST_CASE( getLogs_limit ) {
     JsonRpcFixture fixture( "", true, true, false, false, false, -1,
-    {{"getLogsBlocksLimit", "10"},
-    {"getLogsRecordsLimit", "10"}} );
+    {{"getLogsBlocksLimit", "10"}} );
 
     dev::eth::simulateMining( *( fixture.client ), 1 );
 
@@ -2181,13 +2178,13 @@ contract Logger{
     // 1 10 blocks
     BOOST_REQUIRE_NO_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req) );
 
-    // 2 11 blocks
-    req["toBlock"] = 11;
-    BOOST_REQUIRE_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req), std::exception );
-
-    // with topics
+    // 2 with topics
     req["address"] = contractAddress;
     BOOST_REQUIRE_NO_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req) );
+
+    // 3 11 blocks
+    req["toBlock"] = 11;
+    BOOST_REQUIRE_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req), std::exception );
 }
 
 BOOST_AUTO_TEST_CASE( estimate_gas_low_gas_txn ) {

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -2160,7 +2160,7 @@ contract Logger{
     t["to"] = contractAddress;
     t["gas"] = "99000";
 
-    for(int i=0; i<10; ++i){
+    for(int i=0; i<11; ++i){
 
         std::string txHash = fixture.rpcClient->eth_sendTransaction( t );
         BOOST_REQUIRE( !txHash.empty() );
@@ -2172,7 +2172,7 @@ contract Logger{
     // ask for logs
     Json::Value req;
     req["fromBlock"] = 1;
-    req["toBlock"] = 10;
+    req["toBlock"] = 11;
     req["topics"] = Json::Value(Json::arrayValue);
 
     // 1 10 blocks
@@ -2183,7 +2183,7 @@ contract Logger{
     BOOST_REQUIRE_NO_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req) );
 
     // 3 11 blocks
-    req["toBlock"] = 11;
+    req["toBlock"] = 12;
     BOOST_REQUIRE_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req), std::exception );
 
     // 4 filter

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -316,6 +316,10 @@ ChainParams chainParams;
 
         if( params.count("selfdestructStorageLimitPatchTimestamp") && stoi( params.at( "selfdestructStorageLimitPatchTimestamp" ) ) )
             chainParams.sChain._patchTimestamps[static_cast<size_t>(SchainPatchEnum::SelfdestructStorageLimitPatch)] = stoi( params.at( "selfdestructStorageLimitPatchTimestamp" ) );
+        if( params.count("getLogsBlocksLimit") && stoi( params.at( "getLogsBlocksLimit" ) ) )
+            chainParams.getLogsBlocksLimit = stoi( params.at( "getLogsBlocksLimit" ) );
+        if( params.count("getLogsRecordsLimit") && stoi( params.at( "getLogsRecordsLimit" ) ) )
+            chainParams.getLogsRecordsLimit = stoi( params.at( "getLogsRecordsLimit" ) );
 
         //        web3.reset( new WebThreeDirect(
         //            "eth tests", tempDir.path(), "", chainParams, WithExisting::Kill, {"eth"},
@@ -2114,6 +2118,76 @@ contract Logger{
     logs = fixture.rpcClient->eth_getLogs(t);
     BOOST_REQUIRE(logs.isArray());
     BOOST_REQUIRE_EQUAL(logs.size(), 24);
+}
+
+// limit on getLogs output
+BOOST_AUTO_TEST_CASE( getLogs_limit ) {
+    JsonRpcFixture fixture( "", true, true, false, false, false, -1,
+    {{"getLogsBlocksLimit", "10"},
+    {"getLogsRecordsLimit", "10"}} );
+
+    dev::eth::simulateMining( *( fixture.client ), 1 );
+
+/*
+ // SPDX-License-Identifier: None
+pragma solidity ^0.8;
+
+contract Logger{
+
+    event DummyEvent(uint256, uint256);
+
+    fallback() external payable {
+        for(uint i=0; i<100; ++i)
+            emit DummyEvent(block.number, i);
+    }
+}
+*/
+
+    string bytecode = "6080604052348015600e575f80fd5b5060c080601a5f395ff3fe60806040525f5b6064811015604f577f90778767414a5c844b9d35a8745f67697ee3b8c2c3f4feafe5d9a3e234a5a3654382604051603d9291906067565b60405180910390a18060010190506006565b005b5f819050919050565b6061816051565b82525050565b5f60408201905060785f830185605a565b60836020830184605a565b939250505056fea264697066735822122040208e35f2706dd92c17579466ab671c308efec51f558a755ea2cf81105ab22964736f6c63430008190033";
+
+    Json::Value create;
+    create["code"] = bytecode;
+    create["gas"] = "180000";  // TODO or change global default of 90000?
+
+    string deployHash = fixture.rpcClient->eth_sendTransaction( create );
+    dev::eth::mineTransaction( *( fixture.client ), 1 );
+
+    Json::Value deployReceipt = fixture.rpcClient->eth_getTransactionReceipt( deployHash );
+    string contractAddress = deployReceipt["contractAddress"].asString();
+
+    // generate 10 blocks 10 logs each
+
+    Json::Value t;
+    t["from"] = toJS( fixture.coinbase.address() );
+    t["value"] = jsToDecimal( "0" );
+    t["to"] = contractAddress;
+    t["gas"] = "99000";
+
+    for(int i=0; i<10; ++i){
+
+        std::string txHash = fixture.rpcClient->eth_sendTransaction( t );
+        BOOST_REQUIRE( !txHash.empty() );
+        dev::eth::mineTransaction( *( fixture.client ), 1 );
+        Json::Value receipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
+        BOOST_REQUIRE_EQUAL(receipt["status"], "0x1");
+    }
+
+    // ask for logs
+    Json::Value req;
+    req["fromBlock"] = 1;
+    req["toBlock"] = 10;
+    req["topics"] = Json::Value(Json::arrayValue);
+
+    // 1 10 blocks
+    BOOST_REQUIRE_NO_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req) );
+
+    // 2 11 blocks
+    req["toBlock"] = 11;
+    BOOST_REQUIRE_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req), std::exception );
+
+    // with topics
+    req["address"] = contractAddress;
+    BOOST_REQUIRE_NO_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req) );
 }
 
 BOOST_AUTO_TEST_CASE( estimate_gas_low_gas_txn ) {

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -2185,6 +2185,11 @@ contract Logger{
     // 3 11 blocks
     req["toBlock"] = 11;
     BOOST_REQUIRE_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req), std::exception );
+
+    // 4 filter
+    string filterId = fixture.rpcClient->eth_newFilter( req );
+    BOOST_REQUIRE_THROW( Json::Value res = fixture.rpcClient->eth_getFilterLogs(filterId), std::exception );
+    BOOST_REQUIRE_NO_THROW( Json::Value res = fixture.rpcClient->eth_getFilterChanges(filterId) );
 }
 
 BOOST_AUTO_TEST_CASE( estimate_gas_low_gas_txn ) {

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -300,6 +300,7 @@ JsonRpcFixture( const std::string& _config = "", bool _owner = true,
             push0PatchActivationTimestamp = time(nullptr) + 10;
             chainParams.sChain._patchTimestamps[static_cast<size_t>(SchainPatchEnum::PushZeroPatch)] = push0PatchActivationTimestamp;
             chainParams.sChain.emptyBlockIntervalMs = _emptyBlockIntervalMs;
+            chainParams.maxStorageForSelfdestruct = 64;
             // add random extra data to randomize genesis hash and get random DB path,
             // so that tests can be run in parallel
             // TODO: better make it use ethemeral in-memory databases
@@ -3635,5 +3636,99 @@ BOOST_AUTO_TEST_CASE( test_exceptions ) {
 #endif
 
 BOOST_AUTO_TEST_SUITE_END()
+
+
+BOOST_AUTO_TEST_CASE( suicide_storage_limit ) {
+    JsonRpcFixture fixture;
+    dev::eth::simulateMining( *( fixture.client ), 10 );
+
+    // pragma solidity ^0.8.0;
+
+    // contract SuicideLimit {
+
+    //     uint[] public storageArray;
+
+    //     function store(uint32 size) public {
+    //         for(uint32 i=0; i<size; ++i){
+    //             storageArray.push( i+1 );
+    //         }
+    //     }
+
+    //     function erase(uint32 size) public {
+    //         for(uint32 i=0; i<size; ++i){
+    //             storageArray.pop();
+    //         }
+    //     }
+
+    //     function size() public view returns(uint256) {
+    //         return storageArray.length;
+    //     }
+
+    //     function destruct() external {
+    //         selfdestruct(payable(msg.sender));
+    //     }
+
+    // }
+
+    std::string bytecode = "0x608060405234801561001057600080fd5b506103ab806100206000396000f3fe608060405234801561001057600080fd5b50600436106100575760003560e01c80630e031ab11461005c5780632b68b9c61461008c57806393edc68f14610096578063949d225d146100b2578063b9e95382146100d0575b600080fd5b6100766004803603810190610071919061021f565b6100ec565b604051610083919061025b565b60405180910390f35b610094610110565b005b6100b060048036038101906100ab91906102b2565b610129565b005b6100ba610177565b6040516100c7919061025b565b60405180910390f35b6100ea60048036038101906100e591906102b2565b610183565b005b600081815481106100fc57600080fd5b906000526020600020016000915090505481565b3373ffffffffffffffffffffffffffffffffffffffff16ff5b60005b8163ffffffff168163ffffffff161015610173576000805480610152576101516102df565b5b6001900381819060005260206000200160009055905580600101905061012c565b5050565b60008080549050905090565b60005b8163ffffffff168163ffffffff1610156101e05760006001826101a9919061033d565b908060018154018082558091505060019003906000526020600020016000909163ffffffff16909190915055806001019050610186565b5050565b600080fd5b6000819050919050565b6101fc816101e9565b811461020757600080fd5b50565b600081359050610219816101f3565b92915050565b600060208284031215610235576102346101e4565b5b60006102438482850161020a565b91505092915050565b610255816101e9565b82525050565b6000602082019050610270600083018461024c565b92915050565b600063ffffffff82169050919050565b61028f81610276565b811461029a57600080fd5b50565b6000813590506102ac81610286565b92915050565b6000602082840312156102c8576102c76101e4565b5b60006102d68482850161029d565b91505092915050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052603160045260246000fd5b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b600061034882610276565b915061035383610276565b9250828201905063ffffffff81111561036f5761036e61030e565b5b9291505056fea264697066735822122093330c7c61b090fd27a09fd9fc6ed89c0d0d9cf32ee887edc7d374f929c3064264736f6c63430008180033";
+
+    auto senderAddress = fixture.coinbase.address();
+
+    Json::Value create;
+    create["from"] = toJS( senderAddress );
+    create["data"] = bytecode;
+    create["gas"] = "1800000";
+    string txHash = fixture.rpcClient->eth_sendTransaction( create );
+    dev::eth::mineTransaction( *( fixture.client ), 1 );
+
+    Json::Value receipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
+    BOOST_REQUIRE_EQUAL( receipt["status"], string( "0x1" ) );
+    string contractAddress = receipt["contractAddress"].asString();
+    dev::Address contract = dev::Address( contractAddress );
+
+    // 1 fill data
+    Json::Value txStore;
+    txStore["to"] = contractAddress;
+    txStore["data"] = "0xb9e953820000000000000000000000000000000000000000000000000000000000000002";
+    txStore["from"] = toJS( senderAddress );
+    txStore["gas"] = "500000";
+    txStore["gasPrice"] = fixture.rpcClient->eth_gasPrice();
+    txHash = fixture.rpcClient->eth_sendTransaction( txStore );
+    dev::eth::mineTransaction( *( fixture.client ), 1 );
+    Json::Value storeReceipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
+    BOOST_REQUIRE_EQUAL( storeReceipt["status"], string( "0x1" ) );
+    BOOST_REQUIRE_EQUAL( fixture.client->state().storageUsed( contract ), 96 );
+
+    // 2 suicide should fail
+    Json::Value txSuicide;
+    txSuicide["to"] = contractAddress;
+    txSuicide["data"] = "0x2b68b9c6";
+    txSuicide["from"] = toJS( senderAddress );
+    txSuicide["gas"] = "500000";
+    txSuicide["gasPrice"] = fixture.rpcClient->eth_gasPrice();
+    txHash = fixture.rpcClient->eth_sendTransaction( txSuicide );
+    dev::eth::mineTransaction( *( fixture.client ), 1 );
+    Json::Value suicideReceipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
+    BOOST_REQUIRE_EQUAL( suicideReceipt["status"], string( "0x0" ) );
+
+    // 3 free 1
+    Json::Value txFree;
+    txFree["to"] = contractAddress;
+    txFree["data"] = "0x93edc68f0000000000000000000000000000000000000000000000000000000000000001";
+    txFree["from"] = toJS( senderAddress );
+    txFree["gas"] = "500000";
+    txFree["gasPrice"] = fixture.rpcClient->eth_gasPrice();
+    txHash = fixture.rpcClient->eth_sendTransaction( txFree );
+    dev::eth::mineTransaction( *( fixture.client ), 1 );
+    Json::Value freeReceipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
+    BOOST_REQUIRE_EQUAL( freeReceipt["status"], string( "0x1" ) );
+    BOOST_REQUIRE_EQUAL( fixture.client->state().storageUsed( contract ), 64 );
+
+    // 4 suicide should succeed
+    txHash = fixture.rpcClient->eth_sendTransaction( txSuicide );
+    dev::eth::mineTransaction( *( fixture.client ), 1 );
+    suicideReceipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
+    BOOST_REQUIRE_EQUAL( suicideReceipt["status"], string( "0x1" ) );
+}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description

`selfdestruct` instruction will fail if amount of storage used by this contract before transaction exceeds `maxStorageForSelfdestruct`. This behavior is activated by the `SelfdestructStorageLimitPatch`

see also https://github.com/skalenetwork/internal-support/issues/963

## Tests

`JsonRpcSuite/suicide_storage_limit`

## Performance Impact

Not expected
