### PR TITLE
Feature/skaled 1877 support block hash

### DIFF
--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -847,7 +847,8 @@ Json::Value Eth::eth_getLogs( Json::Value const& _json ) {
             uint64_t number = m_eth.numberFromHash( jsToFixed< 32 >( strHash ) );
             if ( number == PendingBlock )
                 return toJson( LocalisedLogEntries() );
-            filter.withEarliest( number ).withLatest( number );
+            filter.withEarliest( number );
+            filter.withLatest( number );
         }
         return toJson( client()->logs( filter ) );
     } catch ( const TooBigResponse& ) {

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -838,11 +838,24 @@ Json::Value Eth::eth_getFilterLogs( string const& _filterId ) {
 
 Json::Value Eth::eth_getLogs( Json::Value const& _json ) {
     try {
-        return toJson( client()->logs( toLogFilter( _json ) ) );
+        LogFilter filter = toLogFilter( _json );
+        if ( !_json["blockHash"].isNull() ) {
+            if ( !_json["fromBlock"].isNull() || !_json["toBlock"].isNull() )
+                BOOST_THROW_EXCEPTION( JsonRpcException( Errors::ERROR_RPC_INVALID_PARAMS,
+                    "fromBlock and toBlock are not allowed if blockHash is present" ) );
+            string strHash = _json["blockHash"].asString();
+            uint64_t number = m_eth.numberFromHash( jsToFixed< 32 >( strHash ) );
+            if ( number == PendingBlock )
+                return toJson( LocalisedLogEntries() );
+            filter.withEarliest( number ).withLatest( number );
+        }
+        return toJson( client()->logs( filter ) );
     } catch ( const TooBigResponse& ) {
         BOOST_THROW_EXCEPTION( JsonRpcException( Errors::ERROR_RPC_INVALID_PARAMS,
             "Log response size exceeded. Maximum allowed number of requested blocks is " +
                 to_string( this->client()->chainParams().getLogsBlocksLimit ) ) );
+    } catch ( const JsonRpcException& ) {
+        throw;
     } catch ( ... ) {
         BOOST_THROW_EXCEPTION( JsonRpcException( Errors::ERROR_RPC_INVALID_PARAMS ) );
     }

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -844,9 +844,13 @@ Json::Value Eth::eth_getLogs( Json::Value const& _json ) {
                 BOOST_THROW_EXCEPTION( JsonRpcException( Errors::ERROR_RPC_INVALID_PARAMS,
                     "fromBlock and toBlock are not allowed if blockHash is present" ) );
             string strHash = _json["blockHash"].asString();
+            if ( strHash.empty() )
+                throw std::invalid_argument( "blockHash cannot be an empty string" );
             uint64_t number = m_eth.numberFromHash( jsToFixed< 32 >( strHash ) );
             if ( number == PendingBlock )
-                return toJson( LocalisedLogEntries() );
+                BOOST_THROW_EXCEPTION( JsonRpcException( Errors::ERROR_RPC_INVALID_PARAMS,
+                    "A block with this hash does not exist in the database. If this is an old "
+                    "block, try connecting to an archive node" ) );
             filter.withEarliest( number );
             filter.withLatest( number );
         }

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -2190,22 +2190,31 @@ BOOST_AUTO_TEST_CASE( getLogs_blockHash ) {
     JsonRpcFixture fixture;
     dev::eth::simulateMining( *( fixture.client ), 1 );
 
+    string latestHash = fixture.rpcClient->eth_getBlockByNumber("latest", false)["hash"].asString();
+
     Json::Value req;
     req["blockHash"] = "xyz";
+    BOOST_REQUIRE_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req), std::exception );
+
+    req["blockHash"] = Json::Value(Json::arrayValue);
     BOOST_REQUIRE_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req), std::exception );
 
     req["fromBlock"] = 1;
     req["toBlock"] = 1;
     BOOST_REQUIRE_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req), std::exception );
 
+    req["blockHash"] = latestHash;
+    BOOST_REQUIRE_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req), std::exception );
+
     req.removeMember("fromBlock");
     req.removeMember("toBlock");
-    req["blockHash"] = "0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b";
     BOOST_REQUIRE_NO_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req) );
 
-    string hash = fixture.rpcClient->eth_getBlockByNumber("latest", false)["hash"].asString();
-    req["blockHash"] = hash;
-    BOOST_REQUIRE_NO_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req) );
+    req["blockHash"] = "0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b";
+    BOOST_REQUIRE_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req), std::exception );
+
+    req["blockHash"] = "";
+    BOOST_REQUIRE_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req), std::exception );
 }
 
 BOOST_AUTO_TEST_CASE( estimate_gas_low_gas_txn ) {

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -2185,6 +2185,29 @@ contract Logger{
     BOOST_REQUIRE_NO_THROW( Json::Value res = fixture.rpcClient->eth_getFilterChanges(filterId) );
 }
 
+// test blockHash parameter
+BOOST_AUTO_TEST_CASE( getLogs_blockHash ) {
+    JsonRpcFixture fixture;
+    dev::eth::simulateMining( *( fixture.client ), 1 );
+
+    Json::Value req;
+    req["blockHash"] = "xyz";
+    BOOST_REQUIRE_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req), std::exception );
+
+    req["fromBlock"] = 1;
+    req["toBlock"] = 1;
+    BOOST_REQUIRE_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req), std::exception );
+
+    req.removeMember("fromBlock");
+    req.removeMember("toBlock");
+    req["blockHash"] = "0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b";
+    BOOST_REQUIRE_NO_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req) );
+
+    string hash = fixture.rpcClient->eth_getBlockByNumber("latest", false)["hash"].asString();
+    req["blockHash"] = hash;
+    BOOST_REQUIRE_NO_THROW( Json::Value logs = fixture.rpcClient->eth_getLogs(req) );
+}
+
 BOOST_AUTO_TEST_CASE( estimate_gas_low_gas_txn ) {
     JsonRpcFixture fixture;
     dev::eth::simulateMining( *( fixture.client ), 10 );


### PR DESCRIPTION
fixes #1877

Added support of "blockHash" parameter to `eth_getLogs` call.
Spec: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs
1. No other calls are altered.
2. Error is thrown in case of presence of `fromBlock` or `toBlock` parameters together with `blockHash` or if block hash cannot be parsed.
3. In case of non-existing block hash return empty response.

Tests:
1. JsonRpcSuite/getLogs_blockHash
2. Manual sending requests to `https://nodes.mewapi.io/rpc/eth` to compare cases mentioned above.