### PR TITLE
Bug/is 552 zmq assert

### DIFF
--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -90,9 +90,8 @@ void* ZmqBroadcaster::server_socket() const {
     if ( !m_zmq_server_socket ) {
         m_zmq_server_socket = zmq_socket( m_zmq_context, ZMQ_PUB );
 
-        val = 16;
+        int val = 16;
         zmq_setsockopt( m_zmq_server_socket, ZMQ_SNDHWM, &val, sizeof( val ) );
-
 
         const dev::eth::ChainParams& ch = m_client.chainParams();
 

--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -90,15 +90,8 @@ void* ZmqBroadcaster::server_socket() const {
     if ( !m_zmq_server_socket ) {
         m_zmq_server_socket = zmq_socket( m_zmq_context, ZMQ_PUB );
 
-        int val = 15000;
-        zmq_setsockopt( m_zmq_server_socket, ZMQ_HEARTBEAT_IVL, &val, sizeof( val ) );
-        val = 3000;
-        zmq_setsockopt( m_zmq_server_socket, ZMQ_HEARTBEAT_TIMEOUT, &val, sizeof( val ) );
-        val = 60000;
-        zmq_setsockopt( m_zmq_server_socket, ZMQ_HEARTBEAT_TTL, &val, sizeof( val ) );
-
         // remove limits to prevent txns from being dropped out
-        val = 0;
+        int val = 0;
         zmq_setsockopt( m_zmq_server_socket, ZMQ_SNDHWM, &val, sizeof( val ) );
 
 

--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -116,11 +116,11 @@ void* ZmqBroadcaster::client_socket() const {
         int value = 1;
 
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE, &value, sizeof( value ) );
-        value = 300;
+        value = 15;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_IDLE, &value, sizeof( value ) );
         value = 10;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_CNT, &value, sizeof( value ) );
-        value = 300;
+        value = 15;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_INTVL, &value, sizeof( value ) );
 
         value = 16;


### PR DESCRIPTION
Removed ZMQ_HEARBEAT in boradcaster. TCP_KEEPALIVE is stil there

see testing description in comments in issue

performance impact: absent