### PR TITLE
#1963 fix max fee per gas in json rpc representation

### DIFF
--- a/libweb3jsonrpc/JsonHelper.cpp
+++ b/libweb3jsonrpc/JsonHelper.cpp
@@ -120,7 +120,7 @@ Json::Value toJson( dev::eth::Transaction const& _t, std::pair< h256, unsigned >
                 }
                 res["accessList"].append( accessList );
             }
-            if ( _t.txType() != dev::eth::TransactionType::Type1 ) {
+            if ( _t.txType() == dev::eth::TransactionType::Type2 ) {
                 res["maxPriorityFeePerGas"] = toJS( _t.maxPriorityFeePerGas() );
                 res["maxFeePerGas"] = toJS( _t.maxFeePerGas() );
             }
@@ -366,7 +366,7 @@ Json::Value toJson( dev::eth::Transaction const& _t ) {
                 }
                 res["accessList"].append( accessList );
             }
-            if ( _t.txType() != dev::eth::TransactionType::Type1 ) {
+            if ( _t.txType() == dev::eth::TransactionType::Type2 ) {
                 res["maxPriorityFeePerGas"] = toJS( _t.maxPriorityFeePerGas() );
                 res["maxFeePerGas"] = toJS( _t.maxFeePerGas() );
             }
@@ -421,7 +421,7 @@ Json::Value toJson( dev::eth::LocalisedTransaction const& _t ) {
             }
             if ( _t.txType() != dev::eth::TransactionType::Type1 ) {
                 res["maxPriorityFeePerGas"] = toJS( _t.maxPriorityFeePerGas() );
-                res["maxFeePerGas"] = toJS( _t.maxPriorityFeePerGas() );
+                res["maxFeePerGas"] = toJS( _t.maxFeePerGas() );
             }
         }
     }

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -3192,7 +3192,7 @@ BOOST_AUTO_TEST_CASE( eip1559Transactions ) {
 
     // send 1 WEI from 0x5EdF1e852fdD1B0Bc47C0307EF755C76f4B9c251 to 0x7D36aF85A184E220A656525fcBb9A63B9ab3C12b
     // encoded type 2 txn
-    txHash = fixture.rpcClient->eth_sendRawTransaction( "0x02f8c98197808504a817c8008504a817c800827530947d36af85a184e220a656525fcbb9a63b9ab3c12b0180f85bf85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000780a0f1a407dfc1a9f782001d89f617e9b3a2f295378533784fb39960dea60beea2d0a05ac3da2946554ba3d5721850f4f89ee7a0c38e4acab7130908e7904d13174388" );
+    txHash = fixture.rpcClient->eth_sendRawTransaction( "0x02f8c98197808504a817c8018504a817c800827530947d36af85a184e220a656525fcbb9a63b9ab3c12b0180f85bf85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000701a005bd1eedc509a8e94cfcfc84d0b5fd53a0888a475274cbeee321047da5d139f8a00e7f0dd8b5277766d447ea51b7d8f571dc8bb57ff95c068c58f5b6fe9089dde8" );
     auto pendingTransactions = fixture.rpcClient->eth_pendingTransactions();
     BOOST_REQUIRE( pendingTransactions.isArray() && pendingTransactions.size() == 1);
     BOOST_REQUIRE( pendingTransactions[0]["type"] == "0x2" );
@@ -3201,9 +3201,8 @@ BOOST_AUTO_TEST_CASE( eip1559Transactions ) {
     dev::eth::mineTransaction( *( fixture.client ), 1 );
 
     // compare with txn hash from geth
-    BOOST_REQUIRE( txHash == "0x7bd586e93e3012577de4ba33e3b887baf520cbb92c5dd10996b262f9c5c8f747" );
-    std::cout << dev::toHexPrefixed( fixture.client->transactions( 4 )[0].toBytes() ) << '\n';
-    BOOST_REQUIRE( dev::toHexPrefixed( fixture.client->transactions( 4 )[0].toBytes() ) == "0x02f8c98197808504a817c8008504a817c800827530947d36af85a184e220a656525fcbb9a63b9ab3c12b0180f85bf85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000780a0f1a407dfc1a9f782001d89f617e9b3a2f295378533784fb39960dea60beea2d0a05ac3da2946554ba3d5721850f4f89ee7a0c38e4acab7130908e7904d13174388" );
+    BOOST_REQUIRE( txHash == "0xde30b1c26b89e20f6426a87b9427381f9e79e2bb80f992a6f2e1b4dccfa345de" );
+    BOOST_REQUIRE( dev::toHexPrefixed( fixture.client->transactions( 4 )[0].toBytes() ) == "0x02f8c98197808504a817c8018504a817c800827530947d36af85a184e220a656525fcbb9a63b9ab3c12b0180f85bf85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000701a005bd1eedc509a8e94cfcfc84d0b5fd53a0888a475274cbeee321047da5d139f8a00e7f0dd8b5277766d447ea51b7d8f571dc8bb57ff95c068c58f5b6fe9089dde8" );
 
     BOOST_REQUIRE( fixture.rpcClient->eth_getBalance( "0x7D36aF85A184E220A656525fcBb9A63B9ab3C12b", "latest" ) == "0x1" );
 
@@ -3235,13 +3234,15 @@ BOOST_AUTO_TEST_CASE( eip1559Transactions ) {
     BOOST_REQUIRE( result["accessList"].isArray() );
     BOOST_REQUIRE( result.isMember( "maxPriorityFeePerGas" ) && result["maxPriorityFeePerGas"].isString() );
     BOOST_REQUIRE( result.isMember( "maxFeePerGas" ) && result["maxFeePerGas"].isString() );
+    BOOST_REQUIRE( result["maxPriorityFeePerGas"] == "0x4a817c801" );
+    BOOST_REQUIRE( result["maxFeePerGas"] == "0x4a817c800" );
 
     result = fixture.rpcClient->eth_getTransactionByBlockHashAndIndex( blockHash, "0x0" );
     BOOST_REQUIRE( result["hash"].asString() == txHash );
     BOOST_REQUIRE( result["type"] == "0x2" );
     BOOST_REQUIRE( toJS( jsToInt( result["yParity"].asString() ) + 35 + 2 * fixture.client->chainParams().chainID ) == result["v"].asString() );
     BOOST_REQUIRE( result["accessList"].isArray() );
-    BOOST_REQUIRE( result["maxPriorityFeePerGas"] == "0x4a817c800" );
+    BOOST_REQUIRE( result["maxPriorityFeePerGas"] == "0x4a817c801" );
     BOOST_REQUIRE( result["maxFeePerGas"] == "0x4a817c800" );
 
     result = fixture.rpcClient->eth_getTransactionByBlockNumberAndIndex( "0x4", "0x0" );
@@ -3249,7 +3250,7 @@ BOOST_AUTO_TEST_CASE( eip1559Transactions ) {
     BOOST_REQUIRE( result["type"] == "0x2" );
     BOOST_REQUIRE( toJS( jsToInt( result["yParity"].asString() ) + 35 + 2 * fixture.client->chainParams().chainID ) == result["v"].asString() );
     BOOST_REQUIRE( result["accessList"].isArray() );
-    BOOST_REQUIRE( result["maxPriorityFeePerGas"] == "0x4a817c800" );
+    BOOST_REQUIRE( result["maxPriorityFeePerGas"] == "0x4a817c801" );
     BOOST_REQUIRE( result["maxFeePerGas"] == "0x4a817c800" );
 
     BOOST_REQUIRE_NO_THROW( fixture.rpcClient->eth_getBlockByNumber( "0x0", false ) );


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skaled/issues/1963
fixed the typo that prevented skaled to show the correct value of `maxFeePerGas` for `type2` txns

fixed unittets to handle this issue

no performance impact

before fix 
```
maxFeePerGas: 0
maxPriorityFeePerGas: 0
```

after fix 
```
maxFeePerGas: 100000
maxPriorityFeePerGas: 0
```