### PR TITLE
SKALED-1935 Fix skale-vm and test.ClientBase build

### DIFF
--- a/cmake/EthUtils.cmake
+++ b/cmake/EthUtils.cmake
@@ -57,7 +57,7 @@ macro(eth_add_test NAME)
 	add_custom_target("test.${NAME}"
 		DEPENDS testeth
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-		COMMAND ${CMAKE_COMMAND} -DETH_TEST_NAME="${NAME}" -DCTEST_COMMAND="${CTEST_COMMAND}" -P "${ETH_SCRIPTS_DIR}/runtest.cmake"
+                COMMAND ${CMAKE_COMMAND} -DETH_TEST_NAME="${NAME}" -DCTEST_COMMAND="${CMAKE_CTEST_COMMAND}" -P "${ETH_SCRIPTS_DIR}/runtest.cmake"
 	)
 
 endmacro()

--- a/skale-vm/main.cpp
+++ b/skale-vm/main.cpp
@@ -292,6 +292,8 @@ int main( int argc, char** argv ) {
         0 /* gasUsed */, chainParams.chainID );
     EVMSchedule evmSchedule = chainParams.makeEvmSchedule( 0, envInfo.number() );
 
+    state = state.createStateModifyCopy();
+
     Transaction t;
     Address contractDestination( "1122334455667788991011121314151617181920" );
     if ( !code.empty() ) {
@@ -387,5 +389,8 @@ int main( int argc, char** argv ) {
              << '\n';
         cout << "exec time: " << fixed << setprecision( 6 ) << execTime << '\n';
     }
+
+    state.releaseWriteLock();
+
     return 0;
 }

--- a/skale-vm/main.cpp
+++ b/skale-vm/main.cpp
@@ -286,17 +286,18 @@ int main( int argc, char** argv ) {
         }  // Ignore decoding errors.
     }
 
-    unique_ptr< SealEngineFace > se( ChainParams( genesisInfo( networkName ) ).createSealEngine() );
+    ChainParams chainParams( genesisInfo( networkName ) );
     LastBlockHashes lastBlockHashes;
-    EnvInfo const envInfo(
-        blockHeader, lastBlockHashes, 0 /* gasUsed */, se->chainParams().chainID );
+    EnvInfo const envInfo( blockHeader, lastBlockHashes, 0 /*_committedBlockTimestamp*/,
+        0 /* gasUsed */, chainParams.chainID );
+    EVMSchedule evmSchedule = chainParams.makeEvmSchedule( 0, envInfo.number() );
 
     Transaction t;
     Address contractDestination( "1122334455667788991011121314151617181920" );
     if ( !code.empty() ) {
         // Deploy the code on some fake account to be called later.
         Account account( 0, 0 );
-        auto const latestVersion = se->evmSchedule( envInfo.number() ).accountVersion;
+        auto const latestVersion = evmSchedule.accountVersion;
         account.setCode( bytes{ code }, latestVersion );
         std::unordered_map< Address, Account > map;
         map[contractDestination] = account;
@@ -307,10 +308,12 @@ int main( int argc, char** argv ) {
         // data.
         t = Transaction( value, gasPrice, gas, data, 0 );
 
+    t.ignoreExternalGas();  // for tests
+
     state.addBalance( sender, value );
 
-    // HACK 0 here is for gasPrice
-    Executive executive( state, envInfo, *se, 0 );
+    // HACK 1st 0 here is for gasPrice
+    Executive executive( state, envInfo, chainParams, 0, 0 );
     ExecutionResult res;
     executive.setResultRecipient( res );
     t.forceSender( sender );
@@ -346,9 +349,8 @@ int main( int argc, char** argv ) {
     bytes output = std::move( res.output );
 
     if ( mode == Mode::Statistics ) {
-        cout << "Gas used: " << res.gasUsed << " (+"
-             << t.baseGasRequired( se->evmSchedule( envInfo.number() ) ) << " for transaction, -"
-             << res.gasRefunded << " refunded)\n";
+        cout << "Gas used: " << res.gasUsed << " (+" << t.baseGasRequired( evmSchedule )
+             << " for transaction, -" << res.gasRefunded << " refunded)\n";
         cout << "Output: " << toHex( output ) << "\n";
         LogEntries logs = executive.logs();
         cout << logs.size() << " logs" << ( logs.empty() ? "." : ":" ) << "\n";


### PR DESCRIPTION
Adapted full build to use new patch timestamp architecture.
Fixed `make test.ClientBase` (we are not using it, but now it runs).

skale-vm now compiles, does not crash, but still doesn't work fully correctly (as before), see https://github.com/skalenetwork/skaled/issues/1972