### PR TITLE
Bug/1959 missing chainid 1559 txns

### DIFF
--- a/libweb3jsonrpc/JsonHelper.cpp
+++ b/libweb3jsonrpc/JsonHelper.cpp
@@ -107,6 +107,7 @@ Json::Value toJson( dev::eth::Transaction const& _t, std::pair< h256, unsigned >
         res["s"] = toJS( _t.signature().s );
         res["type"] = toJS( int( _t.txType() ) );
         if ( _t.txType() != dev::eth::TransactionType::Legacy ) {
+            res["chainId"] = toJS( _t.chainId() );
             res["yParity"] = toJS( _t.signature().v );
             res["accessList"] = Json::Value( Json::arrayValue );
             for ( const auto& d : _t.accessList() ) {
@@ -352,6 +353,7 @@ Json::Value toJson( dev::eth::Transaction const& _t ) {
         res["v"] = toJS( _t.signature().v );
         res["type"] = toJS( int( _t.txType() ) );
         if ( _t.txType() != dev::eth::TransactionType::Legacy ) {
+            res["chainId"] = toJS( _t.chainId() );
             res["yParity"] = toJS( _t.signature().v );
             res["accessList"] = Json::Value( Json::arrayValue );
             for ( const auto& d : _t.accessList() ) {
@@ -404,6 +406,7 @@ Json::Value toJson( dev::eth::LocalisedTransaction const& _t ) {
         res["s"] = toJS( _t.signature().s.hex() );
         res["type"] = toJS( int( _t.txType() ) );
         if ( _t.txType() != dev::eth::TransactionType::Legacy ) {
+            res["chainId"] = toJS( _t.chainId() );
             res["yParity"] = toJS( _t.signature().v );
             res["accessList"] = Json::Value( Json::arrayValue );
             for ( const auto& d : _t.accessList() ) {

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -2881,7 +2881,8 @@ BOOST_AUTO_TEST_CASE( eip2930Transactions ) {
     Json::Reader().parse( _config, ret );
 
     // Set chainID = 151
-    ret["params"]["chainID"] = "0x97";
+    std::string chainID = "0x97";
+    ret["params"]["chainID"] = chainID;
     time_t eip1559PatchActivationTimestamp = time(nullptr) + 10;
     ret["skaleConfig"]["sChain"]["EIP1559TransactionsPatchTimestamp"] = eip1559PatchActivationTimestamp;
 
@@ -2955,6 +2956,8 @@ BOOST_AUTO_TEST_CASE( eip2930Transactions ) {
     BOOST_REQUIRE( toJS( jsToInt( block["transactions"][0]["yParity"].asString() ) + 35 + 2 * fixture.client->chainParams().chainID ) == block["transactions"][0]["v"].asString() );
     BOOST_REQUIRE( block["transactions"][0]["accessList"].isArray() );
     BOOST_REQUIRE( block["transactions"][0]["accessList"].size() == 0 );
+    BOOST_REQUIRE( block["transactions"][0].isMember( "chainId" ) );
+    BOOST_REQUIRE( block["transactions"][0]["chainId"].asString() == chainID );
 
     std::string blockHash = block["hash"].asString();
     BOOST_REQUIRE( fixture.client->transactionHashes( dev::h256( blockHash ) )[0] == dev::h256( "0xc843560015a655b8f81f65a458be9019bdb5cd8e416b6329ca18f36de0b8244d") );
@@ -3103,6 +3106,8 @@ BOOST_AUTO_TEST_CASE( eip1559Transactions ) {
     BOOST_REQUIRE( block["transactions"][0]["type"] == "0x2" );
     BOOST_REQUIRE( toJS( jsToInt( block["transactions"][0]["yParity"].asString() ) + 35 + 2 * fixture.client->chainParams().chainID ) == block["transactions"][0]["v"].asString() );
     BOOST_REQUIRE( block["transactions"][0]["accessList"].isArray() );
+    BOOST_REQUIRE( block["transactions"][0].isMember( "chainId" ) );
+    BOOST_REQUIRE( block["transactions"][0]["chainId"].asString() == chainID );
 
     std::string blockHash = block["hash"].asString();
 

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -3030,7 +3030,8 @@ BOOST_AUTO_TEST_CASE( eip1559Transactions ) {
     Json::Reader().parse( _config, ret );
 
     // Set chainID = 151
-    ret["params"]["chainID"] = "0x97";
+    std::string chainID = "0x97";
+    ret["params"]["chainID"] = chainID;
     time_t eip1559PatchActivationTimestamp = time(nullptr) + 10;
     ret["skaleConfig"]["sChain"]["EIP1559TransactionsPatchTimestamp"] = eip1559PatchActivationTimestamp;
 


### PR DESCRIPTION
fixes #1959 

add `chainId` field to the JSON representation of `type1` and `type2` transactions

added unit tests to verify the changes. also tested them on the local machine by sending `eth_getBlock` and `eth_getTransaction` calls

no performance impact