### PR TITLE
#2098 fix memory leak

### DIFF
--- a/libdevcore/LevelDB.cpp
+++ b/libdevcore/LevelDB.cpp
@@ -154,6 +154,7 @@ uint64_t LevelDB::getCurrentTimeMs() {
 }
 
 LevelDB::~LevelDB() {
+    m_snapManager.closeAllOpenSnaps( m_db, m_dbReopenId );
     if ( m_db )
         m_db.reset();
     if ( m_options.filter_policy )

--- a/libdevcore/LevelDBSnapManager.cpp
+++ b/libdevcore/LevelDBSnapManager.cpp
@@ -73,6 +73,17 @@ uint64_t LevelDBSnapManager::garbageCollectUnusedOldSnaps(
     return mapSizeAfterCleanup;
 }
 
+void LevelDBSnapManager::closeAllOpenSnaps(
+    std::unique_ptr< leveldb::DB >& _db, uint64_t _dbInstanceId ) {
+    std::unique_lock< std::shared_mutex > snapLock( m_snapMutex );
+    for ( auto&& snap : oldSnaps ) {
+        LDB_CHECK( snap.second );
+        snap.second->close( _db, _dbInstanceId );
+    }
+    if ( m_lastBlockSnap )
+        m_lastBlockSnap->close( _db, _dbInstanceId );
+}
+
 
 // this will be called from EVM processing thread just after the block is processed
 void LevelDBSnapManager::addSnapForBlock(


### PR DESCRIPTION
fixes #2098 

fixed memory leak in LevelDBSnapManager - remove all LevelDB Snapshot objects before destroying a db object
no memory leak found for skaled built with -DSANITIZE=addrss option after applying the fix

tested on the devnet: load schain with transactions and eth_call, stop one container - skaled should exit gracefully and then restart