### PR TITLE
#1938 fix gas price for type2 txns

### DIFF
--- a/libweb3jsonrpc/JsonHelper.cpp
+++ b/libweb3jsonrpc/JsonHelper.cpp
@@ -95,8 +95,7 @@ Json::Value toJson( dev::eth::Transaction const& _t, std::pair< h256, unsigned >
         res["to"] = _t.isCreation() ? Json::Value() : toJS( _t.receiveAddress() );
         res["from"] = toJS( _t.safeSender() );
         res["gas"] = toJS( _t.gas() );
-        if ( _t.txType() != dev::eth::TransactionType::Type2 )
-            res["gasPrice"] = toJS( _t.gasPrice() );
+        res["gasPrice"] = toJS( _t.gasPrice() );
         res["nonce"] = toJS( _t.nonce() );
         res["value"] = toJS( _t.value() );
         res["blockHash"] = toJS( _location.first );
@@ -344,8 +343,7 @@ Json::Value toJson( dev::eth::Transaction const& _t ) {
         res["to"] = _t.isCreation() ? Json::Value() : toJS( _t.to() );
         res["from"] = toJS( _t.from() );
         res["gas"] = toJS( _t.gas() );
-        if ( _t.txType() != dev::eth::TransactionType::Type2 )
-            res["gasPrice"] = toJS( _t.gasPrice() );
+        res["gasPrice"] = toJS( _t.gasPrice() );
         res["value"] = toJS( _t.value() );
         res["data"] = toJS( _t.data(), 32 );
         res["nonce"] = toJS( _t.nonce() );


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skaled/issues/1938

added `gasPrice` for `type2` transactions to the JSON RPC responses
verified on regression network with blockexplorer
