### PR TITLE
Fix state root mismatch error on 4.0.0

### DIFF
--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -595,6 +595,9 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
          receiptsOfCommited.size() > 0 ) {
         // Saving partial receipts old way to be compatible with < 4.0 version
         m_state.safeCommitLegacyPartialTransactionReceipts( receiptsOfCommited );
+    } else {
+        // Making sure the old record was removed from the state db
+        m_state.safeRemoveLegacyPartialTransactionReceipts();
     }
 
     return make_tuple( receipts, receipts.size() - countBad );

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -483,6 +483,8 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
         m_receipts = m_state.safePartialTransactionReceipts( info().number() );
     TransactionReceipts receipts = m_receipts;
 
+    TransactionReceipts receiptsOfCommited;
+
     unsigned countBad = 0;
 
     if ( m_receipts.size() > 0 ) {
@@ -548,6 +550,8 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
             ExecutionResult res =
                 execute( _bc.lastBlockHashes(), tr, Permanence::Committed, OnOpFunc(), i );
 
+            receiptsOfCommited.push_back( m_receipts.back() );
+
             if ( !SkipInvalidTransactionsPatch::isEnabledInWorkingBlock() ||
                  res.excepted != TransactionException::WouldNotBeInBlock ) {
                 receipts.push_back( m_receipts.back() );
@@ -556,7 +560,6 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
                 if ( res.excepted == TransactionException::WouldNotBeInBlock )
                     ++countBad;
             }
-
 
         } catch ( Exception& ex ) {
             ex << errinfo_transactionIndex( i );
@@ -573,7 +576,6 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
     // we got to the end of the block so we do not need partial transaction receipts anymore
     m_state.safeRemoveAllPartialTransactionReceipts();
 
-
     // since we committed changes corresponding to a particular block
     // we need to create a new readonly snap
     LDB_CHECK( m_state.getOriginalDb() );
@@ -586,6 +588,11 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
     }
 
     LDB_CHECK( receipts.size() >= countBad );
+
+    if (!ClearPartialReceiptsPatch::isEnabledWhen( _timestamp ) && receiptsOfCommited.size() > 0) {
+        // Saving partial receipts old way to be compatible with < 4.0 version
+        m_state.safeCommitLegacyPartialTransactionReceipts( receiptsOfCommited );
+    }
 
     return make_tuple( receipts, receipts.size() - countBad );
 }

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -591,13 +591,14 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
 
     LDB_CHECK( receipts.size() >= countBad );
 
-    if ( !ClearPartialReceiptsPatch::isEnabledWhen( _timestamp ) &&
-         !receiptsOfCommited.empty() ) {
-        // Saving partial receipts old way to be compatible with < 4.0 version
-        m_state.safeCommitLegacyPartialTransactionReceipts( receiptsOfCommited );
-    } else {
+    if ( ClearPartialReceiptsPatch::isEnabledWhen( _timestamp ) ) {
         // Making sure the old record was removed from the state db
         m_state.safeRemoveLegacyPartialTransactionReceipts();
+    } else {
+        if ( !receiptsOfCommited.empty() ) {
+            // Saving partial receipts old way to be compatible with < 4.0 version
+            m_state.safeCommitLegacyPartialTransactionReceipts( receiptsOfCommited );
+        }
     }
 
     return make_tuple( receipts, receipts.size() - countBad );

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -550,7 +550,9 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
             ExecutionResult res =
                 execute( _bc.lastBlockHashes(), tr, Permanence::Committed, OnOpFunc(), i );
 
-            receiptsOfCommited.push_back( m_receipts.back() );
+            if ( m_receipts.size() > 0 ) {
+                receiptsOfCommited.push_back( m_receipts.back() );
+            }
 
             if ( !SkipInvalidTransactionsPatch::isEnabledInWorkingBlock() ||
                  res.excepted != TransactionException::WouldNotBeInBlock ) {

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -593,7 +593,12 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
 
     if ( ClearPartialReceiptsPatch::isEnabledWhen( _timestamp ) ) {
         // Making sure the old record was removed from the state db
-        m_state.safeRemoveLegacyPartialTransactionReceipts();
+        auto patchEnum = ClearPartialReceiptsPatch::getEnum();
+        auto activationTimestamp = sealEngine()->chainParams().getPatchTimestamp( patchEnum );
+        // If it is the first block after patch timestamp
+        if ( m_previousBlock.timestamp() < activationTimestamp ) {
+            m_state.safeRemoveLegacyPartialTransactionReceipts();
+        }
     } else {
         if ( !receiptsOfCommited.empty() ) {
             // Saving partial receipts old way to be compatible with < 4.0 version

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -550,7 +550,7 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
             ExecutionResult res =
                 execute( _bc.lastBlockHashes(), tr, Permanence::Committed, OnOpFunc(), i );
 
-            if ( m_receipts.size() > 0 ) {
+            if ( !m_receipts.empty() ) {
                 receiptsOfCommited.push_back( m_receipts.back() );
             }
 
@@ -592,7 +592,7 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
     LDB_CHECK( receipts.size() >= countBad );
 
     if ( !ClearPartialReceiptsPatch::isEnabledWhen( _timestamp ) &&
-         receiptsOfCommited.size() > 0 ) {
+         !receiptsOfCommited.empty() ) {
         // Saving partial receipts old way to be compatible with < 4.0 version
         m_state.safeCommitLegacyPartialTransactionReceipts( receiptsOfCommited );
     } else {

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -589,7 +589,8 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
 
     LDB_CHECK( receipts.size() >= countBad );
 
-    if (!ClearPartialReceiptsPatch::isEnabledWhen( _timestamp ) && receiptsOfCommited.size() > 0) {
+    if ( !ClearPartialReceiptsPatch::isEnabledWhen( _timestamp ) &&
+         receiptsOfCommited.size() > 0 ) {
         // Saving partial receipts old way to be compatible with < 4.0 version
         m_state.safeCommitLegacyPartialTransactionReceipts( receiptsOfCommited );
     }

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -593,10 +593,8 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
 
     if ( ClearPartialReceiptsPatch::isEnabledWhen( _timestamp ) ) {
         // Making sure the old record was removed from the state db
-        auto patchEnum = ClearPartialReceiptsPatch::getEnum();
-        auto activationTimestamp = sealEngine()->chainParams().getPatchTimestamp( patchEnum );
         // If it is the first block after patch timestamp
-        if ( m_previousBlock.timestamp() < activationTimestamp ) {
+        if ( !ClearPartialReceiptsPatch::isEnabledWhen( m_previousBlock.timestamp() ) ) {
             m_state.safeRemoveLegacyPartialTransactionReceipts();
         }
     } else {

--- a/libethereum/SchainPatch.cpp
+++ b/libethereum/SchainPatch.cpp
@@ -38,7 +38,7 @@ SchainPatchEnum getEnumForPatchName( const std::string& _patchName ) {
         return SchainPatchEnum::FlexibleDeploymentPatch;
     else if ( _patchName == "ExternalGasPatch" )
         return SchainPatchEnum::ExternalGasPatch;
-    else if ( _patchName == "ClearPartialReceiptsPatch")
+    else if ( _patchName == "ClearPartialReceiptsPatch" )
         return SchainPatchEnum::ClearPartialReceiptsPatch;
     else
         throw std::out_of_range( _patchName );

--- a/libethereum/SchainPatch.cpp
+++ b/libethereum/SchainPatch.cpp
@@ -38,6 +38,8 @@ SchainPatchEnum getEnumForPatchName( const std::string& _patchName ) {
         return SchainPatchEnum::FlexibleDeploymentPatch;
     else if ( _patchName == "ExternalGasPatch" )
         return SchainPatchEnum::ExternalGasPatch;
+    else if ( _patchName == "ClearPartialReceiptsPatch")
+        return SchainPatchEnum::ClearPartialReceiptsPatch;
     else
         throw std::out_of_range( _patchName );
 }
@@ -74,6 +76,8 @@ std::string getPatchNameForEnum( SchainPatchEnum _enumValue ) {
         return "FlexibleDeploymentPatch";
     case SchainPatchEnum::ExternalGasPatch:
         return "ExternalGasPatch";
+    case SchainPatchEnum::ClearPartialReceiptsPatch:
+        return "ClearPartialReceiptsPatch";
     default:
         throw std::out_of_range(
             "UnknownPatch #" + std::to_string( static_cast< size_t >( _enumValue ) ) );

--- a/libethereum/SchainPatch.h
+++ b/libethereum/SchainPatch.h
@@ -36,32 +36,38 @@ protected:
     static std::atomic< time_t > committedBlockTimestamp;
 };
 
-#define DEFINE_AMNESIC_PATCH( CustomPatch )                                       \
-    class CustomPatch : public SchainPatch {                                      \
-    public:                                                                       \
-        static SchainPatchEnum getEnum() { return SchainPatchEnum::CustomPatch; } \
-        static bool isEnabledInWorkingBlock() {                                   \
-            return isPatchEnabledInWorkingBlock( getEnum() );                     \
-        }                                                                         \
+#define DEFINE_AMNESIC_PATCH( CustomPatch )                   \
+    class CustomPatch : public SchainPatch {                  \
+    public:                                                   \
+        static SchainPatchEnum getEnum() {                    \
+            return SchainPatchEnum::CustomPatch;              \
+        }                                                     \
+        static bool isEnabledInWorkingBlock() {               \
+            return isPatchEnabledInWorkingBlock( getEnum() ); \
+        }                                                     \
     };
 
 // TODO One more overload - with EnvInfo?
-#define DEFINE_SIMPLE_PATCH( CustomPatch )                                        \
-    class CustomPatch : public SchainPatch {                                      \
-    public:                                                                       \
-        static SchainPatchEnum getEnum() { return SchainPatchEnum::CustomPatch; } \
-        static bool isEnabledInWorkingBlock() {                                   \
-            return isPatchEnabledInWorkingBlock( getEnum() );                     \
-        }                                                                         \
-        static bool isEnabledWhen( time_t _committedBlockTimestamp ) {            \
-            return isPatchEnabledWhen( getEnum(), _committedBlockTimestamp );     \
-        }                                                                         \
+#define DEFINE_SIMPLE_PATCH( CustomPatch )                                    \
+    class CustomPatch : public SchainPatch {                                  \
+    public:                                                                   \
+        static SchainPatchEnum getEnum() {                                    \
+            return SchainPatchEnum::CustomPatch;                              \
+        }                                                                     \
+        static bool isEnabledInWorkingBlock() {                               \
+            return isPatchEnabledInWorkingBlock( getEnum() );                 \
+        }                                                                     \
+        static bool isEnabledWhen( time_t _committedBlockTimestamp ) {        \
+            return isPatchEnabledWhen( getEnum(), _committedBlockTimestamp ); \
+        }                                                                     \
     };
 
 #define DEFINE_EVM_PATCH( CustomPatch )                                                 \
     class CustomPatch : public SchainPatch {                                            \
     public:                                                                             \
-        static SchainPatchEnum getEnum() { return SchainPatchEnum::CustomPatch; }       \
+        static SchainPatchEnum getEnum() {                                              \
+            return SchainPatchEnum::CustomPatch;                                        \
+        }                                                                               \
         static bool isEnabledInWorkingBlock() {                                         \
             return isPatchEnabledInWorkingBlock( getEnum() );                           \
         }                                                                               \

--- a/libethereum/SchainPatch.h
+++ b/libethereum/SchainPatch.h
@@ -36,38 +36,33 @@ protected:
     static std::atomic< time_t > committedBlockTimestamp;
 };
 
-#define DEFINE_AMNESIC_PATCH( CustomPatch )                   \
-    class CustomPatch : public SchainPatch {                  \
-    public:                                                   \
-        static SchainPatchEnum getEnum() {                    \
-            return SchainPatchEnum::CustomPatch;              \
-        }                                                     \
-        static bool isEnabledInWorkingBlock() {               \
-            return isPatchEnabledInWorkingBlock( getEnum() ); \
-        }                                                     \
+
+#define DEFINE_AMNESIC_PATCH( CustomPatch )                                       \
+    class CustomPatch : public SchainPatch {                                      \
+    public:                                                                       \
+        static SchainPatchEnum getEnum() { return SchainPatchEnum::CustomPatch; } \
+        static bool isEnabledInWorkingBlock() {                                   \
+            return isPatchEnabledInWorkingBlock( getEnum() );                     \
+        }                                                                         \
     };
 
 // TODO One more overload - with EnvInfo?
-#define DEFINE_SIMPLE_PATCH( CustomPatch )                                    \
-    class CustomPatch : public SchainPatch {                                  \
-    public:                                                                   \
-        static SchainPatchEnum getEnum() {                                    \
-            return SchainPatchEnum::CustomPatch;                              \
-        }                                                                     \
-        static bool isEnabledInWorkingBlock() {                               \
-            return isPatchEnabledInWorkingBlock( getEnum() );                 \
-        }                                                                     \
-        static bool isEnabledWhen( time_t _committedBlockTimestamp ) {        \
-            return isPatchEnabledWhen( getEnum(), _committedBlockTimestamp ); \
-        }                                                                     \
+#define DEFINE_SIMPLE_PATCH( CustomPatch )                                        \
+    class CustomPatch : public SchainPatch {                                      \
+    public:                                                                       \
+        static SchainPatchEnum getEnum() { return SchainPatchEnum::CustomPatch; } \
+        static bool isEnabledInWorkingBlock() {                                   \
+            return isPatchEnabledInWorkingBlock( getEnum() );                     \
+        }                                                                         \
+        static bool isEnabledWhen( time_t _committedBlockTimestamp ) {            \
+            return isPatchEnabledWhen( getEnum(), _committedBlockTimestamp );     \
+        }                                                                         \
     };
 
 #define DEFINE_EVM_PATCH( CustomPatch )                                                 \
     class CustomPatch : public SchainPatch {                                            \
     public:                                                                             \
-        static SchainPatchEnum getEnum() {                                              \
-            return SchainPatchEnum::CustomPatch;                                        \
-        }                                                                               \
+        static SchainPatchEnum getEnum() { return SchainPatchEnum::CustomPatch; }       \
         static bool isEnabledInWorkingBlock() {                                         \
             return isPatchEnabledInWorkingBlock( getEnum() );                           \
         }                                                                               \

--- a/libethereum/SchainPatch.h
+++ b/libethereum/SchainPatch.h
@@ -146,4 +146,10 @@ DEFINE_SIMPLE_PATCH( FlexibleDeploymentPatch );
  */
 DEFINE_SIMPLE_PATCH( ExternalGasPatch );
 
+/*
+ * Purpose: do not save partial receipts after block is executed
+ * Version introduced: 4.0.0
+ */
+DEFINE_SIMPLE_PATCH( ClearPartialReceiptsPatch );
+
 #endif  // SCHAINPATCH_H

--- a/libethereum/SchainPatchEnum.h
+++ b/libethereum/SchainPatchEnum.h
@@ -20,6 +20,7 @@ enum class SchainPatchEnum {
     VerifyBlsSyncPatch,
     FlexibleDeploymentPatch,
     ExternalGasPatch,
+    ClearPartialReceiptsPatch,
     PatchesCount
 };
 

--- a/libskale/OverlayDB.cpp
+++ b/libskale/OverlayDB.cpp
@@ -116,23 +116,35 @@ std::vector< dev::bytes > OverlayDB::getPartialTransactionReceipts(
 }
 
 void OverlayDB::setLegacyPartialTransactionReceipts( const dev::bytes& _rawReceipt ) {
-    string legacyPrefix( "safeLastTransactionReceipts" );
-    m_db_face->insert( legacyPrefix, skale::slicing::toSlice( _rawReceipt ) );
+    string legacyKey( "safeLastTransactionReceipts" );
+    m_db_face->insert( legacyKey, skale::slicing::toSlice( _rawReceipt ) );
 }
 
 dev::bytes OverlayDB::getLegacyPartialTransactionReceipts() const {
     dev::bytes legacyPartialTransactionReceipts;
 
-    string legacyPrefix( "safeLastTransactionReceipts" );
+    string legacyKey( "safeLastTransactionReceipts" );
 
     if ( m_db_face ) {
         const std::string lookupResult =
-            m_db_face->lookup( skale::slicing::toSlice( "safeLastTransactionReceipts" ) );
+            m_db_face->lookup( skale::slicing::toSlice( legacyKey ) );
         if ( !lookupResult.empty() )
             legacyPartialTransactionReceipts.insert(
                 legacyPartialTransactionReceipts.end(), lookupResult.begin(), lookupResult.end() );
     }
     return legacyPartialTransactionReceipts;
+}
+
+void OverlayDB::cleanupLegacyTransactionReceipts() {
+    string legacyKey( "safeLastTransactionReceipts" );
+    if ( m_db_face ) {
+        const std::string lookupResult =
+            m_db_face->lookup( skale::slicing::toSlice( legacyKey ) );
+        if ( !lookupResult.empty() ) {
+            m_db_face->kill( legacyKey );
+            m_db_face->commit( "Cleanup legacy receipts" );
+        }
+    }
 }
 
 void OverlayDB::removeAllPartialTransactionReceipts() {

--- a/libskale/OverlayDB.cpp
+++ b/libskale/OverlayDB.cpp
@@ -126,8 +126,7 @@ dev::bytes OverlayDB::getLegacyPartialTransactionReceipts() const {
     string legacyKey( "safeLastTransactionReceipts" );
 
     if ( m_db_face ) {
-        const std::string lookupResult =
-            m_db_face->lookup( skale::slicing::toSlice( legacyKey ) );
+        const std::string lookupResult = m_db_face->lookup( skale::slicing::toSlice( legacyKey ) );
         if ( !lookupResult.empty() )
             legacyPartialTransactionReceipts.insert(
                 legacyPartialTransactionReceipts.end(), lookupResult.begin(), lookupResult.end() );
@@ -138,8 +137,7 @@ dev::bytes OverlayDB::getLegacyPartialTransactionReceipts() const {
 void OverlayDB::cleanupLegacyTransactionReceipts() {
     string legacyKey( "safeLastTransactionReceipts" );
     if ( m_db_face ) {
-        const std::string lookupResult =
-            m_db_face->lookup( skale::slicing::toSlice( legacyKey ) );
+        const std::string lookupResult = m_db_face->lookup( skale::slicing::toSlice( legacyKey ) );
         if ( !lookupResult.empty() ) {
             m_db_face->kill( legacyKey );
             m_db_face->commit( "Cleanup legacy receipts" );

--- a/libskale/OverlayDB.cpp
+++ b/libskale/OverlayDB.cpp
@@ -116,8 +116,11 @@ std::vector< dev::bytes > OverlayDB::getPartialTransactionReceipts(
 }
 
 void OverlayDB::setLegacyPartialTransactionReceipts( const dev::bytes& _rawReceipt ) {
-    string legacyKey( "safeLastTransactionReceipts" );
-    m_db_face->insert( legacyKey, skale::slicing::toSlice( _rawReceipt ) );
+    if ( m_db_face ) {
+        string legacyKey( "safeLastTransactionReceipts" );
+        m_db_face->insert( legacyKey, skale::slicing::toSlice( _rawReceipt ) );
+        m_db_face->commit( "Set legacy receipts" );
+    }
 }
 
 dev::bytes OverlayDB::getLegacyPartialTransactionReceipts() const {

--- a/libskale/OverlayDB.cpp
+++ b/libskale/OverlayDB.cpp
@@ -115,6 +115,25 @@ std::vector< dev::bytes > OverlayDB::getPartialTransactionReceipts(
     return partialTransactionReceipts;
 }
 
+void OverlayDB::setLegacyPartialTransactionReceipts( const dev::bytes& _rawReceipt ) {
+    string legacyPrefix( "safeLastTransactionReceipts" );
+    m_db_face->insert( legacyPrefix, skale::slicing::toSlice( _rawReceipt ) );
+}
+
+dev::bytes OverlayDB::getLegacyPartialTransactionReceipts() const {
+    dev::bytes legacyPartialTransactionReceipts;
+
+    string legacyPrefix( "safeLastTransactionReceipts" );
+
+    if ( m_db_face ) {
+        const std::string lookupResult =
+            m_db_face->lookup( skale::slicing::toSlice( "safeLastTransactionReceipts" ) );
+        if ( !lookupResult.empty() )
+            legacyPartialTransactionReceipts.insert(
+                legacyPartialTransactionReceipts.end(), lookupResult.begin(), lookupResult.end() );
+    }
+    return legacyPartialTransactionReceipts;
+}
 
 void OverlayDB::removeAllPartialTransactionReceipts() {
     // first we get all keys
@@ -136,7 +155,6 @@ void OverlayDB::removeAllPartialTransactionReceipts() {
 
     m_db_face->commit( "Clean partial keys" );
 }
-
 
 void OverlayDB::setLastExecutedTransactionHash( const dev::h256& _newHash ) {
     this->lastExecutedTransactionHash = _newHash;

--- a/libskale/OverlayDB.h
+++ b/libskale/OverlayDB.h
@@ -73,6 +73,9 @@ public:
     void setPartialTransactionReceipt( const dev::bytes& _newReceipt,
         dev::eth::BlockNumber _blockNumber, uint64_t _transactionIndex );
 
+    dev::bytes getLegacyPartialTransactionReceipts() const;
+    void setLegacyPartialTransactionReceipts( const dev::bytes& _newReceipt );
+
     // commit key-value pairs in storage
     void commitStorageValues();
     void commit();

--- a/libskale/OverlayDB.h
+++ b/libskale/OverlayDB.h
@@ -75,6 +75,7 @@ public:
 
     dev::bytes getLegacyPartialTransactionReceipts() const;
     void setLegacyPartialTransactionReceipts( const dev::bytes& _newReceipt );
+    void cleanupLegacyTransactionReceipts();
 
     // commit key-value pairs in storage
     void commitStorageValues();

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -338,7 +338,6 @@ dev::eth::TransactionReceipts State::safeLegacyPartialTransactionReceipts() {
         }
     }
     return dev::eth::TransactionReceipts();
-
 }
 
 void State::safeCommitLegacyPartialTransactionReceipts(

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -321,6 +321,13 @@ void State::safeRemoveAllPartialTransactionReceipts() {
 }
 
 
+void State::safeRemoveLegacyPartialTransactionReceipts() {
+    if ( m_db_ptr ) {
+        m_db_ptr->cleanupLegacyTransactionReceipts();
+    }
+}
+
+
 dev::eth::TransactionReceipts State::safeLegacyPartialTransactionReceipts() {
     dev::eth::TransactionReceipts legacyPartialTransactionReceipts;
     if ( m_db_ptr ) {

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -321,6 +321,29 @@ void State::safeRemoveAllPartialTransactionReceipts() {
 }
 
 
+dev::eth::TransactionReceipts State::safeLegacyPartialTransactionReceipts() {
+    dev::eth::TransactionReceipts legacyPartialTransactionReceipts;
+    if ( m_db_ptr ) {
+        auto rawTransactionReceipts = m_db_ptr->getLegacyPartialTransactionReceipts();
+        if ( !rawTransactionReceipts.empty() ) {
+            dev::RLP rlp( rawTransactionReceipts );
+            dev::eth::BlockReceipts blockReceipts( rlp );
+            legacyPartialTransactionReceipts.insert( legacyPartialTransactionReceipts.end(),
+                blockReceipts.receipts.begin(), blockReceipts.receipts.end() );
+        }
+    }
+
+    return legacyPartialTransactionReceipts;
+}
+
+void State::safeCommitLegacyPartialTransactionReceipts( const dev::eth::TransactionReceipts& _receipts ) {
+    dev::eth::BlockReceipts blockReceipts;
+    blockReceipts.receipts.insert(blockReceipts.receipts.begin(), _receipts.begin(), _receipts.end());
+    m_db_ptr->setLegacyPartialTransactionReceipts( blockReceipts.rlp() );
+    m_db_ptr->commit();
+}
+
+
 void State::safeSetAndCommitPartialTransactionReceipt(
     const dev::bytes& _receipt, dev::eth::BlockNumber _blockNumber, uint64_t _transactionIndex ) {
     if ( m_db_ptr ) {

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -348,8 +348,9 @@ void State::safeCommitLegacyPartialTransactionReceipts(
     dev::eth::BlockReceipts blockReceipts;
     blockReceipts.receipts.insert(
         blockReceipts.receipts.begin(), _receipts.begin(), _receipts.end() );
-    m_db_ptr->setLegacyPartialTransactionReceipts( blockReceipts.rlp() );
-    m_db_ptr->commit();
+    if ( m_db_ptr ) {
+        m_db_ptr->setLegacyPartialTransactionReceipts( blockReceipts.rlp() );
+    }
 }
 
 

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -336,9 +336,11 @@ dev::eth::TransactionReceipts State::safeLegacyPartialTransactionReceipts() {
     return legacyPartialTransactionReceipts;
 }
 
-void State::safeCommitLegacyPartialTransactionReceipts( const dev::eth::TransactionReceipts& _receipts ) {
+void State::safeCommitLegacyPartialTransactionReceipts(
+    const dev::eth::TransactionReceipts& _receipts ) {
     dev::eth::BlockReceipts blockReceipts;
-    blockReceipts.receipts.insert(blockReceipts.receipts.begin(), _receipts.begin(), _receipts.end());
+    blockReceipts.receipts.insert(
+        blockReceipts.receipts.begin(), _receipts.begin(), _receipts.end() );
     m_db_ptr->setLegacyPartialTransactionReceipts( blockReceipts.rlp() );
     m_db_ptr->commit();
 }

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -329,18 +329,16 @@ void State::safeRemoveLegacyPartialTransactionReceipts() {
 
 
 dev::eth::TransactionReceipts State::safeLegacyPartialTransactionReceipts() {
-    dev::eth::TransactionReceipts legacyPartialTransactionReceipts;
     if ( m_db_ptr ) {
         auto rawTransactionReceipts = m_db_ptr->getLegacyPartialTransactionReceipts();
         if ( !rawTransactionReceipts.empty() ) {
             dev::RLP rlp( rawTransactionReceipts );
             dev::eth::BlockReceipts blockReceipts( rlp );
-            legacyPartialTransactionReceipts.insert( legacyPartialTransactionReceipts.end(),
-                blockReceipts.receipts.begin(), blockReceipts.receipts.end() );
+            return blockReceipts.receipts;
         }
     }
+    return dev::eth::TransactionReceipts();
 
-    return legacyPartialTransactionReceipts;
 }
 
 void State::safeCommitLegacyPartialTransactionReceipts(

--- a/libskale/State.h
+++ b/libskale/State.h
@@ -229,6 +229,10 @@ public:
     dev::h256 safeLastExecutedTransactionHash();
     dev::eth::TransactionReceipts safePartialTransactionReceipts(
         dev::eth::BlockNumber _blockNumber );
+
+    void safeCommitLegacyPartialTransactionReceipts(const dev::eth::TransactionReceipts& _receipts);
+    dev::eth::TransactionReceipts safeLegacyPartialTransactionReceipts();
+
     void safeRemoveAllPartialTransactionReceipts();
 
 

--- a/libskale/State.h
+++ b/libskale/State.h
@@ -229,6 +229,7 @@ public:
     dev::h256 safeLastExecutedTransactionHash();
     dev::eth::TransactionReceipts safePartialTransactionReceipts(
         dev::eth::BlockNumber _blockNumber );
+    void safeRemoveLegacyPartialTransactionReceipts();
 
     void safeCommitLegacyPartialTransactionReceipts(
         const dev::eth::TransactionReceipts& _receipts );

--- a/libskale/State.h
+++ b/libskale/State.h
@@ -230,7 +230,8 @@ public:
     dev::eth::TransactionReceipts safePartialTransactionReceipts(
         dev::eth::BlockNumber _blockNumber );
 
-    void safeCommitLegacyPartialTransactionReceipts(const dev::eth::TransactionReceipts& _receipts);
+    void safeCommitLegacyPartialTransactionReceipts(
+        const dev::eth::TransactionReceipts& _receipts );
     dev::eth::TransactionReceipts safeLegacyPartialTransactionReceipts();
 
     void safeRemoveAllPartialTransactionReceipts();

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -459,6 +459,9 @@ struct RestrictedAddressFixture : public JsonRpcFixture {
         ownerAddress = Address( "00000000000000000000000000000000000000AA" );
         std::string fileName = "test";
         path = dev::getDataDir() / "filestorage" / Address( ownerAddress ).hex() / fileName;
+        if ( boost::filesystem::exists( path ) ) {
+            boost::filesystem::remove_all( path );
+        }
         data =
             ( "0x"
               "00000000000000000000000000000000000000000000000000000000000000AA"

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -1774,10 +1774,24 @@ BOOST_AUTO_TEST_CASE( simplePoWTransaction ) {
 }
 
 BOOST_AUTO_TEST_CASE( clearPartialReceipts ) {
-    JsonRpcFixture fixture;
-    auto senderAddress = fixture.coinbase.address();
-    fixture.client->setAuthor( senderAddress );
-    dev::eth::simulateMining( *( fixture.client ), 1000 );
+    // Prepare fixture
+    std::string _config = c_genesisConfigString;
+    Json::Value ret;
+    Json::Reader().parse( _config, ret );
+
+    std::string chainID = "0x97";  // 151
+    ret["params"]["chainID"] = chainID;
+    time_t clearPartialReceiptsActivationTs = time(nullptr) + 10;
+    ret["skaleConfig"]["sChain"]["ClearPartialReceiptsPatchTimestamp"] = clearPartialReceiptsActivationTs;
+
+    Json::FastWriter fastWriter;
+    std::string config = fastWriter.write( ret );
+    JsonRpcFixture fixture( config );
+
+    // To fill coinbase wallet
+    dev::eth::simulateMining( *( fixture.client ), 20 );
+
+    string senderAddress = toJS(fixture.coinbase.address());
 
     Json::Value transactionCallObject;
     transactionCallObject["from"] = toJS( senderAddress );
@@ -1797,12 +1811,7 @@ BOOST_AUTO_TEST_CASE( clearPartialReceipts ) {
     BOOST_REQUIRE_EQUAL( state.safePartialTransactionReceipts(blockNumber).size(), 0 );
     BOOST_REQUIRE_EQUAL( state.safeLegacyPartialTransactionReceipts().size(), 1 );
 
-    std::string _config = c_genesisConfigString;
-    Json::Value config;
-    Json::Reader().parse( _config, config );
-    time_t clearPartialReceiptsActivationTs = time(nullptr) + 1;
-    config["skaleConfig"]["sChain"]["ClearPartialReceiptsPatch"] = clearPartialReceiptsActivationTs;
-    sleep(2);
+    sleep(10);
 
     ts = toTransactionSkeleton( transactionCallObject );
     ts = fixture.client->populateTransactionWithDefaults( ts );

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -1734,7 +1734,7 @@ BOOST_AUTO_TEST_CASE( simplePoWTransaction ) {
     auto latestBlockNumber = fixture.client->blockInfo(fixture.client->hashFromNumber(LatestBlock)).number();
 
     // wait for patch turning on and see how it happens
-    string txHash;    
+    string txHash;
     BlockHeader badInfo, goodInfo;
     uint64_t blockCounter = 2;
     for ( ;; ) {
@@ -1771,6 +1771,50 @@ BOOST_AUTO_TEST_CASE( simplePoWTransaction ) {
 
     Json::Value receipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
     BOOST_REQUIRE_EQUAL( receipt["status"], "0x1" );
+}
+
+BOOST_AUTO_TEST_CASE( clearPartialReceipts ) {
+    JsonRpcFixture fixture;
+    auto senderAddress = fixture.coinbase.address();
+    fixture.client->setAuthor( senderAddress );
+    dev::eth::simulateMining( *( fixture.client ), 1000 );
+
+    Json::Value transactionCallObject;
+    transactionCallObject["from"] = toJS( senderAddress );
+    transactionCallObject["to"] = "0x692a70d2e424a56d2c6c27aa97d1a86395877b3a";
+    transactionCallObject["data"] = "0x28b5e32b";
+
+    TransactionSkeleton ts = toTransactionSkeleton( transactionCallObject );
+    ts = fixture.client->populateTransactionWithDefaults( ts );
+    pair< bool, Secret > ar = fixture.accountHolder->authenticate( ts );
+    Transaction tx( ts, ar.second );
+
+    auto txHash = fixture.rpcClient->eth_sendRawTransaction( toJS( tx.toBytes() ) );
+    dev::eth::mineTransaction( *( fixture.client ), 1 );
+    auto receipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
+    dev::eth::BlockNumber blockNumber = jsToInt(receipt["blockNumber"].asString());
+    State state( fixture.client->state() );
+    BOOST_REQUIRE_EQUAL( state.safePartialTransactionReceipts(blockNumber).size(), 0 );
+    BOOST_REQUIRE_EQUAL( state.safeLegacyPartialTransactionReceipts().size(), 1 );
+
+    std::string _config = c_genesisConfigString;
+    Json::Value config;
+    Json::Reader().parse( _config, config );
+    time_t clearPartialReceiptsActivationTs = time(nullptr) + 1;
+    config["skaleConfig"]["sChain"]["ClearPartialReceiptsPatch"] = clearPartialReceiptsActivationTs;
+    sleep(2);
+
+    ts = toTransactionSkeleton( transactionCallObject );
+    ts = fixture.client->populateTransactionWithDefaults( ts );
+    ar = fixture.accountHolder->authenticate( ts );
+    Transaction txAfter( ts, ar.second );
+
+    auto txHashAfter = fixture.rpcClient->eth_sendRawTransaction( toJS( txAfter.toBytes() ) );
+    dev::eth::mineTransaction( *( fixture.client ), 1 );
+    auto receiptAfter = fixture.rpcClient->eth_getTransactionReceipt( txHashAfter );
+    dev::eth::BlockNumber blockNumberAfter = jsToInt(receiptAfter["blockNumber"].asString());
+    BOOST_REQUIRE_EQUAL( state.safePartialTransactionReceipts(blockNumberAfter).size(), 0 );
+    BOOST_REQUIRE_EQUAL( state.safeLegacyPartialTransactionReceipts().size(), 0 );
 }
 
 BOOST_AUTO_TEST_CASE( recalculateExternalGas ) {
@@ -3007,11 +3051,11 @@ BOOST_AUTO_TEST_CASE( debugGetPatchTimestamps ) {
 
         std::string patchName = getPatchNameForEnum(patchEnum) + "Timestamp";
         patchName[0] = tolower( patchName[0] );
-        configJson["skaleConfig"]["sChain"][patchName] = ts; 
+        configJson["skaleConfig"]["sChain"][patchName] = ts;
     }
 
     Json::FastWriter fastWriter;
-    std::string customConfigFile = fastWriter.write( configJson ); 
+    std::string customConfigFile = fastWriter.write( configJson );
 
     JsonRpcFixture fixture(customConfigFile, false, false, false, false);
     Json::Value returnedPatchTimestamps = fixture.rpcClient->debug_getPatchTimestamps();
@@ -3022,7 +3066,7 @@ BOOST_AUTO_TEST_CASE( debugGetPatchTimestamps ) {
 
         std::string patchName = getPatchNameForEnum(patchEnum) + "Timestamp";
         patchName[0] = tolower( patchName[0] );
-        size_t returnedTimestamp = static_cast< size_t > (returnedPatchTimestamps[patchName].asInt()); 
+        size_t returnedTimestamp = static_cast< size_t > (returnedPatchTimestamps[patchName].asInt());
 
         BOOST_REQUIRE_EQUAL( returnedTimestamp, patchTimestamps[patchIdx]);
     }
@@ -4339,6 +4383,7 @@ BOOST_AUTO_TEST_CASE( mtm_import_future_txs ) {
     BOOST_REQUIRE_EQUAL( tq->status().current, 5 );
 
     call = fixture.rpcClient->debug_getFutureTransactions();
+    BOOST_REQUIRE_EQUAL( call.size(), 0 );
     BOOST_REQUIRE_EQUAL( call.size(), 0 );
 
     fixture.client->skaleHost()->pauseConsensus( false );

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -1782,7 +1782,7 @@ BOOST_AUTO_TEST_CASE( clearPartialReceipts ) {
     std::string chainID = "0x97";  // 151
     ret["params"]["chainID"] = chainID;
     time_t clearPartialReceiptsActivationTs = time(nullptr) + 10;
-    ret["skaleConfig"]["sChain"]["ClearPartialReceiptsPatchTimestamp"] = clearPartialReceiptsActivationTs;
+    ret["skaleConfig"]["sChain"]["clearPartialReceiptsPatchTimestamp"] = clearPartialReceiptsActivationTs;
 
     Json::FastWriter fastWriter;
     std::string config = fastWriter.write( ret );

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -4453,7 +4453,6 @@ BOOST_AUTO_TEST_CASE( mtm_import_future_txs ) {
 
     call = fixture.rpcClient->debug_getFutureTransactions();
     BOOST_REQUIRE_EQUAL( call.size(), 0 );
-    BOOST_REQUIRE_EQUAL( call.size(), 0 );
 
     fixture.client->skaleHost()->pauseConsensus( false );
 }

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -3784,6 +3784,8 @@ BOOST_AUTO_TEST_CASE( maxFeePerGasPatch ) {
     txHash = fixture.rpcClient->eth_sendTransaction( txRefill );
     dev::eth::mineTransaction( *( fixture.client ), 1 );
 
+    sleep( 1 );
+
     // send a txn with maxPriorityFeePerGas > maxFeePerGas after MaxFeePerGasPatchTimestamp, it should fail
     BOOST_REQUIRE_THROW( fixture.rpcClient->eth_sendRawTransaction( "0x02f86d8197018504a817c8018504a817c800827530947d36af85a184e220a656525fcbb9a63b9ab3c12b8080c080a0aea5ff86373cbbbb33c9f3e9a25ceb9a694ee71beff452a4d29903d73fd30ca9a00458d4f7d54be178b42d230cc5a4740540d55b8ca0f9c74c79c1d49f6686b1e6" ), jsonrpc::JsonRpcException ); // INVALID_PARAMS
 }

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -1827,6 +1827,19 @@ BOOST_AUTO_TEST_CASE( clearPartialReceipts ) {
     dev::eth::BlockNumber blockNumberAfter = jsToInt(receiptAfter["blockNumber"].asString());
     BOOST_REQUIRE_EQUAL( state.safePartialTransactionReceipts(blockNumberAfter).size(), 0 );
     BOOST_REQUIRE_EQUAL( state.safeLegacyPartialTransactionReceipts().size(), 0 );
+
+
+    ts = toTransactionSkeleton( transactionCallObject );
+    ts = fixture.client->populateTransactionWithDefaults( ts );
+    ar = fixture.accountHolder->authenticate( ts );
+    Transaction txAfterAgain( ts, ar.second );
+
+    auto txHashAfterAgain = fixture.rpcClient->eth_sendRawTransaction( toJS( txAfterAgain.toBytes() ) );
+    dev::eth::mineTransaction( *( fixture.client ), 1 );
+    auto receiptAfterAgain = fixture.rpcClient->eth_getTransactionReceipt( txHashAfterAgain );
+    dev::eth::BlockNumber blockNumberAfterAgain = jsToInt(receiptAfterAgain["blockNumber"].asString());
+    BOOST_REQUIRE_EQUAL( state.safePartialTransactionReceipts(blockNumberAfterAgain).size(), 0 );
+    BOOST_REQUIRE_EQUAL( state.safeLegacyPartialTransactionReceipts().size(), 0 );
 }
 
 BOOST_AUTO_TEST_CASE( recalculateExternalGas ) {


### PR DESCRIPTION
## Description
Keep the old way of saving partial receipts before `ClearPartialReceiptsPatchTimestamp`

## Tests
- Added unit tests
- Tested on local network by launching archive node with `syncFromCatchup=True` 

## Performance Impact
- Additional commit to DB added per block. No performance changes expected. 
