### PR TITLE
Feature/2004 Add debug api for patchTimestamps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: Cache apt packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4.2.0
         with:
           path: |
             /var/cache/apt/archives

--- a/docs/json-rpc-interface.md
+++ b/docs/json-rpc-interface.md
@@ -8,6 +8,8 @@ This doc does NOT describe all possible erroneous situations.
 
 Parameters marked as `OPTIONAL` are optional, otherwise they are required!
 
+---
+
 ## `web3_*` Methods
 
 ### `web3_clientVersion`
@@ -37,6 +39,9 @@ Get `sha3` (`keccak256`) hash of input data
 1. Input data represented as a "0x"-prefixed hex `String`
 #### Return format
 Output data represented as a "0x"-prefixed hex `String` (32 bytes)
+
+
+---
 
 ## `net_*` Methods
 
@@ -78,6 +83,8 @@ Returns 0
 None
 #### Return format
 `String` value "0x0"
+
+---
 
 ## `eth_*` Methods
 
@@ -1007,36 +1014,56 @@ WS(S): unsubscribe from events/transactions/blocks/stats (see `eth_subscribe`)
 #### Return format
 None
 
+
+---
+
 ## `personal_*` Methods
 Not supported
+
+---
 
 ## `db_*` Methods
 Not supported
 
+---
+
 ## `shh_*` Methods
 Not supported
 
+---
+
 ## `debug_*` Methods
-### debug_accountRangeAt
+### `debug_accountRangeAt`
 #### Description
 Not supported, always throws exception
 
-### debug_traceTransaction
-### debug_storageRangeAt
+### `debug_traceTransaction`
+### `debug_storageRangeAt`
 #### Description
 Not supported, always throws exception
 
-### debug_preimage
+### `debug_preimage`
 #### Description
 Not supported, always throws exception
 
-### debug_traceBlockByNumber
-### debug_traceBlockByHash
-### debug_traceCall
+### `debug_traceBlockByNumber`
+### `debug_traceBlockByHash`
+### `debug_traceCall`
+
+### `debug_getPatchTimestamps`
+
+#### Description
+Gets timestamps for all patches defined.
+
+#### Parameters
+None
+
+#### Return format
+Returns the timestamp of each defined patch. Returns `0` for any undefined patch timestamp.
 
 
 ## Non-standard Methods
-### oracle_submitRequest
-### oracle_checkResult
+### `oracle_submitRequest`
+### `oracle_checkResult`
 
 

--- a/libethereum/SchainPatch.cpp
+++ b/libethereum/SchainPatch.cpp
@@ -26,8 +26,6 @@ SchainPatchEnum getEnumForPatchName( const std::string& _patchName ) {
         return SchainPatchEnum::StorageDestructionPatch;
     else if ( _patchName == "SkipInvalidTransactionsPatch" )
         return SchainPatchEnum::SkipInvalidTransactionsPatch;
-    else if ( _patchName == "SelfdestructStorageLimitPatch" )
-        return SchainPatchEnum::SelfdestructStorageLimitPatch;
     else if ( _patchName == "VerifyDaSigsPatch" )
         return SchainPatchEnum::VerifyDaSigsPatch;
     else if ( _patchName == "FastConsensusPatch" )
@@ -64,8 +62,6 @@ std::string getPatchNameForEnum( SchainPatchEnum _enumValue ) {
         return "StorageDestructionPatch";
     case SchainPatchEnum::SkipInvalidTransactionsPatch:
         return "SkipInvalidTransactionsPatch";
-    case SchainPatchEnum::SelfdestructStorageLimitPatch:
-        return "SelfdestructStorageLimitPatch";
     case SchainPatchEnum::VerifyDaSigsPatch:
         return "VerifyDaSigsPatch";
     case SchainPatchEnum::FastConsensusPatch:

--- a/libethereum/SchainPatch.cpp
+++ b/libethereum/SchainPatch.cpp
@@ -26,6 +26,8 @@ SchainPatchEnum getEnumForPatchName( const std::string& _patchName ) {
         return SchainPatchEnum::StorageDestructionPatch;
     else if ( _patchName == "SkipInvalidTransactionsPatch" )
         return SchainPatchEnum::SkipInvalidTransactionsPatch;
+    else if ( _patchName == "SelfdestructStorageLimitPatch" )
+        return SchainPatchEnum::SelfdestructStorageLimitPatch;
     else if ( _patchName == "VerifyDaSigsPatch" )
         return SchainPatchEnum::VerifyDaSigsPatch;
     else if ( _patchName == "FastConsensusPatch" )

--- a/libethereum/SchainPatch.h
+++ b/libethereum/SchainPatch.h
@@ -128,11 +128,6 @@ DEFINE_AMNESIC_PATCH( StorageDestructionPatch );
 /*
  * Enable restriction on contract storage size, when it's doing selfdestruct
  */
-DEFINE_SIMPLE_PATCH( SelfdestructStorageLimitPatch );
-
-/*
- * Enable restriction on contract storage size, when it's doing selfdestruct
- */
 DEFINE_SIMPLE_PATCH( EIP1559TransactionsPatch );
 
 /*

--- a/libethereum/SchainPatchEnum.h
+++ b/libethereum/SchainPatchEnum.h
@@ -14,7 +14,6 @@ enum class SchainPatchEnum {
     ContractStoragePatch,
     StorageDestructionPatch,
     SkipInvalidTransactionsPatch,
-    SelfdestructStorageLimitPatch,
     VerifyDaSigsPatch,
     FastConsensusPatch,
     EIP1559TransactionsPatch,

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -117,3 +117,18 @@ Json::Value Debug::debug_getFutureTransactions() {
         t.removeMember( "data" );
     return res;
 }
+
+Json::Value Debug::debug_getPatchTimestamps() {
+    Json::Value jsonResponse;
+    ChainParams chainParams = m_eth.chainParams();
+
+    size_t numberOfPatches = static_cast< size_t >( SchainPatchEnum::PatchesCount );
+    for ( size_t patch = 0; patch < numberOfPatches; patch++ ) {
+        SchainPatchEnum patchEnum = static_cast< SchainPatchEnum >( patch );
+        std::string patchName = getPatchNameForEnum( patchEnum ) + "Timestamp";
+        patchName[0] = tolower( patchName[0] );
+        jsonResponse[patchName] = chainParams.getPatchTimestamp( patchEnum );
+    }
+
+    return jsonResponse;
+}

--- a/libweb3jsonrpc/Debug.h
+++ b/libweb3jsonrpc/Debug.h
@@ -53,6 +53,8 @@ public:
 
     virtual Json::Value debug_getFutureTransactions() override;
 
+    virtual Json::Value debug_getPatchTimestamps() override;
+
 private:
     eth::Client& m_eth;
     SkaleDebugInterface* m_debugInterface = nullptr;

--- a/libweb3jsonrpc/DebugFace.h
+++ b/libweb3jsonrpc/DebugFace.h
@@ -88,6 +88,10 @@ public:
         this->bindAndAddMethod( jsonrpc::Procedure( "debug_getFutureTransactions",
                                     jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, NULL ),
             &dev::rpc::DebugFace::debug_getFutureTransactionsI );
+
+        this->bindAndAddMethod( jsonrpc::Procedure( "debug_getPatchTimestamps",
+                                    jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, NULL ),
+            &dev::rpc::DebugFace::debug_getPatchTimestampsI );
     }
     inline virtual void debug_accountRangeAtI( const Json::Value& request, Json::Value& response ) {
         response = this->debug_accountRangeAt( request[0u].asString(), request[1u].asInt(),
@@ -159,6 +163,10 @@ public:
         response = this->debug_getFutureTransactions();
     }
 
+    inline virtual void debug_getPatchTimestampsI( const Json::Value&, Json::Value& response ) {
+        response = this->debug_getPatchTimestamps();
+    }
+
     virtual Json::Value debug_accountRangeAt(
         const std::string& param1, int param2, const std::string& param3, int param4 ) = 0;
     virtual Json::Value debug_storageRangeAt( const std::string& param1, int param2,
@@ -181,6 +189,8 @@ public:
     virtual uint64_t debug_doBlocksDbCompaction() = 0;
 
     virtual Json::Value debug_getFutureTransactions() = 0;
+
+    virtual Json::Value debug_getPatchTimestamps() = 0;
 };
 
 }  // namespace rpc

--- a/test/unittests/libweb3jsonrpc/WebThreeStubClient.cpp
+++ b/test/unittests/libweb3jsonrpc/WebThreeStubClient.cpp
@@ -1402,3 +1402,13 @@ Json::Value WebThreeStubClient::debug_getFutureTransactions() {
         throw jsonrpc::JsonRpcException(
             jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString() );
 }
+
+Json::Value WebThreeStubClient::debug_getPatchTimestamps() {
+    Json::Value p;
+    Json::Value result = this->CallMethod( "debug_getPatchTimestamps", p );
+    if ( result.isObject() )
+        return result;
+    else
+        throw jsonrpc::JsonRpcException(
+            jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString() );
+}

--- a/test/unittests/libweb3jsonrpc/WebThreeStubClient.h
+++ b/test/unittests/libweb3jsonrpc/WebThreeStubClient.h
@@ -167,6 +167,7 @@ public:
     Json::Value debug_doStateDbCompaction() noexcept( false );
     Json::Value debug_doBlocksDbCompaction() noexcept( false );
     Json::Value debug_getFutureTransactions() noexcept( false );
+    Json::Value debug_getPatchTimestamps() noexcept( false );
 };
 
 #endif  // JSONRPC_CPP_STUB_WEBTHREESTUBCLIENT_H_

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -2989,6 +2989,43 @@ BOOST_AUTO_TEST_CASE( doDbCompactionDebugCall ) {
     fixture.rpcClient->debug_doBlocksDbCompaction();
 }
 
+BOOST_AUTO_TEST_CASE( debugGetPatchTimestamps ) {
+    Json::Value configJson;
+    Json::Reader().parse(c_genesisConfigString, configJson);
+
+    // indexed by enum int value
+    std::vector< size_t > patchTimestamps;
+
+    // Set custom config file & create timestamps for each patch
+    size_t numPatches = static_cast< size_t >( SchainPatchEnum::PatchesCount );
+    for (size_t patch = 0; patch < numPatches ; patch++ ) {
+        SchainPatchEnum patchEnum = static_cast< SchainPatchEnum >( patch );
+        size_t ts = patch + 1000; // just to offset from the default values (0, 1)
+        patchTimestamps.push_back(ts);
+
+        std::string patchName = getPatchNameForEnum(patchEnum) + "Timestamp";
+        patchName[0] = tolower( patchName[0] );
+        configJson["skaleConfig"]["sChain"][patchName] = ts; 
+    }
+
+    Json::FastWriter fastWriter;
+    std::string customConfigFile = fastWriter.write( configJson ); 
+
+    JsonRpcFixture fixture(customConfigFile, false, false, false, false);
+    Json::Value returnedPatchTimestamps = fixture.rpcClient->debug_getPatchTimestamps();
+
+    // compare returned timestamps to actual timestamps
+    for( size_t patchIdx = 0; patchIdx <  numPatches; patchIdx++ ) {
+        SchainPatchEnum patchEnum = static_cast< SchainPatchEnum >( patchIdx );
+
+        std::string patchName = getPatchNameForEnum(patchEnum) + "Timestamp";
+        patchName[0] = tolower( patchName[0] );
+        size_t returnedTimestamp = static_cast< size_t > (returnedPatchTimestamps[patchName].asInt()); 
+
+        BOOST_REQUIRE_EQUAL( returnedTimestamp, patchTimestamps[patchIdx]);
+    }
+}
+
 BOOST_AUTO_TEST_CASE( powTxnGasLimit ) {
     JsonRpcFixture fixture( c_genesisConfigString, false, false, true, false );
 


### PR DESCRIPTION
## Description

- Added new RPC debug function that returns all patchTimestamps
- Only callable when debug API is enabled

Example call:
```bash
curl -X POST --data '{"jsonrpc":"2.0","method":"debug_getPatchTimestamps","params":null,"id":1205}' <http_endpoint>
```

Example response:
```bash
{"id":1205,"jsonrpc":"2.0","result":{"contractStoragePatchTimestamp":1681732800,"contractStorageZeroValuePatchTimestamp":1681128000,"correctForkInPowPatchTimestamp":1710331200,"eIP1559TransactionsPatchTimestamp":1721818800,"externalGasPatchTimestamp":1727712000,"fastConsensusPatchTimestamp":1721822400,"flexibleDeploymentPatchTimestamp":1721826000,"powCheckPatchTimestamp":1702296000,"precompiledConfigPatchTimestamp":1710331200,"pushZeroPatchTimestamp":1710331200,"revertableFSPatchTimestamp":1681473600,"selfdestructStorageLimitPatchTimestamp":0,"skipInvalidTransactionsPatchTimestamp":1702382400,"storageDestructionPatchTimestamp":1702393200,"verifyBlsSyncPatchTimestamp":1721829600,"verifyDaSigsPatchTimestamp":1681300800}}
```


## Tests

- debugGetPatchTimestamps
  - Compares the output of RPC call to the timestamps defined in the config file.
  
Fixes #2004 

## Note
This pr is replicate from a closed pr that included non-signed commits: https://github.com/skalenetwork/skaled/pull/2077