### PR TITLE
#1890 add more logs for archive node

### DIFF
--- a/libdevcore/LevelDB.h
+++ b/libdevcore/LevelDB.h
@@ -71,6 +71,7 @@ public:
     static std::atomic< uint64_t > g_keyDeletesStats;
     // count of the keys that are scheduled to be deleted but are not yet deleted
     static std::atomic< uint64_t > g_keysToBeDeletedStats;
+    static uint64_t getCurrentTimeMs();
 
 private:
     std::unique_ptr< leveldb::DB > m_db;
@@ -123,7 +124,6 @@ private:
         }
     };
     void openDBInstanceUnsafe();
-    uint64_t getCurrentTimeMs();
     void reopenDataBaseIfNeeded();
 };
 

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -717,6 +717,10 @@ size_t Client::syncTransactions(
            << cc::debug( " transactions in " ) << cc::size10( timer.elapsed() * 1000 )
            << cc::debug( "(" ) << ( bool ) m_syncTransactionQueue << cc::debug( ")" );
 
+    if ( chainParams().nodeInfo.syncNode )
+        LOG( m_logger ) << "HSCT: "
+                        << m_working.mutableState().mutableHistoricState().getBlockCommitTime();
+
     return goodReceipts;
 }
 

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -713,9 +713,8 @@ size_t Client::syncTransactions(
     // Tell network about the new transactions.
     m_skaleHost->noteNewTransactions();
 
-    ctrace << cc::debug( "Processed " ) << cc::size10( newPendingReceipts.size() )
-           << cc::debug( " transactions in " ) << cc::size10( timer.elapsed() * 1000 )
-           << cc::debug( "(" ) << ( bool ) m_syncTransactionQueue << cc::debug( ")" );
+    ctrace << "Processed " << newPendingReceipts.size() << " transactions in "
+           << timer.elapsed() * 1000 << "(" << ( bool ) m_syncTransactionQueue << ")";
 
 #ifdef HISTORIC_STATE
     LOG( m_logger ) << "HSCT: "

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -718,7 +718,7 @@ size_t Client::syncTransactions(
 
 #ifdef HISTORIC_STATE
     LOG( m_logger ) << "HSCT: "
-                    << m_working.mutableState().mutableHistoricState().getBlockCommitTime();
+                    << m_working.mutableState().mutableHistoricState().getAndResetBlockCommitTime();
 #endif
     return goodReceipts;
 }

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -717,10 +717,10 @@ size_t Client::syncTransactions(
            << cc::debug( " transactions in " ) << cc::size10( timer.elapsed() * 1000 )
            << cc::debug( "(" ) << ( bool ) m_syncTransactionQueue << cc::debug( ")" );
 
-    if ( chainParams().nodeInfo.syncNode )
-        LOG( m_logger ) << "HSCT: "
-                        << m_working.mutableState().mutableHistoricState().getBlockCommitTime();
-
+#ifdef HISTORIC_STATE
+    LOG( m_logger ) << "HSCT: "
+                    << m_working.mutableState().mutableHistoricState().getBlockCommitTime();
+#endif
     return goodReceipts;
 }
 

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -723,6 +723,7 @@ void SkaleHost::createBlock( const ConsensusExtFace::transactions_vector& _appro
                                    skaledTimeFinish - skaledTimeStart )
                                    .count();
     }
+
     latestBlockTime = skaledTimeFinish;
     LOG( m_debugLogger ) << "Successfully imported " << n_succeeded << " of " << out_txns.size()
                          << " transactions";

--- a/libhistoric/HistoricState.cpp
+++ b/libhistoric/HistoricState.cpp
@@ -45,7 +45,7 @@ HistoricState::HistoricState( HistoricState const& _s )
       m_nonExistingAccountsCache( _s.m_nonExistingAccountsCache ),
       m_unrevertablyTouched( _s.m_unrevertablyTouched ),
       m_accountStartNonce( _s.m_accountStartNonce ),
-      blockCommitTimeMs( _s.blockCommitTimeMs ) {}
+      m_blockCommitTimeMs( _s.m_blockCommitTimeMs ) {}
 
 OverlayDB HistoricState::openDB(
     fs::path const& _basePath, h256 const& _genesisHash, WithExisting _we ) {
@@ -138,7 +138,7 @@ HistoricState& HistoricState::operator=( HistoricState const& _s ) {
     m_nonExistingAccountsCache = _s.m_nonExistingAccountsCache;
     m_unrevertablyTouched = _s.m_unrevertablyTouched;
     m_accountStartNonce = _s.m_accountStartNonce;
-    blockCommitTimeMs = _s.blockCommitTimeMs;
+    m_blockCommitTimeMs = _s.m_blockCommitTimeMs;
     return *this;
 }
 
@@ -205,14 +205,14 @@ void HistoricState::commitExternalChanges( AccountMap const& _accountMap ) {
     m_unchangedCacheEntries.clear();
     boost::chrono::high_resolution_clock::time_point historicStateFinish =
         boost::chrono::high_resolution_clock::now();
-    blockCommitTimeMs += boost::chrono::duration_cast< boost::chrono::milliseconds >(
+    m_blockCommitTimeMs += boost::chrono::duration_cast< boost::chrono::milliseconds >(
         historicStateFinish - historicStateStart )
-                             .count();
+                               .count();
 }
 
 uint64_t HistoricState::getBlockCommitTime() {
-    uint64_t retVal = blockCommitTimeMs;
-    blockCommitTimeMs = 0;
+    uint64_t retVal = m_blockCommitTimeMs;
+    m_blockCommitTimeMs = 0;
     return retVal;
 }
 

--- a/libhistoric/HistoricState.h
+++ b/libhistoric/HistoricState.h
@@ -296,7 +296,7 @@ public:
 
     void setRootFromDB();
 
-    uint64_t getBlockCommitTime();
+    uint64_t getAndResetBlockCommitTime();
 
 private:
     /// Turns all "touched" empty accounts into non-alive accounts.
@@ -348,7 +348,7 @@ private:
     AddressHash commitExternalChangesIntoTrieDB(
         AccountMap const& _cache, SecureTrieDB< Address, OverlayDB >& _state );
 
-    uint64_t m_blockCommitTimeMs = 0;
+    uint64_t m_totalTimeSpentInStateCommitsPerBlock = 0;
 };
 
 std::ostream& operator<<( std::ostream& _out, HistoricState const& _s );

--- a/libhistoric/HistoricState.h
+++ b/libhistoric/HistoricState.h
@@ -296,6 +296,8 @@ public:
 
     void setRootFromDB();
 
+    uint64_t getBlockCommitTime();
+
 private:
     /// Turns all "touched" empty accounts into non-alive accounts.
     void removeEmptyAccounts();
@@ -345,6 +347,8 @@ private:
 
     AddressHash commitExternalChangesIntoTrieDB(
         AccountMap const& _cache, SecureTrieDB< Address, OverlayDB >& _state );
+
+    uint64_t blockCommitTimeMs = 0;
 };
 
 std::ostream& operator<<( std::ostream& _out, HistoricState const& _s );

--- a/libhistoric/HistoricState.h
+++ b/libhistoric/HistoricState.h
@@ -348,7 +348,7 @@ private:
     AddressHash commitExternalChangesIntoTrieDB(
         AccountMap const& _cache, SecureTrieDB< Address, OverlayDB >& _state );
 
-    uint64_t blockCommitTimeMs = 0;
+    uint64_t m_blockCommitTimeMs = 0;
 };
 
 std::ostream& operator<<( std::ostream& _out, HistoricState const& _s );


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skaled/issues/1890

added `HSCT` - historic state commit time. measures the time per block consumed by historic state committing to the database 

tested on local machine