### PR TITLE
Bug/is 1083 catchup snapshot priority archive

### DIFF
--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1606,25 +1606,8 @@ int main( int argc, char** argv ) try {
         std::vector< std::string > coreVolumes = { BlockChain::getChainDirName( chainParams ),
             "filestorage", "prices_" + chainParams.nodeInfo.id.str() + ".db",
             "blocks_" + chainParams.nodeInfo.id.str() + ".db" };
-        std::vector< std::string > archiveVolumes = {};
-        if ( chainParams.nodeInfo.archiveMode ) {
-#ifdef HISTORIC_STATE
-            archiveVolumes.insert( archiveVolumes.end(), { "historic_roots", "historic_state" } );
-#endif
-        }
         snapshotManager.reset( new SnapshotManager(
             chainParams, getDataDir(), sharedSpace ? sharedSpace->getPath() : "" ) );
-    }
-
-    bool downloadGenesisForSyncNode = false;
-    if ( chainParams.nodeInfo.syncNode ) {
-        auto bc = BlockChain( chainParams, getDataDir() );
-        if ( bc.number() == 0 ) {
-            downloadSnapshotFlag = true;
-            if ( chainParams.nodeInfo.syncFromCatchup ) {
-                downloadGenesisForSyncNode = true;
-            }
-        }
     }
 
     if ( downloadSnapshotFlag ) {
@@ -1637,18 +1620,8 @@ int main( int argc, char** argv ) try {
             sharedSpace_lock.reset( new std::lock_guard< SharedSpace >( *sharedSpace ) );
 
         try {
-            if ( !downloadGenesisForSyncNode )
-                downloadAndProccessSnapshot(
-                    snapshotManager, chainParams, urlToDownloadSnapshotFrom, true );
-            else {
-                try {
-                    downloadAndProccessSnapshot(
-                        snapshotManager, chainParams, urlToDownloadSnapshotFrom, false );
-                    snapshotManager->restoreSnapshot( 0 );
-                } catch ( SnapshotManager::SnapshotAbsent& ) {
-                    clog( VerbosityWarning, "main" ) << "Snapshot for 0 block is not found";
-                }
-            }
+            downloadAndProccessSnapshot(
+                snapshotManager, chainParams, urlToDownloadSnapshotFrom, true );
 
             // if we dont have 0 snapshot yet
             try {
@@ -1671,6 +1644,26 @@ int main( int argc, char** argv ) try {
         }
 
     }  // if --download-snapshot
+
+    // download 0 snapshot if needed
+    if ( chainParams.nodeInfo.syncNode ) {
+        auto bc = BlockChain( chainParams, getDataDir() );
+        if ( bc.number() == 0 ) {
+            if ( chainParams.nodeInfo.syncFromCatchup && !downloadSnapshotFlag ) {
+                statusAndControl->setExitState( StatusAndControl::StartAgain, true );
+                statusAndControl->setExitState( StatusAndControl::StartFromSnapshot, true );
+                statusAndControl->setSubsystemRunning( StatusAndControl::SnapshotDownloader, true );
+
+                try {
+                    downloadAndProccessSnapshot(
+                        snapshotManager, chainParams, urlToDownloadSnapshotFrom, false );
+                    snapshotManager->restoreSnapshot( 0 );
+                } catch ( SnapshotManager::SnapshotAbsent& ) {
+                    clog( VerbosityWarning, "main" ) << "Snapshot for 0 block is not found";
+                }
+            }
+        }
+    }
 
     statusAndControl->setSubsystemRunning( StatusAndControl::SnapshotDownloader, false );
 

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1592,6 +1592,7 @@ int main( int argc, char** argv ) try {
 
     std::string urlToDownloadSnapshotFrom = "";
     if ( vm.count( "no-snapshot-majority" ) ) {
+        downloadSnapshotFlag = true;
         urlToDownloadSnapshotFrom = vm["no-snapshot-majority"].as< string >();
         clog( VerbosityInfo, "main" )
             << "Manually set url to download snapshot from: " << urlToDownloadSnapshotFrom;


### PR DESCRIPTION
fixes https://github.com/skalenetwork/internal-support/issues/1083. 

reworked `syncFromCatchup` flag - it  doesn't enable `downloadSnapshotFlag` anymore 

tested with functional tests and manually on the devnet

no performance impact