### PR TITLE
#1980 fix mismatched v

### DIFF
--- a/libweb3jsonrpc/JsonHelper.cpp
+++ b/libweb3jsonrpc/JsonHelper.cpp
@@ -101,8 +101,9 @@ Json::Value toJson( dev::eth::Transaction const& _t, std::pair< h256, unsigned >
         res["blockHash"] = toJS( _location.first );
         res["transactionIndex"] = toJS( _location.second );
         res["blockNumber"] = toJS( _blockNumber );
-        res["v"] = _t.txType() != dev::eth::TransactionType::Legacy ? toJS( _t.signature().v ) :
-                                                                      toJS( 37 + _t.signature().v );
+        res["v"] = _t.txType() == dev::eth::TransactionType::Legacy ?
+                       toJS( 37 + _t.signature().v ) :
+                       toJS( _t.signature().v );
         res["r"] = toJS( _t.signature().r );
         res["s"] = toJS( _t.signature().s );
         res["type"] = toJS( int( _t.txType() ) );
@@ -350,7 +351,9 @@ Json::Value toJson( dev::eth::Transaction const& _t ) {
         res["nonce"] = toJS( _t.nonce() );
         res["r"] = toJS( _t.signature().r );
         res["s"] = toJS( _t.signature().s );
-        res["v"] = toJS( _t.signature().v );
+        res["v"] = _t.txType() == dev::eth::TransactionType::Legacy ?
+                       toJS( 37 + _t.signature().v ) :
+                       toJS( _t.signature().v );
         res["type"] = toJS( int( _t.txType() ) );
         if ( _t.txType() != dev::eth::TransactionType::Legacy ) {
             res["chainId"] = toJS( _t.chainId() );
@@ -400,8 +403,9 @@ Json::Value toJson( dev::eth::LocalisedTransaction const& _t ) {
         res["to"] = _t.isCreation() ? Json::Value() : toJS( _t.receiveAddress() );
         res["transactionIndex"] = toJS( _t.transactionIndex() );
         res["value"] = toJS( _t.value() );
-        res["v"] = _t.txType() != dev::eth::TransactionType::Legacy ? toJS( _t.signature().v ) :
-                                                                      toJS( 37 + _t.signature().v );
+        res["v"] = _t.txType() == dev::eth::TransactionType::Legacy ?
+                       toJS( 37 + _t.signature().v ) :
+                       toJS( _t.signature().v );
         res["r"] = toJS( _t.signature().r.hex() );
         res["s"] = toJS( _t.signature().s.hex() );
         res["type"] = toJS( int( _t.txType() ) );

--- a/libweb3jsonrpc/JsonHelper.cpp
+++ b/libweb3jsonrpc/JsonHelper.cpp
@@ -101,8 +101,8 @@ Json::Value toJson( dev::eth::Transaction const& _t, std::pair< h256, unsigned >
         res["blockHash"] = toJS( _location.first );
         res["transactionIndex"] = toJS( _location.second );
         res["blockNumber"] = toJS( _blockNumber );
-        res["v"] = _t.isReplayProtected() ? toJS( 2 * _t.chainId() + 35 + _t.signature().v ) :
-                                            toJS( 27 + _t.signature().v );
+        res["v"] = _t.txType() != dev::eth::TransactionType::Legacy ? toJS( _t.signature().v ) :
+                                                                      toJS( 37 + _t.signature().v );
         res["r"] = toJS( _t.signature().r );
         res["s"] = toJS( _t.signature().s );
         res["type"] = toJS( int( _t.txType() ) );
@@ -400,8 +400,8 @@ Json::Value toJson( dev::eth::LocalisedTransaction const& _t ) {
         res["to"] = _t.isCreation() ? Json::Value() : toJS( _t.receiveAddress() );
         res["transactionIndex"] = toJS( _t.transactionIndex() );
         res["value"] = toJS( _t.value() );
-        res["v"] = _t.isReplayProtected() ? toJS( 2 * _t.chainId() + 35 + _t.signature().v ) :
-                                            toJS( 27 + _t.signature().v );
+        res["v"] = _t.txType() != dev::eth::TransactionType::Legacy ? toJS( _t.signature().v ) :
+                                                                      toJS( 37 + _t.signature().v );
         res["r"] = toJS( _t.signature().r.hex() );
         res["s"] = toJS( _t.signature().s.hex() );
         res["type"] = toJS( int( _t.txType() ) );

--- a/libweb3jsonrpc/JsonHelper.cpp
+++ b/libweb3jsonrpc/JsonHelper.cpp
@@ -101,10 +101,13 @@ Json::Value toJson( dev::eth::Transaction const& _t, std::pair< h256, unsigned >
         res["blockHash"] = toJS( _location.first );
         res["transactionIndex"] = toJS( _location.second );
         res["blockNumber"] = toJS( _blockNumber );
-        res["v"] = _t.txType() == dev::eth::TransactionType::Legacy ?
-                       ( _t.isReplayProtected() ? toJS( 2 * _t.chainId() + 35 + _t.signature().v ) :
-                                                  toJS( 27 + _t.signature().v ) ) :
-                       toJS( _t.signature().v );
+        if ( _t.txType() == dev::eth::TransactionType::Legacy )
+            if ( _t.isReplayProtected() )
+                res["v"] = toJS( 2 * _t.chainId() + 35 + _t.signature().v );
+            else
+                res["v"] = toJS( 27 + _t.signature().v );
+        else
+            res["v"] = toJS( _t.signature().v );
         res["r"] = toJS( _t.signature().r );
         res["s"] = toJS( _t.signature().s );
         res["type"] = toJS( int( _t.txType() ) );
@@ -352,10 +355,13 @@ Json::Value toJson( dev::eth::Transaction const& _t ) {
         res["nonce"] = toJS( _t.nonce() );
         res["r"] = toJS( _t.signature().r );
         res["s"] = toJS( _t.signature().s );
-        res["v"] = _t.txType() == dev::eth::TransactionType::Legacy ?
-                       ( _t.isReplayProtected() ? toJS( 2 * _t.chainId() + 35 + _t.signature().v ) :
-                                                  toJS( 27 + _t.signature().v ) ) :
-                       toJS( _t.signature().v );
+        if ( _t.txType() == dev::eth::TransactionType::Legacy )
+            if ( _t.isReplayProtected() )
+                res["v"] = toJS( 2 * _t.chainId() + 35 + _t.signature().v );
+            else
+                res["v"] = toJS( 27 + _t.signature().v );
+        else
+            res["v"] = toJS( _t.signature().v );
         res["type"] = toJS( int( _t.txType() ) );
         if ( _t.txType() != dev::eth::TransactionType::Legacy ) {
             res["chainId"] = toJS( _t.chainId() );
@@ -405,10 +411,13 @@ Json::Value toJson( dev::eth::LocalisedTransaction const& _t ) {
         res["to"] = _t.isCreation() ? Json::Value() : toJS( _t.receiveAddress() );
         res["transactionIndex"] = toJS( _t.transactionIndex() );
         res["value"] = toJS( _t.value() );
-        res["v"] = _t.txType() == dev::eth::TransactionType::Legacy ?
-                       ( _t.isReplayProtected() ? toJS( 2 * _t.chainId() + 35 + _t.signature().v ) :
-                                                  toJS( 27 + _t.signature().v ) ) :
-                       toJS( _t.signature().v );
+        if ( _t.txType() == dev::eth::TransactionType::Legacy )
+            if ( _t.isReplayProtected() )
+                res["v"] = toJS( 2 * _t.chainId() + 35 + _t.signature().v );
+            else
+                res["v"] = toJS( 27 + _t.signature().v );
+        else
+            res["v"] = toJS( _t.signature().v );
         res["r"] = toJS( _t.signature().r.hex() );
         res["s"] = toJS( _t.signature().s.hex() );
         res["type"] = toJS( int( _t.txType() ) );

--- a/libweb3jsonrpc/JsonHelper.cpp
+++ b/libweb3jsonrpc/JsonHelper.cpp
@@ -102,7 +102,8 @@ Json::Value toJson( dev::eth::Transaction const& _t, std::pair< h256, unsigned >
         res["transactionIndex"] = toJS( _location.second );
         res["blockNumber"] = toJS( _blockNumber );
         res["v"] = _t.txType() == dev::eth::TransactionType::Legacy ?
-                       toJS( 37 + _t.signature().v ) :
+                       ( _t.isReplayProtected() ? toJS( 2 * _t.chainId() + 35 + _t.signature().v ) :
+                                                  toJS( 27 + _t.signature().v ) ) :
                        toJS( _t.signature().v );
         res["r"] = toJS( _t.signature().r );
         res["s"] = toJS( _t.signature().s );
@@ -352,7 +353,8 @@ Json::Value toJson( dev::eth::Transaction const& _t ) {
         res["r"] = toJS( _t.signature().r );
         res["s"] = toJS( _t.signature().s );
         res["v"] = _t.txType() == dev::eth::TransactionType::Legacy ?
-                       toJS( 37 + _t.signature().v ) :
+                       ( _t.isReplayProtected() ? toJS( 2 * _t.chainId() + 35 + _t.signature().v ) :
+                                                  toJS( 27 + _t.signature().v ) ) :
                        toJS( _t.signature().v );
         res["type"] = toJS( int( _t.txType() ) );
         if ( _t.txType() != dev::eth::TransactionType::Legacy ) {
@@ -404,7 +406,8 @@ Json::Value toJson( dev::eth::LocalisedTransaction const& _t ) {
         res["transactionIndex"] = toJS( _t.transactionIndex() );
         res["value"] = toJS( _t.value() );
         res["v"] = _t.txType() == dev::eth::TransactionType::Legacy ?
-                       toJS( 37 + _t.signature().v ) :
+                       ( _t.isReplayProtected() ? toJS( 2 * _t.chainId() + 35 + _t.signature().v ) :
+                                                  toJS( 27 + _t.signature().v ) ) :
                        toJS( _t.signature().v );
         res["r"] = toJS( _t.signature().r.hex() );
         res["s"] = toJS( _t.signature().s.hex() );

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -3064,7 +3064,7 @@ BOOST_AUTO_TEST_CASE( eip2930Transactions ) {
     BOOST_REQUIRE( block["transactions"].size() == 1 );
     BOOST_REQUIRE( block["transactions"][0]["hash"].asString() == txHash );
     BOOST_REQUIRE( block["transactions"][0]["type"] == "0x1" );
-    BOOST_REQUIRE( toJS( jsToInt( block["transactions"][0]["yParity"].asString() ) + 35 + 2 * fixture.client->chainParams().chainID ) == block["transactions"][0]["v"].asString() );
+    BOOST_REQUIRE( block["transactions"][0]["yParity"].asString() == block["transactions"][0]["v"].asString() );
     BOOST_REQUIRE( block["transactions"][0]["accessList"].isArray() );
     BOOST_REQUIRE( block["transactions"][0]["accessList"].size() == 0 );
     BOOST_REQUIRE( block["transactions"][0].isMember( "chainId" ) );
@@ -3081,20 +3081,20 @@ BOOST_AUTO_TEST_CASE( eip2930Transactions ) {
     result = fixture.rpcClient->eth_getTransactionByHash( txHash );
     BOOST_REQUIRE( result["hash"].asString() == txHash );
     BOOST_REQUIRE( result["type"] == "0x1" );
-    BOOST_REQUIRE( toJS( jsToInt( result["yParity"].asString() ) + 35 + 2 * fixture.client->chainParams().chainID ) == result["v"].asString() );
+    BOOST_REQUIRE( result["yParity"].asString() == result["v"].asString() );
     BOOST_REQUIRE( result["accessList"].isArray() );
     BOOST_REQUIRE( result["accessList"].size() == 0 );
 
     result = fixture.rpcClient->eth_getTransactionByBlockHashAndIndex( blockHash, "0x0" );
     BOOST_REQUIRE( result["hash"].asString() == txHash );
     BOOST_REQUIRE( result["type"] == "0x1" );
-    BOOST_REQUIRE( toJS( jsToInt( result["yParity"].asString() ) + 35 + 2 * fixture.client->chainParams().chainID ) == result["v"].asString() );
+    BOOST_REQUIRE( result["yParity"].asString() == result["v"].asString() );
     BOOST_REQUIRE( result["accessList"].isArray() );
 
     result = fixture.rpcClient->eth_getTransactionByBlockNumberAndIndex( "0x4", "0x0" );
     BOOST_REQUIRE( result["hash"].asString() == txHash );
     BOOST_REQUIRE( result["type"] == "0x1" );
-    BOOST_REQUIRE( toJS( jsToInt( result["yParity"].asString() ) + 35 + 2 * fixture.client->chainParams().chainID ) == result["v"].asString() );
+    BOOST_REQUIRE( result["yParity"].asString() == result["v"].asString() );
     BOOST_REQUIRE( result["accessList"].isArray() );
     BOOST_REQUIRE( result["accessList"].size() == 0 );
 
@@ -3202,7 +3202,6 @@ BOOST_AUTO_TEST_CASE( eip1559Transactions ) {
 
     // compare with txn hash from geth
     BOOST_REQUIRE( txHash == "0x7bd586e93e3012577de4ba33e3b887baf520cbb92c5dd10996b262f9c5c8f747" );
-    std::cout << dev::toHexPrefixed( fixture.client->transactions( 4 )[0].toBytes() ) << '\n';
     BOOST_REQUIRE( dev::toHexPrefixed( fixture.client->transactions( 4 )[0].toBytes() ) == "0x02f8c98197808504a817c8008504a817c800827530947d36af85a184e220a656525fcbb9a63b9ab3c12b0180f85bf85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000780a0f1a407dfc1a9f782001d89f617e9b3a2f295378533784fb39960dea60beea2d0a05ac3da2946554ba3d5721850f4f89ee7a0c38e4acab7130908e7904d13174388" );
 
     BOOST_REQUIRE( fixture.rpcClient->eth_getBalance( "0x7D36aF85A184E220A656525fcBb9A63B9ab3C12b", "latest" ) == "0x1" );
@@ -3216,7 +3215,7 @@ BOOST_AUTO_TEST_CASE( eip1559Transactions ) {
     BOOST_REQUIRE( block["transactions"].size() == 1 );
     BOOST_REQUIRE( block["transactions"][0]["hash"].asString() == txHash );
     BOOST_REQUIRE( block["transactions"][0]["type"] == "0x2" );
-    BOOST_REQUIRE( toJS( jsToInt( block["transactions"][0]["yParity"].asString() ) + 35 + 2 * fixture.client->chainParams().chainID ) == block["transactions"][0]["v"].asString() );
+    BOOST_REQUIRE( block["transactions"][0]["yParity"].asString() == block["transactions"][0]["v"].asString() );
     BOOST_REQUIRE( block["transactions"][0]["accessList"].isArray() );
     BOOST_REQUIRE( block["transactions"][0].isMember( "chainId" ) );
     BOOST_REQUIRE( block["transactions"][0]["chainId"].asString() == chainID );
@@ -3231,7 +3230,7 @@ BOOST_AUTO_TEST_CASE( eip1559Transactions ) {
     result = fixture.rpcClient->eth_getTransactionByHash( txHash );
     BOOST_REQUIRE( result["hash"].asString() == txHash );
     BOOST_REQUIRE( result["type"] == "0x2" );
-    BOOST_REQUIRE( toJS( jsToInt( result["yParity"].asString() ) + 35 + 2 * fixture.client->chainParams().chainID ) == result["v"].asString() );
+    BOOST_REQUIRE( result["yParity"].asString() == result["v"].asString() );
     BOOST_REQUIRE( result["accessList"].isArray() );
     BOOST_REQUIRE( result.isMember( "maxPriorityFeePerGas" ) && result["maxPriorityFeePerGas"].isString() );
     BOOST_REQUIRE( result.isMember( "maxFeePerGas" ) && result["maxFeePerGas"].isString() );
@@ -3239,7 +3238,7 @@ BOOST_AUTO_TEST_CASE( eip1559Transactions ) {
     result = fixture.rpcClient->eth_getTransactionByBlockHashAndIndex( blockHash, "0x0" );
     BOOST_REQUIRE( result["hash"].asString() == txHash );
     BOOST_REQUIRE( result["type"] == "0x2" );
-    BOOST_REQUIRE( toJS( jsToInt( result["yParity"].asString() ) + 35 + 2 * fixture.client->chainParams().chainID ) == result["v"].asString() );
+    BOOST_REQUIRE( result["yParity"].asString() == result["v"].asString() );
     BOOST_REQUIRE( result["accessList"].isArray() );
     BOOST_REQUIRE( result["maxPriorityFeePerGas"] == "0x4a817c800" );
     BOOST_REQUIRE( result["maxFeePerGas"] == "0x4a817c800" );
@@ -3247,7 +3246,7 @@ BOOST_AUTO_TEST_CASE( eip1559Transactions ) {
     result = fixture.rpcClient->eth_getTransactionByBlockNumberAndIndex( "0x4", "0x0" );
     BOOST_REQUIRE( result["hash"].asString() == txHash );
     BOOST_REQUIRE( result["type"] == "0x2" );
-    BOOST_REQUIRE( toJS( jsToInt( result["yParity"].asString() ) + 35 + 2 * fixture.client->chainParams().chainID ) == result["v"].asString() );
+    BOOST_REQUIRE( result["yParity"].asString() == result["v"].asString() );
     BOOST_REQUIRE( result["accessList"].isArray() );
     BOOST_REQUIRE( result["maxPriorityFeePerGas"] == "0x4a817c800" );
     BOOST_REQUIRE( result["maxFeePerGas"] == "0x4a817c800" );


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skaled/issues/1980

fixed mismatched `v` field for `type1` and `type2` txns in txns json-rpc representation

tested on local machine comparing the results with geth
fixed unittests

no performance impact


before fix
```
  v: "0xf9454e86107da",
  value: 0,
  yParity: "0x1"
```

after fix
```
  v: "0x1",
  value: 0,
  yParity: "0x1"
```