### PR TITLE
Enhancement/1978 Disable leveldb log during snapshot & add DB path to log

### DIFF
--- a/libdevcore/DBFactory.cpp
+++ b/libdevcore/DBFactory.cpp
@@ -138,10 +138,14 @@ std::unique_ptr< DatabaseFace > DBFactory::create( DatabaseKind _kind, fs::path 
 
 std::unique_ptr< DatabaseFace > DBFactory::createHistoric(
     DatabaseKind _kind, fs::path const& _path ) {
+
+    LevelDB::LevelDBOptions options;
+    LevelDB::WrapperOptions wrapperOptions;
+
     switch ( _kind ) {
     case DatabaseKind::LevelDB:
-        return std::unique_ptr< DatabaseFace >( new LevelDB( _path, LevelDB::defaultReadOptions(),
-            LevelDB::defaultWriteOptions(), LevelDB::defaultDBOptions(), s_reopenPeriodMs ) );
+        wrapperOptions.reopenPeriodMs = s_reopenPeriodMs;
+        return std::unique_ptr< DatabaseFace >( new LevelDB( _path, options, wrapperOptions ) );
         break;
     default:
         assert( false );

--- a/libdevcore/DBFactory.cpp
+++ b/libdevcore/DBFactory.cpp
@@ -138,7 +138,6 @@ std::unique_ptr< DatabaseFace > DBFactory::create( DatabaseKind _kind, fs::path 
 
 std::unique_ptr< DatabaseFace > DBFactory::createHistoric(
     DatabaseKind _kind, fs::path const& _path ) {
-
     LevelDB::LevelDBOptions options;
     LevelDB::WrapperOptions wrapperOptions;
 

--- a/libdevcore/LevelDB.cpp
+++ b/libdevcore/LevelDB.cpp
@@ -161,7 +161,7 @@ void LevelDB::openDBInstanceUnsafe( bool _enableLogger ) {
 
     if ( _enableLogger ) {
         cnote << "LEVELDB_OPENED:" << m_path.string()
-            << ":TIME_MS:" << m_lastDBOpenTimeMs - startTimeMs;
+              << ":TIME_MS:" << m_lastDBOpenTimeMs - startTimeMs;
     }
 }
 uint64_t LevelDB::getCurrentTimeMs() {

--- a/libdevcore/LevelDB.cpp
+++ b/libdevcore/LevelDB.cpp
@@ -158,8 +158,11 @@ void LevelDB::openDBInstanceUnsafe( bool _enableLogger ) {
     m_db.reset( db );
     m_lastDBOpenTimeMs = getCurrentTimeMs();
     m_dbReopenId++;
-    cnote << "LEVELDB_OPENED:" << m_path.string()
-          << ":TIME_MS:" << m_lastDBOpenTimeMs - startTimeMs;
+
+    if ( _enableLogger ) {
+        cnote << "LEVELDB_OPENED:" << m_path.string()
+            << ":TIME_MS:" << m_lastDBOpenTimeMs - startTimeMs;
+    }
 }
 uint64_t LevelDB::getCurrentTimeMs() {
     auto currentTime = std::chrono::system_clock::now().time_since_epoch();

--- a/libdevcore/LevelDB.cpp
+++ b/libdevcore/LevelDB.cpp
@@ -128,7 +128,7 @@ LevelDB::WrapperOptions LevelDB::defaultWrapperOptions() {
     return options;
 }
 
-LevelDB::LevelDB( boost::filesystem::path const& _path, LevelDBOptions _levelDBOptions, 
+LevelDB::LevelDB( boost::filesystem::path const& _path, LevelDBOptions _levelDBOptions,
     WrapperOptions _wrapperOptions )
     : m_db( nullptr ),
       m_readOptions( std::move( _levelDBOptions.readOptions ) ),
@@ -141,8 +141,8 @@ LevelDB::LevelDB( boost::filesystem::path const& _path, LevelDBOptions _levelDBO
 
 // this does not hold any locks so it needs to be called
 // either from a constructor or from a function that holds a lock on m_db
-void LevelDB::openDBInstanceUnsafe(bool _enableLogger) {
-    if (_enableLogger) {
+void LevelDB::openDBInstanceUnsafe( bool _enableLogger ) {
+    if ( _enableLogger ) {
         cnote << "Time to (re)open LevelDB at " + m_path.string();
     }
 
@@ -158,7 +158,8 @@ void LevelDB::openDBInstanceUnsafe(bool _enableLogger) {
     m_db.reset( db );
     m_lastDBOpenTimeMs = getCurrentTimeMs();
     m_dbReopenId++;
-    cnote << "LEVELDB_OPENED:" <<  m_path.string() << ":TIME_MS:" << m_lastDBOpenTimeMs - startTimeMs;
+    cnote << "LEVELDB_OPENED:" << m_path.string()
+          << ":TIME_MS:" << m_lastDBOpenTimeMs - startTimeMs;
 }
 uint64_t LevelDB::getCurrentTimeMs() {
     auto currentTime = std::chrono::system_clock::now().time_since_epoch();

--- a/libdevcore/LevelDB.cpp
+++ b/libdevcore/LevelDB.cpp
@@ -119,21 +119,33 @@ leveldb::Options LevelDB::defaultSnapshotDBOptions() {
     return options;
 }
 
-LevelDB::LevelDB( boost::filesystem::path const& _path, leveldb::ReadOptions _readOptions,
-    leveldb::WriteOptions _writeOptions, leveldb::Options _dbOptions, int64_t _reopenPeriodMs )
+LevelDB::LevelDBOptions LevelDB::defaultLevelDBOptions() {
+    LevelDBOptions options;
+    return options;
+}
+LevelDB::WrapperOptions LevelDB::defaultWrapperOptions() {
+    WrapperOptions options;
+    return options;
+}
+
+LevelDB::LevelDB( boost::filesystem::path const& _path, LevelDBOptions _levelDBOptions, 
+    WrapperOptions _wrapperOptions )
     : m_db( nullptr ),
-      m_readOptions( std::move( _readOptions ) ),
-      m_writeOptions( std::move( _writeOptions ) ),
-      m_options( std::move( _dbOptions ) ),
+      m_readOptions( std::move( _levelDBOptions.readOptions ) ),
+      m_writeOptions( std::move( _levelDBOptions.writeOptions ) ),
+      m_options( std::move( _levelDBOptions.dbOptions ) ),
       m_path( _path ),
-      m_reopenPeriodMs( _reopenPeriodMs ) {
-    openDBInstanceUnsafe();
+      m_reopenPeriodMs( _wrapperOptions.reopenPeriodMs ) {
+    openDBInstanceUnsafe( _wrapperOptions.enableLogger );
 }
 
 // this does not hold any locks so it needs to be called
 // either from a constructor or from a function that holds a lock on m_db
-void LevelDB::openDBInstanceUnsafe() {
-    cnote << "Time to (re)open LevelDB at " + m_path.string();
+void LevelDB::openDBInstanceUnsafe(bool _enableLogger) {
+    if (_enableLogger) {
+        cnote << "Time to (re)open LevelDB at " + m_path.string();
+    }
+
     auto startTimeMs = getCurrentTimeMs();
     auto db = static_cast< leveldb::DB* >( nullptr );
     auto const status = leveldb::DB::Open( m_options, m_path.string(), &db );

--- a/libdevcore/LevelDB.cpp
+++ b/libdevcore/LevelDB.cpp
@@ -158,7 +158,7 @@ void LevelDB::openDBInstanceUnsafe(bool _enableLogger) {
     m_db.reset( db );
     m_lastDBOpenTimeMs = getCurrentTimeMs();
     m_dbReopenId++;
-    cnote << "LEVELDB_OPENED:TIME_MS:" << m_lastDBOpenTimeMs - startTimeMs;
+    cnote << "LEVELDB_OPENED:" <<  m_path.string() << ":TIME_MS:" << m_lastDBOpenTimeMs - startTimeMs;
 }
 uint64_t LevelDB::getCurrentTimeMs() {
     auto currentTime = std::chrono::system_clock::now().time_since_epoch();

--- a/libdevcore/LevelDB.h
+++ b/libdevcore/LevelDB.h
@@ -63,7 +63,8 @@ public:
     };
 
     explicit LevelDB( boost::filesystem::path const& _path,
-        LevelDBOptions _levelDBOptions = defaultLevelDBOptions(), WrapperOptions _wrapperOptions = defaultWrapperOptions() );
+        LevelDBOptions _levelDBOptions = defaultLevelDBOptions(),
+        WrapperOptions _wrapperOptions = defaultWrapperOptions() );
 
     ~LevelDB();
 
@@ -165,7 +166,7 @@ private:
             m_levedlDB.m_dbMutex.unlock();
         }
     };
-    void openDBInstanceUnsafe(bool _enableLogger = true);
+    void openDBInstanceUnsafe( bool _enableLogger = true );
     void reopenDataBaseIfNeeded();
     leveldb::Status getValue( leveldb::ReadOptions _readOptions, const leveldb::Slice& _key,
         std::string& _value, const std::shared_ptr< LevelDBSnap >& _snap ) const;

--- a/libdevcore/LevelDB.h
+++ b/libdevcore/LevelDB.h
@@ -49,10 +49,21 @@ public:
     static leveldb::ReadOptions defaultSnapshotReadOptions();
     static leveldb::Options defaultSnapshotDBOptions();
 
+    /// Options regarding levelDB database
+    struct LevelDBOptions {
+        leveldb::ReadOptions readOptions = defaultReadOptions();
+        leveldb::WriteOptions writeOptions = defaultWriteOptions();
+        leveldb::Options dbOptions = defaultDBOptions();
+    };
+
+    /// Options regarding the wrapper of levelDB
+    struct WrapperOptions {
+        int64_t reopenPeriodMs = -1;
+        bool enableLogger = false;
+    };
+
     explicit LevelDB( boost::filesystem::path const& _path,
-        leveldb::ReadOptions _readOptions = defaultReadOptions(),
-        leveldb::WriteOptions _writeOptions = defaultWriteOptions(),
-        leveldb::Options _dbOptions = defaultDBOptions(), int64_t _reopenPeriodMs = -1 );
+        LevelDBOptions _levelDBOptions = defaultLevelDBOptions(), WrapperOptions _wrapperOptions = defaultWrapperOptions() );
 
     ~LevelDB();
 
@@ -154,11 +165,14 @@ private:
             m_levedlDB.m_dbMutex.unlock();
         }
     };
-    void openDBInstanceUnsafe();
+    void openDBInstanceUnsafe(bool _enableLogger = true);
     void reopenDataBaseIfNeeded();
     leveldb::Status getValue( leveldb::ReadOptions _readOptions, const leveldb::Slice& _key,
         std::string& _value, const std::shared_ptr< LevelDBSnap >& _snap ) const;
     void reopen();
+
+    static LevelDBOptions defaultLevelDBOptions();
+    static WrapperOptions defaultWrapperOptions();
 };
 
 }  // namespace dev::db

--- a/libdevcore/LevelDB.h
+++ b/libdevcore/LevelDB.h
@@ -59,7 +59,7 @@ public:
     /// Options regarding the wrapper of levelDB
     struct WrapperOptions {
         int64_t reopenPeriodMs = -1;
-        bool enableLogger = false;
+        bool enableLogger = true;
     };
 
     explicit LevelDB( boost::filesystem::path const& _path,

--- a/libdevcore/SplitDB.h
+++ b/libdevcore/SplitDB.h
@@ -69,15 +69,9 @@ public:
         leveldb::ReadOptions _readOptions = defaultReadOptions(),
         leveldb::WriteOptions _writeOptions = defaultWriteOptions(),
         leveldb::Options _dbOptions = defaultDBOptions() ) {
-        
-        LevelDB::LevelDBOptions options = {
-            _readOptions,
-            _writeOptions,
-            _dbOptions
-        };
+        LevelDB::LevelDBOptions options = { _readOptions, _writeOptions, _dbOptions };
 
-        auto leveldb =
-            std::make_shared< LevelDB >( _path, options );
+        auto leveldb = std::make_shared< LevelDB >( _path, options );
         split_db = std::make_unique< SplitDB >( leveldb );
         backend = split_db->newInterface();
     }

--- a/libdevcore/SplitDB.h
+++ b/libdevcore/SplitDB.h
@@ -69,8 +69,15 @@ public:
         leveldb::ReadOptions _readOptions = defaultReadOptions(),
         leveldb::WriteOptions _writeOptions = defaultWriteOptions(),
         leveldb::Options _dbOptions = defaultDBOptions() ) {
+        
+        LevelDB::LevelDBOptions options = {
+            _readOptions,
+            _writeOptions,
+            _dbOptions
+        };
+
         auto leveldb =
-            std::make_shared< LevelDB >( _path, _readOptions, _writeOptions, _dbOptions );
+            std::make_shared< LevelDB >( _path, options );
         split_db = std::make_unique< SplitDB >( leveldb );
         backend = split_db->newInterface();
     }

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -496,9 +496,16 @@ void SnapshotManager::computeDatabaseHash(
     bool isContinue = true;
 
     while ( isContinue ) {
-        std::unique_ptr< dev::db::LevelDB > m_db( new dev::db::LevelDB( _dbDir.string(),
-            dev::db::LevelDB::defaultSnapshotReadOptions(), dev::db::LevelDB::defaultWriteOptions(),
-            dev::db::LevelDB::defaultSnapshotDBOptions() ) );
+        dev::db::LevelDB::LevelDBOptions options = {
+            dev::db::LevelDB::defaultSnapshotReadOptions(), 
+            dev::db::LevelDB::defaultWriteOptions(),
+            dev::db::LevelDB::defaultSnapshotDBOptions()
+        };
+        dev::db::LevelDB::WrapperOptions wrapperOptions;
+        wrapperOptions.enableLogger = false;
+
+        std::unique_ptr< dev::db::LevelDB > m_db( new dev::db::LevelDB( _dbDir.string(), options, 
+        wrapperOptions) );
 
         isContinue = m_db->hashBasePartially( &dbCtx, lastHashedKey );
     }
@@ -522,9 +529,12 @@ void SnapshotManager::addLastPriceToHash( unsigned _blockNumber, secp256k1_sha25
         std::string last_price_str;
         std::string last_price_key = "1.0:" + std::to_string( _blockNumber );
         while ( it != end ) {
+            dev::db::LevelDB::LevelDBOptions options;
+            options.dbOptions = dev::db::LevelDB::defaultSnapshotDBOptions();
+
             std::unique_ptr< dev::db::LevelDB > m_db( new dev::db::LevelDB( it->path().string(),
-                dev::db::LevelDB::defaultReadOptions(), dev::db::LevelDB::defaultWriteOptions(),
-                dev::db::LevelDB::defaultSnapshotDBOptions() ) );
+                options ) );
+
             if ( m_db->exists( last_price_key ) ) {
                 last_price_str = m_db->lookup( last_price_key );
                 break;

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -496,16 +496,13 @@ void SnapshotManager::computeDatabaseHash(
     bool isContinue = true;
 
     while ( isContinue ) {
-        dev::db::LevelDB::LevelDBOptions options = {
-            dev::db::LevelDB::defaultSnapshotReadOptions(), 
-            dev::db::LevelDB::defaultWriteOptions(),
-            dev::db::LevelDB::defaultSnapshotDBOptions()
-        };
+        dev::db::LevelDB::LevelDBOptions options = { dev::db::LevelDB::defaultSnapshotReadOptions(),
+            dev::db::LevelDB::defaultWriteOptions(), dev::db::LevelDB::defaultSnapshotDBOptions() };
         dev::db::LevelDB::WrapperOptions wrapperOptions;
         wrapperOptions.enableLogger = false;
 
-        std::unique_ptr< dev::db::LevelDB > m_db( new dev::db::LevelDB( _dbDir.string(), options, 
-        wrapperOptions) );
+        std::unique_ptr< dev::db::LevelDB > m_db(
+            new dev::db::LevelDB( _dbDir.string(), options, wrapperOptions ) );
 
         isContinue = m_db->hashBasePartially( &dbCtx, lastHashedKey );
     }
@@ -532,8 +529,8 @@ void SnapshotManager::addLastPriceToHash( unsigned _blockNumber, secp256k1_sha25
             dev::db::LevelDB::LevelDBOptions options;
             options.dbOptions = dev::db::LevelDB::defaultSnapshotDBOptions();
 
-            std::unique_ptr< dev::db::LevelDB > m_db( new dev::db::LevelDB( it->path().string(),
-                options ) );
+            std::unique_ptr< dev::db::LevelDB > m_db(
+                new dev::db::LevelDB( it->path().string(), options ) );
 
             if ( m_db->exists( last_price_key ) ) {
                 last_price_str = m_db->lookup( last_price_key );

--- a/test/unittests/libweb3core/LevelDBHash.cpp
+++ b/test/unittests/libweb3core/LevelDBHash.cpp
@@ -76,9 +76,13 @@ BOOST_AUTO_TEST_CASE( hash ) {
         std::string lastHashedKey = "start";
         bool isContinue = true;
         while ( isContinue ) {
-            std::unique_ptr< dev::db::LevelDB > m_db( new dev::db::LevelDB( td.path(),
-                dev::db::LevelDB::defaultSnapshotReadOptions(), dev::db::LevelDB::defaultWriteOptions(),
-                dev::db::LevelDB::defaultSnapshotDBOptions() ) );
+            dev::db::LevelDB::LevelDBOptions options = {
+                dev::db::LevelDB::defaultSnapshotReadOptions(),
+                dev::db::LevelDB::defaultWriteOptions(),
+                dev::db::LevelDB::defaultSnapshotDBOptions()
+            };
+
+            std::unique_ptr< dev::db::LevelDB > m_db( new dev::db::LevelDB( td.path(), options) );
 
             isContinue = m_db->hashBasePartially( &dbCtx, lastHashedKey );
         }


### PR DESCRIPTION
## Description

- Added log flag to LevelDB (passed to constructor)
- Disable the flag for db snapshots to avoid cluttering the output when snapshotting
- Add db path to logger
- Small refactor on LevelDB constructor parameters
  - Pass 2 structures instead of 6 parameters

## Tests

- Tested locally - no logs during snapshot

---
Fixes #1978 #1965 
