### PR TITLE
Bug/is 968 functional tests

### DIFF
--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -165,10 +165,6 @@ void SnapshotManager::restoreSnapshot( unsigned _blockNumber ) {
     if ( _blockNumber > 0 )
         volumes = allVolumes;
 #endif
-    //    if ( chainParams.nodeInfo.archiveMode && _blockNumber == 0 )
-    //        volumes = coreVolumes;
-    //    else
-    //        volumes = allVolumes;
 
     int dummy_counter = 0;
     for ( const string& vol : volumes ) {
@@ -769,10 +765,6 @@ void SnapshotManager::computeSnapshotHash( unsigned _blockNumber, bool is_checki
     if ( _blockNumber > 0 )
         volumes = allVolumes;
 #endif
-    //    if ( chainParams.nodeInfo.archiveMode && _blockNumber == 0 )
-    //        volumes = coreVolumes;
-    //    else
-    //        volumes = allVolumes;
 
     for ( const auto& volume : volumes ) {
         int res = btrfs.subvolume.property_set(

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -184,6 +184,19 @@ void SnapshotManager::restoreSnapshot( unsigned _blockNumber ) {
             batched_io::test_crash_before_commit( "SnapshotManager::doSnapshot" );
 
     }  // for
+
+    if ( _blockNumber > 0 ) {
+#ifdef HISTORIC_STATE
+        for ( const string& vol : allVolumes ) {
+            // continue if already present
+            if ( fs::exists( dataDir / vol ) && 0 == btrfs.present( ( dataDir / vol ).c_str() ) )
+                continue;
+
+            // create if not created yet ( only makes sense for historic nodes and 0 block number )
+            btrfs.subvolume.create( ( dataDir / vol ).c_str() );
+        }  // for
+#endif
+    }
 }
 
 // exceptions:

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -185,7 +185,7 @@ void SnapshotManager::restoreSnapshot( unsigned _blockNumber ) {
 
     }  // for
 
-    if ( _blockNumber > 0 ) {
+    if ( _blockNumber == 0 ) {
 #ifdef HISTORIC_STATE
         for ( const string& vol : allVolumes ) {
             // continue if already present

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -160,11 +160,15 @@ void SnapshotManager::restoreSnapshot( unsigned _blockNumber ) {
 
     UnsafeRegion::lock ur_lock;
 
-    std::vector< std::string > volumes;
-    if ( chainParams.nodeInfo.archiveMode && _blockNumber == 0 )
-        volumes = coreVolumes;
-    else
+    std::vector< std::string > volumes = coreVolumes;
+#ifdef HISTORIC_STATE
+    if ( _blockNumber > 0 )
         volumes = allVolumes;
+#endif
+    //    if ( chainParams.nodeInfo.archiveMode && _blockNumber == 0 )
+    //        volumes = coreVolumes;
+    //    else
+    //        volumes = allVolumes;
 
     int dummy_counter = 0;
     for ( const string& vol : volumes ) {
@@ -747,11 +751,15 @@ void SnapshotManager::computeSnapshotHash( unsigned _blockNumber, bool is_checki
 
     int dummy_counter = 0;
 
-    std::vector< std::string > volumes;
-    if ( chainParams.nodeInfo.archiveMode && _blockNumber == 0 )
-        volumes = coreVolumes;
-    else
+    std::vector< std::string > volumes = coreVolumes;
+#ifdef HISTORIC_STATE
+    if ( _blockNumber > 0 )
         volumes = allVolumes;
+#endif
+    //    if ( chainParams.nodeInfo.archiveMode && _blockNumber == 0 )
+    //        volumes = coreVolumes;
+    //    else
+    //        volumes = allVolumes;
 
     for ( const auto& volume : volumes ) {
         int res = btrfs.subvolume.property_set(

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -582,8 +582,7 @@ std::string Skale::oracle_checkResult( std::string& receipt ) {
 namespace snapshot {
 
 bool download( const std::string& strURLWeb3, unsigned& block_number, const fs::path& saveTo,
-    fn_progress_t onProgress, bool isBinaryDownload, std::string* pStrErrorDescription,
-    bool forArchiveNode ) {
+    fn_progress_t onProgress, bool isBinaryDownload, std::string* pStrErrorDescription ) {
     if ( pStrErrorDescription )
         pStrErrorDescription->clear();
     std::ofstream f;
@@ -636,7 +635,6 @@ bool download( const std::string& strURLWeb3, unsigned& block_number, const fs::
         joIn["method"] = "skale_getSnapshot";
         nlohmann::json joParams = nlohmann::json::object();
         joParams["blockNumber"] = block_number;
-        joParams["forArchiveNode"] = forArchiveNode;
         joIn["params"] = joParams;
         skutils::rest::data_t d = cli.call( joIn );
         if ( !d.err_s_.empty() ) {

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -66,6 +66,7 @@ std::string exceptionToErrorMessage();
 volatile bool Skale::g_bShutdownViaWeb3Enabled = false;
 volatile bool Skale::g_bNodeInstanceShouldShutdown = false;
 Skale::list_fn_on_shutdown_t Skale::g_list_fn_on_shutdown;
+const uint64_t Skale::SNAPSHOT_DOWNLOAD_MONITOR_THREAD_SLEEP_MS = 10;
 
 Skale::Skale( Client& _client, std::shared_ptr< SharedSpace > _sharedSpace )
     : m_client( _client ), m_shared_space( _sharedSpace ) {}
@@ -211,7 +212,7 @@ nlohmann::json Skale::impl_skale_getSnapshot( const nlohmann::json& joRequest, C
                         m_client.chainParams().nodeInfo.archiveMode ) ) {
                 if ( threadExitRequested )
                     break;
-                sleep( 10 );
+                sleep( SNAPSHOT_DOWNLOAD_MONITOR_THREAD_SLEEP_MS );
             }
 
             clog( VerbosityInfo, "skale_downloadSnapshotFragmentMonitorThread" )

--- a/libweb3jsonrpc/Skale.h
+++ b/libweb3jsonrpc/Skale.h
@@ -84,6 +84,10 @@ public:
     typedef std::function< void() > fn_on_shutdown_t;
     static void onShutdownInvoke( fn_on_shutdown_t fn );
 
+    static uint64_t snapshotDownloadFragmentMonitorThreadTimeout() {
+        return SNAPSHOT_DOWNLOAD_MONITOR_THREAD_SLEEP_MS;
+    }
+
 public:
     nlohmann::json impl_skale_getSnapshot(
         const nlohmann::json& joRequest, dev::eth::Client& client );
@@ -98,6 +102,8 @@ private:
     static volatile bool g_bNodeInstanceShouldShutdown;
     typedef std::list< fn_on_shutdown_t > list_fn_on_shutdown_t;
     static list_fn_on_shutdown_t g_list_fn_on_shutdown;
+
+    static const uint64_t SNAPSHOT_DOWNLOAD_MONITOR_THREAD_SLEEP_MS;
 
     dev::eth::Client& m_client;
     std::shared_ptr< SharedSpace > m_shared_space;

--- a/libweb3jsonrpc/Skale.h
+++ b/libweb3jsonrpc/Skale.h
@@ -118,7 +118,7 @@ typedef std::function< bool( size_t idxChunck, size_t cntChunks ) > fn_progress_
 
 extern bool download( const std::string& strURLWeb3, unsigned& block_number, const fs::path& saveTo,
     fn_progress_t onProgress, bool isBinaryDownload = true,
-    std::string* pStrErrorDescription = nullptr, bool forArchiveNode = false );
+    std::string* pStrErrorDescription = nullptr );
 
 };  // namespace snapshot
 

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -251,8 +251,7 @@ void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >
     const std::string& strURLWeb3, const ChainParams& chainParams ) {
     fs::path saveTo;
     try {
-        clog( VerbosityInfo, "downloadSnapshot" )
-            << cc::normal( "Will download snapshot from " ) << cc::u( strURLWeb3 ) << std::endl;
+        clog( VerbosityInfo, "downloadSnapshot" ) << "Will download snapshot from " << strURLWeb3;
 
         try {
             bool isBinaryDownload = true;
@@ -262,8 +261,7 @@ void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >
                 strURLWeb3, block_number, saveTo,
                 [&]( size_t idxChunck, size_t cntChunks ) -> bool {
                     clog( VerbosityInfo, "downloadSnapshot" )
-                        << cc::normal( "... download progress ... " ) << cc::size10( idxChunck )
-                        << cc::normal( " of " ) << cc::size10( cntChunks ) << "\r";
+                        << "... download progress ... " << idxChunck << " of " << cntChunks << "\r";
                     return true;  // continue download
                 },
                 isBinaryDownload, &strErrorDescription );
@@ -281,14 +279,12 @@ void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >
             std::throw_with_nested( std::runtime_error( "Exception while downloading snapshot" ) );
         }
         clog( VerbosityInfo, "downloadSnapshot" )
-            << cc::success( "Snapshot download success for block " )
-            << cc::u( to_string( block_number ) ) << std::endl;
+            << "Snapshot download success for block " << to_string( block_number );
         try {
             snapshotManager->importDiff( block_number );
         } catch ( ... ) {
-            std::throw_with_nested( std::runtime_error(
-                cc::fatal( "FATAL:" ) + " " +
-                cc::error( "Exception while importing downloaded snapshot: " ) ) );
+            std::throw_with_nested(
+                std::runtime_error( "FATAL: Exception while importing downloaded snapshot: " ) );
         }
 
         /// HACK refactor this piece of code! ///
@@ -304,7 +300,7 @@ void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >
             }
             if ( db_path.empty() ) {
                 clog( VerbosityError, "downloadSnapshot" )
-                    << cc::fatal( "Snapshot downloaded without " + prefix + " db" ) << std::endl;
+                    << "Snapshot downloaded without " + prefix + " db";
                 return;
             }
 
@@ -315,8 +311,7 @@ void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >
 
     } catch ( ... ) {
         std::throw_with_nested(
-            std::runtime_error( cc::fatal( "FATAL:" ) + " " +
-                                cc::error( "Exception while processing downloaded snapshot: " ) ) );
+            std::runtime_error( "FATAL: Exception while processing downloaded snapshot: " ) );
     }
     if ( !saveTo.empty() )
         fs::remove( saveTo );

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1652,9 +1652,9 @@ int main( int argc, char** argv ) try {
                 // sleep before send skale_getSnapshot again - will receive error
                 clog( VerbosityInfo, "main" )
                     << std::string( "Will sleep for " )
-                    << chainParams.sChain.snapshotDownloadInactiveTimeout
+                    << chainParams.sChain.snapshotDownloadInactiveTimeout + 10
                     << std::string( " seconds before downloading 0 snapshot" );
-                sleep( chainParams.sChain.snapshotDownloadInactiveTimeout );
+                sleep( chainParams.sChain.snapshotDownloadInactiveTimeout + 10 );
 
                 downloadAndProccessSnapshot(
                     snapshotManager, chainParams, urlToDownloadSnapshotFrom, false );

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -266,7 +266,7 @@ void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >
                         << cc::normal( " of " ) << cc::size10( cntChunks ) << "\r";
                     return true;  // continue download
                 },
-                isBinaryDownload, &strErrorDescription, chainParams.nodeInfo.archiveMode );
+                isBinaryDownload, &strErrorDescription );
             std::cout << "                                                  \r";  // clear
                                                                                   // progress
                                                                                   // line

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1652,9 +1652,11 @@ int main( int argc, char** argv ) try {
                 // sleep before send skale_getSnapshot again - will receive error
                 clog( VerbosityInfo, "main" )
                     << std::string( "Will sleep for " )
-                    << chainParams.sChain.snapshotDownloadInactiveTimeout + 10
+                    << chainParams.sChain.snapshotDownloadInactiveTimeout +
+                           dev::rpc::Skale::snapshotDownloadFragmentMonitorThreadTimeout()
                     << std::string( " seconds before downloading 0 snapshot" );
-                sleep( chainParams.sChain.snapshotDownloadInactiveTimeout + 10 );
+                sleep( chainParams.sChain.snapshotDownloadInactiveTimeout +
+                       dev::rpc::Skale::snapshotDownloadFragmentMonitorThreadTimeout() );
 
                 downloadAndProccessSnapshot(
                     snapshotManager, chainParams, urlToDownloadSnapshotFrom, false );


### PR DESCRIPTION
fixed https://github.com/skalenetwork/internal-support/issues/968

fixed the functional tests for historic build : skaled uses `#ifdef` instead of `config.archiveMode` to identify archive and historic nodes

verified with functional tests|
verified on a devnet

no performance impact