### PR TITLE
1774 revert hwm limits

### DIFF
--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -97,8 +97,7 @@ void* ZmqBroadcaster::server_socket() const {
         val = 60000;
         zmq_setsockopt( m_zmq_server_socket, ZMQ_HEARTBEAT_TTL, &val, sizeof( val ) );
 
-        // remove limits to prevent txns from being dropped out
-        val = 0;
+        val = 16;
         zmq_setsockopt( m_zmq_server_socket, ZMQ_SNDHWM, &val, sizeof( val ) );
 
 
@@ -132,7 +131,7 @@ void* ZmqBroadcaster::client_socket() const {
         value = 300;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_INTVL, &value, sizeof( value ) );
 
-        value = 0;
+        value = 16;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_RCVHWM, &value, sizeof( value ) );
 
         const dev::eth::ChainParams& ch = m_client.chainParams();


### PR DESCRIPTION
fixes #1919 

reverts #1774 

revert hwm limits to prevent ram growth

tested and verified on qa testnet