### PR TITLE
Enabling state root check for sync/indexer/archive nodes

### DIFF
--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -601,8 +601,7 @@ void SkaleHost::createBlock( const ConsensusExtFace::transactions_vector& _appro
                              << stCurrent.hex();
 
         // FATAL if mismatch in non-default
-        if ( _winningNodeIndex != 0 && dev::h256::Arith( stCurrent ) != _stateRoot &&
-             !this->m_client.chainParams().nodeInfo.syncNode ) {
+        if ( _winningNodeIndex != 0 && dev::h256::Arith( stCurrent ) != _stateRoot ) {
             LOG( m_errorLogger ) << "FATAL STATE ROOT MISMATCH ERROR: current state root "
                                  << dev::h256::Arith( stCurrent ).str()
                                  << " is not equal to arrived state root " << _stateRoot.str()


### PR DESCRIPTION
## Description

This PR enables state root check for sync, indexer and archive nodes. If a state root discrepancy is detected, the node will stop and exit with code 200.

## Tests

Tested on the devnet:
1. Create Schain with indexer node
2. Wait for 3 snapshots
3. Modify /var/lib/skale/schains/[CHAIN_NAME]/snapshots/[CURRENT_SNAPSHOT_BN]/snapshot_hash.txt
4. Check that indexer node container stopped with exit code 200 and data dir is intact

Same procedure for the archive node

## Performance Impact

No performance impact
