### PR TITLE
Bug/1911 eth fee history block count

### DIFF
--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -962,7 +962,7 @@ Json::Value Eth::eth_createAccessList(
     return result;
 }
 
-Json::Value Eth::eth_feeHistory( const std::string& _blockCount, const std::string& _newestBlock,
+Json::Value Eth::eth_feeHistory( dev::u256 _blockCount, const std::string& _newestBlock,
     const Json::Value& _rewardPercentiles ) {
     try {
         if ( !_rewardPercentiles.isArray() )
@@ -974,8 +974,7 @@ Json::Value Eth::eth_feeHistory( const std::string& _blockCount, const std::stri
             }
         }
 
-        auto blockCount = jsToU256( _blockCount );
-        if ( blockCount > MAX_BLOCK_RANGE )
+        if ( _blockCount > MAX_BLOCK_RANGE )
             throw std::runtime_error( "Max block range reached. Please try smaller blockCount." );
 
         auto newestBlock = jsToBlockNumber( _newestBlock );
@@ -984,10 +983,10 @@ Json::Value Eth::eth_feeHistory( const std::string& _blockCount, const std::stri
 
         auto result = Json::Value( Json::objectValue );
         dev::u256 oldestBlock;
-        if ( blockCount > newestBlock )
+        if ( _blockCount > newestBlock )
             oldestBlock = 1;
         else
-            oldestBlock = dev::u256( newestBlock ) - blockCount + 1;
+            oldestBlock = dev::u256( newestBlock ) - _blockCount + 1;
         result["oldestBlock"] = toJS( oldestBlock );
 
         result["baseFeePerGas"] = Json::Value( Json::arrayValue );

--- a/libweb3jsonrpc/Eth.h
+++ b/libweb3jsonrpc/Eth.h
@@ -219,7 +219,7 @@ public:
     virtual Json::Value eth_createAccessList(
         const Json::Value& param1, const std::string& param2 ) override;
     virtual Json::Value eth_feeHistory(
-        const std::string& param1, const std::string& param2, const Json::Value& param3 ) override;
+        dev::u256 param1, const std::string& param2, const Json::Value& param3 ) override;
     virtual std::string eth_maxPriorityFeePerGas() override;
 
     void setTransactionDefaults( eth::TransactionSkeleton& _t );

--- a/test/unittests/libethereum/ClientTest.cpp
+++ b/test/unittests/libethereum/ClientTest.cpp
@@ -39,7 +39,7 @@ using namespace dev::test;
 using namespace dev::p2p;
 namespace fs = boost::filesystem;
 
-static size_t rand_port = 1024 + rand() % 64000;
+static size_t rand_port = ( srand(time(nullptr)), 1024 + rand() % 64000 );
 
 struct FixtureCommon {
     const string BTRFS_FILE_PATH = "btrfs.file";

--- a/test/unittests/libweb3jsonrpc/WebThreeStubClient.cpp
+++ b/test/unittests/libweb3jsonrpc/WebThreeStubClient.cpp
@@ -841,7 +841,7 @@ Json::Value WebThreeStubClient::eth_createAccessList( const Json::Value& param1,
         throw jsonrpc::JsonRpcException(
             jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString() );
 }
-#include <iostream>
+
 Json::Value WebThreeStubClient::eth_feeHistory( const Json::Value& param1, const std::string& param2, const Json::Value& param3 ) {
     Json::Value p;
     if ( param1.isString() )

--- a/test/unittests/libweb3jsonrpc/WebThreeStubClient.cpp
+++ b/test/unittests/libweb3jsonrpc/WebThreeStubClient.cpp
@@ -841,10 +841,13 @@ Json::Value WebThreeStubClient::eth_createAccessList( const Json::Value& param1,
         throw jsonrpc::JsonRpcException(
             jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString() );
 }
-
-Json::Value WebThreeStubClient::eth_feeHistory( const std::string& param1, const std::string& param2, const Json::Value& param3 ) {
+#include <iostream>
+Json::Value WebThreeStubClient::eth_feeHistory( const Json::Value& param1, const std::string& param2, const Json::Value& param3 ) {
     Json::Value p;
-    p.append( param1 );
+    if ( param1.isString() )
+        p.append( param1.asString() );
+    if ( param1.isUInt() )
+        p.append( param1.asUInt() );
     p.append( param2 );
     p.append( param3 );
     Json::Value result = this->CallMethod( "eth_feeHistory", p );

--- a/test/unittests/libweb3jsonrpc/WebThreeStubClient.h
+++ b/test/unittests/libweb3jsonrpc/WebThreeStubClient.h
@@ -5,6 +5,8 @@
 #ifndef JSONRPC_CPP_STUB_WEBTHREESTUBCLIENT_H_
 #define JSONRPC_CPP_STUB_WEBTHREESTUBCLIENT_H_
 
+#include <any>
+
 #include <jsonrpccpp/client.h>
 
 class WebThreeStubClient : public jsonrpc::Client {
@@ -98,7 +100,7 @@ public:
     std::string eth_sendRawTransaction( const std::string& param1 ) noexcept( false );
     std::string eth_maxPriorityFeePerGas() noexcept( false );
     Json::Value eth_createAccessList( const Json::Value& param1, const std::string& param2 ) noexcept( false );
-    Json::Value eth_feeHistory( const std::string& param1, const std::string& param2, const Json::Value& param3 ) noexcept( false );
+    Json::Value eth_feeHistory( const Json::Value& param1, const std::string& param2, const Json::Value& param3 ) noexcept( false );
     bool eth_notePassword( const std::string& param1 ) noexcept( false );
     bool db_put( const std::string& param1, const std::string& param2,
         const std::string& param3 ) noexcept( false );

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -3226,6 +3226,8 @@ BOOST_AUTO_TEST_CASE( eip1559RpcMethods ) {
             BOOST_REQUIRE_EQUAL( feeHistory["reward"][i][j].asString(), toJS( 0 ) );
         }
     }
+
+    BOOST_REQUIRE_NO_THROW( fixture.rpcClient->eth_feeHistory( blockCnt, "latest", percentiles ) );
 }
 
 BOOST_AUTO_TEST_CASE( etherbase_generation2 ) {


### PR DESCRIPTION
fixes #1911 

make `eth_feeHistory` accept first parameter `blockCount` either as `string` or as `int`.

added unittest