### PR TITLE
1922 fix block by number error

### DIFF
--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -602,7 +602,8 @@ Json::Value Eth::eth_getBlockByNumber( string const& _blockNumber, bool _include
         BlockNumber bn = ( h == LatestBlock || h == PendingBlock ) ? client()->number() : h;
 
         u256 baseFeePerGas;
-        if ( EIP1559TransactionsPatch::isEnabledWhen( client()->blockInfo( bn - 1 ).timestamp() ) )
+        if ( bn > 0 &&
+             EIP1559TransactionsPatch::isEnabledWhen( client()->blockInfo( bn - 1 ).timestamp() ) )
             try {
                 baseFeePerGas = client()->gasBidPrice( bn - 1 );
             } catch ( std::invalid_argument& _e ) {

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -3134,6 +3134,8 @@ BOOST_AUTO_TEST_CASE( eip1559Transactions ) {
     BOOST_REQUIRE( result["accessList"].isArray() );
     BOOST_REQUIRE( result["maxPriorityFeePerGas"] == "0x4a817c800" );
     BOOST_REQUIRE( result["maxFeePerGas"] == "0x4a817c800" );
+
+    BOOST_REQUIRE_NO_THROW( fixture.rpcClient->eth_getBlockByNumber( "0x0", false ) );
 }
 
 BOOST_AUTO_TEST_CASE( eip2930RpcMethods ) {


### PR DESCRIPTION
fixes #1922

added extra check to ensure that skaled doesn't ask block info for a block with negative number

added unittest

verified on the local machine