### PR TITLE
Fix chainId in estimateGas call

### DIFF
--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -92,8 +92,8 @@ std::pair< bool, ExecutionResult > ClientBase::estimateGasStep( int64_t _gas, Bl
     t.forceChainId( chainId() );
     t.ignoreExternalGas();
     EnvInfo const env( _pendingBlock.info(), bc().lastBlockHashes(),
-        _pendingBlock.previousInfo().timestamp(), 0, _gas );
-    // Make a copy of state!! It will be deleted after step!
+        _pendingBlock.previousInfo().timestamp(), 0, _gas, bc().chainParams().chainID );
+    // Make a copy of the state, it will be deleted after this step
     State tempState = _latestBlock.mutableState();
     tempState.addBalance( _from, ( u256 )( t.gas() * t.gasPrice() + t.value() ) );
     ExecutionResult executionResult =


### PR DESCRIPTION
## Description

This pull request addresses a bug in the eth_estimateGas function. Specifically, it fixes how the estimateGasStep handles the chainId field, ensuring it works correctly with this parameter.

## Tests

- Added unit test (`JsonRpcSuite/eth_estimateGas_chainId`)
- Verified the behavior on both Skaled and Geth environments to compare results:

```
curl -X POST     -H "Content-Type: application/json"     -d ' { "jsonrpc": "2.0", "id": 4337, "method": "eth_call", "params": [ { "data": "0x6080604052348015600f57600080fd5b50604051633013bad360e21b815246600482015260240160405180910390fdfe" }, "0x2DFCA4" ] } '
```

Sepolia response (chainId: 0xaa36a7): 
```
{"jsonrpc":"2.0","id":4337,"error":{"code":3,"message":"execution reverted","data":"0xc04eeb4c0000000000000000000000000000000000000000000000000000000000aa36a7"}}
```

Skaled response (chainId: 0x1234):
```
{"error":{"code":3,"data":"0xc04eeb4c0000000000000000000000000000000000000000000000000000000000001234","message":"EVM revert instruction without description message"},"id":4337,"jsonrpc":"2.0"}
```

## Performance Impact

API changes only, no performance impact