### PR TITLE
SKALED-1900 release build with separate debug info

### DIFF
--- a/.github/workflows/custom_build.yml
+++ b/.github/workflows/custom_build.yml
@@ -22,6 +22,7 @@ on:
         options: 
         - Debug
         - RelWithDebInfo
+        - Release
         default: RelWithDebInfo
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,7 +118,6 @@ jobs:
           make skaled -j$(nproc)
           #echo "Ensure release mode skaled does not have any debug markers"
           cp skaled/skaled skaled/skaled-debug
-          strip skaled/skaled
           cd ..
       - name: Configure historic state build
         run: |
@@ -141,7 +140,6 @@ jobs:
           make skaled -j$(nproc)
           #echo "Ensure release mode skaled does not have any debug markers"
           cp skaled/skaled skaled/skaled-debug
-          strip skaled/skaled
           cd ..
       - name: Build and publish container
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,6 +116,7 @@ jobs:
           cd build
           make skaled -j$(nproc)
           cp skaled/skaled skaled/skaled-debug
+          strip --strip-all skaled/skaled
           cd ..
       - name: Configure historic state build
         run: |
@@ -136,6 +137,7 @@ jobs:
           cd build-historic
           make skaled -j$(nproc)
           cp skaled/skaled skaled/skaled-debug
+          strip --strip-all skaled/skaled
           cd ..
       - name: Build and publish container
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,7 +103,7 @@ jobs:
           export CC=gcc-9
           export CXX=g++-9
           export TARGET=all
-          export CMAKE_BUILD_TYPE=Release
+          export CMAKE_BUILD_TYPE=RelWithDebInfo
           mkdir -p build
           cd build
           cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE ..

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
           export CC=gcc-9
           export CXX=g++-9
           export TARGET=all
-          export CMAKE_BUILD_TYPE=RelWithDebInfo
+          export CMAKE_BUILD_TYPE=Release
           cd deps
           ./clean.sh
           rm -f ./libwebsockets-from-git.tar.gz
@@ -102,10 +102,9 @@ jobs:
           export CC=gcc-9
           export CXX=g++-9
           export TARGET=all
-          export CMAKE_BUILD_TYPE=RelWithDebInfo
+          export CMAKE_BUILD_TYPE=Release
           mkdir -p build
           cd build
-          # -DCMAKE_C_FLAGS=-O3 -DCMAKE_CXX_FLAGS=-O3
           cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE ..
           cd ..
       - name: Build all
@@ -116,7 +115,6 @@ jobs:
           export CMAKE_BUILD_TYPE=RelWithDebInfo
           cd build
           make skaled -j$(nproc)
-          #echo "Ensure release mode skaled does not have any debug markers"
           cp skaled/skaled skaled/skaled-debug
           cd ..
       - name: Configure historic state build
@@ -127,7 +125,6 @@ jobs:
           export CMAKE_BUILD_TYPE=RelWithDebInfo
           mkdir -p build-historic
           cd build-historic
-          # -DCMAKE_C_FLAGS=-O3 -DCMAKE_CXX_FLAGS=-O3
           cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DHISTORIC_STATE=1 ..
           cd ..
       - name: Build historic state version
@@ -138,7 +135,6 @@ jobs:
           export CMAKE_BUILD_TYPE=RelWithDebInfo
           cd build-historic
           make skaled -j$(nproc)
-          #echo "Ensure release mode skaled does not have any debug markers"
           cp skaled/skaled skaled/skaled-debug
           cd ..
       - name: Build and publish container

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,6 @@ jobs:
         run: |
           sudo apt-get -y remove libzmq* || true
           sudo apt-get -y install software-properties-common gcc-9 g++-9 || true
-          sudo apt-get -y install liblz4-dev || true
 
       - name: Use g++-9 and gcov-9 by default
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           sudo apt-get -y remove libzmq* || true
           sudo apt-get -y install software-properties-common gcc-9 g++-9 || true
+          sudo apt-get -y install liblz4-dev || true
 
       - name: Use g++-9 and gcov-9 by default
         run: |

--- a/.github/workflows/setup-build-publish.yml
+++ b/.github/workflows/setup-build-publish.yml
@@ -151,6 +151,13 @@ jobs:
           export CMAKE_BUILD_TYPE=$BUILD_TYPE
           cd build
           make skaled -j$(nproc)
+          if [[ "$BUILD_TYPE" = "Release" ]]; then
+              debug_wc=$(objdump -h skaled/skaled | grep -i debug | wc -l)
+              sym_wc=$(readelf -s skaled/skaled | wc -l)
+              if (( debug_wc != 0 || sym_wc > 10000 )); then
+                  exit 1
+              fi
+          fi
           cd ..
       - name: Build and publish container
         env:

--- a/.github/workflows/setup-build-publish.yml
+++ b/.github/workflows/setup-build-publish.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           sudo apt-get -y remove libzmq* || true
           sudo apt-get -y install software-properties-common gcc-9 g++-9 || true
+          sudo apt-get -y install liblz4-dev || true
   
       - name: Use g++-9 and gcov-9 by default
         run: |

--- a/.github/workflows/setup-build-publish.yml
+++ b/.github/workflows/setup-build-publish.yml
@@ -61,7 +61,6 @@ jobs:
         run: |
           sudo apt-get -y remove libzmq* || true
           sudo apt-get -y install software-properties-common gcc-9 g++-9 || true
-          sudo apt-get -y install liblz4-dev || true
   
       - name: Use g++-9 and gcov-9 by default
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,12 +18,6 @@ list( APPEND CMAKE_MODULE_PATH ${DEPS_INSTALL_ROOT}/lib/cmake )
 
 link_directories( ${CMAKE_BINARY_DIR}/deps/lib )          # HACK for not-found -lff in testeth
 
-if( NOT CMAKE_BUILD_TYPE MATCHES "Debug" )
-    set( CMAKE_CXX_FLAGS           "${CMAKE_CXX_FLAGS}           -rdynamic" )
-    set( CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS}    -rdynamic" )
-    set( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -rdynamic" )
-endif()
-
 option( SKALED_PROFILING "Build for profiling" OFF )
 if( SKALED_PROFILING )
     set( CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -pg" )
@@ -31,6 +25,8 @@ if( SKALED_PROFILING )
     set( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pg" )
     set( CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -pg" )
 endif()
+
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -s")
 
 if( CMAKE_BUILD_TYPE STREQUAL "Release" )
     set( CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -O3" )

--- a/deps/build.sh
+++ b/deps/build.sh
@@ -2116,7 +2116,9 @@ then
 		cd build2
 		eval "$MAKE" "${PARALLEL_MAKE_OPTIONS}"
 		eval "$MAKE" "${PARALLEL_MAKE_OPTIONS}" install
-        eval strip --strip-debug "${INSTALL_ROOT}"/lib/libfolly*.a
+		if [ "$DEBUG" = "0" ]; then
+            eval strip --strip-debug "${INSTALL_ROOT}"/lib/libfolly*.a
+        fi
 		cd "$SOURCES_ROOT"
 	else
 		echo -e "${COLOR_SUCCESS}SKIPPED${COLOR_RESET}"

--- a/deps/build.sh
+++ b/deps/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 set -e
 export SKALED_DEPS_CHAIN=1
 
@@ -1158,16 +1159,20 @@ then
 			#
 			echo -e "${COLOR_INFO}configuring it${COLOR_DOTS}...${COLOR_RESET}"
 			cd libuv
-			eval ./autogen.sh
-			eval ./configure "${CONF_CROSSCOMPILING_OPTS_GENERIC}" --enable-static --disable-shared --with-pic --prefix="$INSTALL_ROOT" "${CONF_DEBUG_OPTIONS}"
+			# eval ./autogen.sh
+			# eval ./configure "${CONF_CROSSCOMPILING_OPTS_GENERIC}" --enable-static --disable-shared --with-pic --prefix="$INSTALL_ROOT" "${CONF_DEBUG_OPTIONS}"
 			#--with-sysroot=="$INSTALL_ROOT"
-			cd ..
+            mkdir build && cd build
+            eval "$CMAKE" "${CMAKE_CROSSCOMPILING_OPTS}" -DCMAKE_INSTALL_PREFIX="$INSTALL_ROOT" -DCMAKE_BUILD_TYPE="$TOP_CMAKE_BUILD_TYPE" \
+                -DBUILD_SHARED_LIBS=OFF \
+                ..
+            cd ../..
 		fi
 		echo -e "${COLOR_INFO}building it${COLOR_DOTS}...${COLOR_RESET}"
-		cd libuv
+		cd libuv/build
 		eval "$MAKE" "${PARALLEL_MAKE_OPTIONS}"
 		eval "$MAKE" "${PARALLEL_MAKE_OPTIONS}" install
-		cd ..
+		cd ../..
 		cd "$SOURCES_ROOT"
 	else
 		echo -e "${COLOR_SUCCESS}SKIPPED${COLOR_RESET}"
@@ -1391,13 +1396,21 @@ then
 		cd boost_1_68_0
 		echo -e "${COLOR_INFO}configuring and building it${COLOR_DOTS}...${COLOR_RESET}"
 		eval ./bootstrap.sh --prefix="$INSTALL_ROOT" --with-libraries=atomic,context,filesystem,program_options,regex,system,thread,date_time,iostreams
+
+        if [ "$DEBUG" = "1" ]; then
+            variant=debug
+        else
+            variant=release
+        fi
+
 		if [ ${ARCH} = "arm" ]
 		then
 			sed -i -e 's#using gcc ;#using gcc : arm : /usr/local/toolchains/gcc7.2-arm/bin/arm-linux-gnueabihf-g++ ;#g' project-config.jam
-			eval ./b2 "${CONF_CROSSCOMPILING_OPTS_BOOST}" cxxflags=-fPIC cflags=-fPIC "${PARALLEL_MAKE_OPTIONS}" --prefix="$INSTALL_ROOT" --layout=system variant=debug link=static threading=multi install
+			eval ./b2 "${CONF_CROSSCOMPILING_OPTS_BOOST}" cxxflags=-fPIC cflags=-fPIC "${PARALLEL_MAKE_OPTIONS}" --prefix="$INSTALL_ROOT" --layout=system variant=$variant link=static threading=multi install
 		else
-			eval ./b2 cxxflags=-fPIC cflags=-fPIC "${PARALLEL_MAKE_OPTIONS}" --prefix="$INSTALL_ROOT" --layout=system variant=debug link=static threading=multi install
+			eval ./b2 cxxflags=-fPIC cflags=-fPIC "${PARALLEL_MAKE_OPTIONS}" --prefix="$INSTALL_ROOT" --layout=system variant=$variant link=static threading=multi install
 		fi
+
 		cd ..
 		cd "$SOURCES_ROOT"
 	else
@@ -2082,6 +2095,7 @@ then
 				eval tar -xzf folly-from-git.tar.gz
 			fi
 			echo -e "${COLOR_INFO}fixing it${COLOR_DOTS}...${COLOR_RESET}"
+            sed -i 's/list(APPEND FOLLY_LINK_LIBRARIES ${LIBUNWIND_LIBRARIES})/list(APPEND FOLLY_LINK_LIBRARIES ${LIBUNWIND_LIBRARIES} lzma)/' ./folly/CMake/folly-deps.cmake
 			sed -i 's/google::InstallFailureFunction(abort);/google::InstallFailureFunction( reinterpret_cast < google::logging_fail_func_t > ( abort ) );/g' ./folly/folly/init/Init.cpp
 			echo -e "${COLOR_INFO}configuring it${COLOR_DOTS}...${COLOR_RESET}"
 			cd folly
@@ -2091,6 +2105,8 @@ then
                                 -DBOOST_ROOT="$INSTALL_ROOT" -DBOOST_LIBRARYDIR="$INSTALL_ROOT/lib" -DBoost_NO_WARN_NEW_VERSIONS=1 -DBoost_DEBUG=ON \
 				-DBUILD_SHARED_LIBS=OFF \
 				-DBUILD_TESTS=OFF -DBUILD_BROKEN_TESTS=OFF -DBUILD_HANGING_TESTS=OFF -DBUILD_SLOW_TESTS=OFF \
+                -DCMAKE_INCLUDE_PATH="${INSTALL_ROOT}/include" \
+                -DCMAKE_LIBRARY_PATH="${INSTALL_ROOT}/lib" \
 				..
 			cd ..
 		else
@@ -2100,6 +2116,7 @@ then
 		cd build2
 		eval "$MAKE" "${PARALLEL_MAKE_OPTIONS}"
 		eval "$MAKE" "${PARALLEL_MAKE_OPTIONS}" install
+        eval strip --strip-debug "${INSTALL_ROOT}"/lib/libfolly*.a
 		cd "$SOURCES_ROOT"
 	else
 		echo -e "${COLOR_SUCCESS}SKIPPED${COLOR_RESET}"

--- a/skaled/CMakeLists.txt
+++ b/skaled/CMakeLists.txt
@@ -30,7 +30,6 @@ target_link_libraries(
         pthread
         idn2
         batched-io
-        lz4
     )
 if (CONSENSUS)
     target_link_libraries(${EXECUTABLE_NAME} PRIVATE consensus)

--- a/skaled/CMakeLists.txt
+++ b/skaled/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(
         pthread
         idn2
         batched-io
+        lz4
     )
 if (CONSENSUS)
     target_link_libraries(${EXECUTABLE_NAME} PRIVATE consensus)


### PR DESCRIPTION
1. All dependencies, are built with `-O3` and without `-g`.
2. `skaled` is built with `-O3` but WITH `-g`.
3. `-rdynamic` removed.
4. `skaled` binary is stripped, but it's copy wit debug info is kept.

CUSTOM BUILD Now contains option to build maximally optimized "Release" configuration

Consequences:
 1. Stack trace printed by skaled on crash will not contain any function names.
 2. gdb will be able to use `skaled-debug` file to load debug info for original skaled
 3. `addr2line` will be able to convert addresses from skaled's printed stack trace into source code locations using `skaled-debug` binary

Testing:
1
```
objdump -h skaled | grep debug
nm -a skaled
```
2 Execute `strip` command on `skaled` and see that it's size didn't change
3 `ojdump -h <file> | grep debug` on all project libraries shows no result too.

`skaled` binary size `29575576`