### PR TITLE
Bug/skaled 1951 broken all tests

### DIFF
--- a/libethcore/ChainOperationParams.cpp
+++ b/libethcore/ChainOperationParams.cpp
@@ -82,8 +82,10 @@ EVMSchedule const ChainOperationParams::makeEvmSchedule(
         result = EIP158Schedule;
     else if ( _workingBlockNumber >= EIP150ForkBlock )
         result = EIP150Schedule;
+    else if ( _workingBlockNumber >= homesteadForkBlock )
+        return HomesteadSchedule;
     else
-        result = HomesteadSchedule;
+        return FrontierSchedule;
 
     // 2 based on previous - decide by timestamp
     if ( PushZeroPatch::isEnabledWhen( _committedBlockTimestamp ) )

--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -94,6 +94,8 @@ struct EVMSchedule {
 };
 
 static const EVMSchedule DefaultSchedule = EVMSchedule();
+// Used only in GeneralStateTests --all tests
+static const EVMSchedule FrontierSchedule = EVMSchedule( false, false, 21000 );
 static const EVMSchedule HomesteadSchedule = EVMSchedule( true, true, 53000 );
 
 static const EVMSchedule EIP150Schedule = [] {
@@ -112,7 +114,7 @@ static const EVMSchedule EIP158Schedule = [] {
     EVMSchedule schedule = EIP150Schedule;
     schedule.expByteGas = 50;
     schedule.eip158Mode = true;
-    schedule.maxCodeSize = 1024 * 64;  // We are now using 64k code size limit in SKALE
+    schedule.maxCodeSize = 0x6000; // 1024 * 64;  // We are now using 64k code size limit in SKALE
     return schedule;
 }();
 

--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -114,7 +114,7 @@ static const EVMSchedule EIP158Schedule = [] {
     EVMSchedule schedule = EIP150Schedule;
     schedule.expByteGas = 50;
     schedule.eip158Mode = true;
-    schedule.maxCodeSize = 0x6000; // 1024 * 64;  // We are now using 64k code size limit in SKALE
+    schedule.maxCodeSize = 1024 * 64;  // We are now using 64k code size limit in SKALE
     return schedule;
 }();
 

--- a/libethereum/Transaction.h
+++ b/libethereum/Transaction.h
@@ -127,7 +127,7 @@ public:
 
     void ignoreExternalGas() {
         m_externalGasIsChecked = true;
-        m_externalGas = 0;
+        m_externalGas.reset();
     }
 
 private:

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -940,6 +940,10 @@ void checkBlocks(
             _testname + "transaction data in rlp and in field do not match" );
         BOOST_CHECK_MESSAGE( trField.gas() == trRlp.gas(),
             _testname + "transaction gasLimit in rlp and in field do not match" );
+        if( trField.gasPrice() != trRlp.gasPrice() ){
+            cout << trField.gasPrice() << "!=" << trRlp.gasPrice() << endl;
+            throw -1;
+        }
         BOOST_CHECK_MESSAGE( trField.gasPrice() == trRlp.gasPrice(),
             _testname + "transaction gasPrice in rlp and in field do not match" );
         BOOST_CHECK_MESSAGE( trField.nonce() == trRlp.nonce(),
@@ -1079,8 +1083,8 @@ BOOST_AUTO_TEST_CASE( stTransactionTest,
                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
 BOOST_AUTO_TEST_CASE( stTransitionTest,
                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
-BOOST_AUTO_TEST_CASE( stWalletTest,
-                         *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
+// BOOST_AUTO_TEST_CASE( stWalletTest,
+//                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
 
 // Homestead Tests
 BOOST_AUTO_TEST_CASE( stCallDelegateCodesCallCodeHomestead,

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -1111,10 +1111,6 @@ BOOST_AUTO_TEST_CASE( stZeroCallsTest,
                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
 BOOST_AUTO_TEST_CASE( stZeroCallsRevert,
                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
-// BOOST_AUTO_TEST_CASE( stCodeSizeLimit,
-//                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
-// BOOST_AUTO_TEST_CASE( stCreateTest,
-//                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
 BOOST_AUTO_TEST_CASE( stRevertTest,
                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
 

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -940,10 +940,6 @@ void checkBlocks(
             _testname + "transaction data in rlp and in field do not match" );
         BOOST_CHECK_MESSAGE( trField.gas() == trRlp.gas(),
             _testname + "transaction gasLimit in rlp and in field do not match" );
-        if( trField.gasPrice() != trRlp.gasPrice() ){
-            cout << trField.gasPrice() << "!=" << trRlp.gasPrice() << endl;
-            throw -1;
-        }
         BOOST_CHECK_MESSAGE( trField.gasPrice() == trRlp.gasPrice(),
             _testname + "transaction gasPrice in rlp and in field do not match" );
         BOOST_CHECK_MESSAGE( trField.nonce() == trRlp.nonce(),
@@ -1083,8 +1079,8 @@ BOOST_AUTO_TEST_CASE( stTransactionTest,
                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
 BOOST_AUTO_TEST_CASE( stTransitionTest,
                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
-// BOOST_AUTO_TEST_CASE( stWalletTest,
-//                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
+BOOST_AUTO_TEST_CASE( stWalletTest,
+                         *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
 
 // Homestead Tests
 BOOST_AUTO_TEST_CASE( stCallDelegateCodesCallCodeHomestead,
@@ -1115,10 +1111,10 @@ BOOST_AUTO_TEST_CASE( stZeroCallsTest,
                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
 BOOST_AUTO_TEST_CASE( stZeroCallsRevert,
                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
-BOOST_AUTO_TEST_CASE( stCodeSizeLimit,
-                         *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
-BOOST_AUTO_TEST_CASE( stCreateTest,
-                         *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
+// BOOST_AUTO_TEST_CASE( stCodeSizeLimit,
+//                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
+// BOOST_AUTO_TEST_CASE( stCreateTest,
+//                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
 BOOST_AUTO_TEST_CASE( stRevertTest,
                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {}
 

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -418,6 +418,7 @@ void ImportTest::importTransaction( json_spirit::mObject const& _o, eth::Transac
                        toInt( _o.at( "gasLimit" ) ), Address( _o.at( "to" ).get_str() ),
                        importData( _o ), toInt( _o.at( "nonce" ) ),
                        Secret( _o.at( "secretKey" ).get_str() ) );
+        o_tr.ignoreExternalGas();
     } else {
         requireJsonFields( _o, "transaction",
             {{"data", jsonVType::str_type}, {"gasLimit", jsonVType::str_type},
@@ -429,6 +430,7 @@ void ImportTest::importTransaction( json_spirit::mObject const& _o, eth::Transac
         RLP transactionRLP( transactionRLPStream.out() );
         try {
             o_tr = Transaction( transactionRLP.data(), CheckTransaction::Everything );
+            o_tr.ignoreExternalGas();
         } catch ( InvalidSignature const& ) {
             // create unsigned transaction
             o_tr = _o.at( "to" ).get_str().empty() ?
@@ -438,6 +440,7 @@ void ImportTest::importTransaction( json_spirit::mObject const& _o, eth::Transac
                        Transaction( toInt( _o.at( "value" ) ), toInt( _o.at( "gasPrice" ) ),
                            toInt( _o.at( "gasLimit" ) ), Address( _o.at( "to" ).get_str() ),
                            importData( _o ), toInt( _o.at( "nonce" ) ) );
+            o_tr.ignoreExternalGas();
         } catch ( Exception& _e ) {
             cnote << "invalid transaction" << boost::diagnostic_information( _e );
         }

--- a/test/tools/libtestutils/Common.cpp
+++ b/test/tools/libtestutils/Common.cpp
@@ -39,7 +39,7 @@ boost::filesystem::path dev::test::getTestPath() {
         return Options::get().testpath;
 
     string testPath;
-    const char* ptestPath = getenv( "ETHEREUM_TEST_PATH" );
+    static const char* ptestPath = getenv( "ETHEREUM_TEST_PATH" );
 
     if ( ptestPath == nullptr ) {
         clog( VerbosityDebug, "test" )

--- a/test/unittests/libdevcore/CommonJS.cpp
+++ b/test/unittests/libdevcore/CommonJS.cpp
@@ -105,26 +105,26 @@ BOOST_AUTO_TEST_CASE( test_jsToFixed, *boost::unit_test::precondition( dev::test
                           "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" ) );
     h256 b( "0x000000000000000000000000000000000000000000000000000000740c54b42f" );
     BOOST_CHECK( b == jsToFixed< 32 >( "498423084079" ) );
-    BOOST_CHECK( h256() == jsToFixed< 32 >( "NotAHexadecimalOrDecimal" ) );
+    BOOST_CHECK_THROW( jsToFixed< 32 >( "NotAHexadecimalOrDecimal" ), std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE( test_jsToInt, *boost::unit_test::precondition( dev::test::run_not_express ) ) {
     BOOST_CHECK( 43832124 == jsToInt( "43832124" ) );
     BOOST_CHECK( 1342356623 == jsToInt( "0x5002bc8f" ) );
     BOOST_CHECK( 3483942 == jsToInt( "015224446" ) );
-    BOOST_CHECK( 0 == jsToInt( "NotAHexadecimalOrDecimal" ) );
+    BOOST_CHECK_THROW( jsToInt( "NotAHexadecimalOrDecimal" ), std::invalid_argument );
 
     BOOST_CHECK( u256( "983298932490823474234" ) == jsToInt< 32 >( "983298932490823474234" ) );
     BOOST_CHECK( u256( "983298932490823474234" ) == jsToInt< 32 >( "0x354e03915c00571c3a" ) );
-    BOOST_CHECK( u256() == jsToInt< 32 >( "NotAHexadecimalOrDecimal" ) );
+    BOOST_CHECK_THROW( jsToInt< 32 >( "NotAHexadecimalOrDecimal" ), std::invalid_argument );
     BOOST_CHECK( u128( "228273101986715476958866839113050921216" ) ==
                  jsToInt< 16 >( "0xabbbccddeeff11223344556677889900" ) );
-    BOOST_CHECK( u128() == jsToInt< 16 >( "NotAHexadecimalOrDecimal" ) );
+    BOOST_CHECK_THROW( jsToInt< 16 >( "NotAHexadecimalOrDecimal" ), std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE( test_jsToU256, *boost::unit_test::precondition( dev::test::run_not_express ) ) {
     BOOST_CHECK( u256( "983298932490823474234" ) == jsToU256( "983298932490823474234" ) );
-    BOOST_CHECK( u256() == jsToU256( "NotAHexadecimalOrDecimal" ) );
+    BOOST_CHECK_THROW( jsToU256( "NotAHexadecimalOrDecimal" ), std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Summary: all functionality is fine, minor problems were only in tests.

Changes:
 1. Use `ignoreExternalGas()` in several places in tests.
 2. Get back `Frontier` fork (used in some tests).
 3. Disabled `stCodeSizeLimit` and `stCreateTest` in `BCGeneralStateTests` because they require `maxCodeSize` 0x6000 (and we have 64k).
 4. Fixed CommonJSTests

See also https://github.com/skalenetwork/skaled/issues/1998