### PR TITLE
SKALED-1900 release build with separate debug info

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -83,7 +83,7 @@
         for C in $(docker ps -aq); do docker logs $C>$C.log; done || true
       if: ${{ always() }}
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: ${{ always() }}
       continue-on-error: true
       with:

--- a/.github/workflows/setup-build-publish.yml
+++ b/.github/workflows/setup-build-publish.yml
@@ -161,7 +161,7 @@ jobs:
           bash ./scripts/build_and_publish.sh
   
       - name: Upload skaled binary as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: skaled-${{ inputs.node_type }}


### PR DESCRIPTION
1. All dependencies, are built with `-O3` and without `-g`.
2. `skaled` is built with `-O3` but WITH `-g`.
3. `-rdynamic` removed.
4. `skaled` binary is stripped, but it's copy wit debug info is kept.

CUSTOM BUILD Now contains option to build maximally optimized "Release" configuration

Consequences:
 1. Stack trace printed by skaled on crash will not contain any function names.
 2. gdb will be able to use `skaled-debug` file to load debug info for original skaled
 3. `addr2line` will be able to convert addresses from skaled's printed stack trace into source code locations using `skaled-debug` binary

Testing:
1
```
objdump -h skaled | grep debug
nm -a skaled
```
2 Execute `strip` command on `skaled` and see that it's size didn't change
3 `ojdump -h <file> | grep debug` on all project libraries shows no result too.

`skaled` binary size `29575576`

UPDATE This is second attempt of this PR. It fixes dependency from shared library libuv.so