### PR TITLE
Revert keepalive timeouts

### DIFF
--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -116,11 +116,11 @@ void* ZmqBroadcaster::client_socket() const {
         int value = 1;
 
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE, &value, sizeof( value ) );
-        value = 300;
+        value = 275;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_IDLE, &value, sizeof( value ) );
         value = 10;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_CNT, &value, sizeof( value ) );
-        value = 300;
+        value = 275;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_INTVL, &value, sizeof( value ) );
 
         value = 16;

--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -116,11 +116,11 @@ void* ZmqBroadcaster::client_socket() const {
         int value = 1;
 
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE, &value, sizeof( value ) );
-        value = 15;
+        value = 300;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_IDLE, &value, sizeof( value ) );
         value = 10;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_CNT, &value, sizeof( value ) );
-        value = 15;
+        value = 300;
         zmq_setsockopt( m_zmq_client_socket, ZMQ_TCP_KEEPALIVE_INTVL, &value, sizeof( value ) );
 
         value = 16;


### PR DESCRIPTION
## Description

This PR sets keepalive values in broadcaster to 275s, to being able broadcast transactions using Azure instances

## Tests

Tested on the devnet, using jmeter

## Performance Impact

Performance increased: TPS +20% comparing with 3.20.0 build
