### PR TITLE
Fix getBlockByHash and getBlockByNumber for 0 block

### DIFF
--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -545,10 +545,11 @@ Json::Value Eth::eth_getBlockByHash( string const& _blockHash, bool _includeTran
             return Json::Value( Json::nullValue );
 
         u256 baseFeePerGas;
-        if ( EIP1559TransactionsPatch::isEnabledWhen(
-                 client()->blockInfo( client()->numberFromHash( h ) - 1 ).timestamp() ) )
+        BlockNumber bn = client()->numberFromHash( h );
+        if ( bn > 0 &&
+             EIP1559TransactionsPatch::isEnabledWhen( client()->blockInfo( bn - 1 ).timestamp() ) )
             try {
-                baseFeePerGas = client()->gasBidPrice( client()->numberFromHash( h ) - 1 );
+                baseFeePerGas = client()->gasBidPrice( bn - 1 );
             } catch ( std::invalid_argument& _e ) {
                 cdebug << "Cannot get gas price for block " << h;
                 cdebug << _e.what();
@@ -563,7 +564,6 @@ Json::Value Eth::eth_getBlockByHash( string const& _blockHash, bool _includeTran
             Transactions transactions = client()->transactions( h );
 
 #ifdef HISTORIC_STATE
-            BlockNumber bn = client()->numberFromHash( h );
             if ( SkipInvalidTransactionsPatch::hasPotentialInvalidTransactionsInBlock(
                      bn, client()->blockChain() ) ) {
                 // remove invalid transactions
@@ -581,7 +581,6 @@ Json::Value Eth::eth_getBlockByHash( string const& _blockHash, bool _includeTran
             h256s transactions = client()->transactionHashes( h );
 
 #ifdef HISTORIC_STATE
-            BlockNumber bn = client()->numberFromHash( h );
             if ( SkipInvalidTransactionsPatch::hasPotentialInvalidTransactionsInBlock(
                      bn, client()->blockChain() ) ) {
                 // remove invalid transactions

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -3949,6 +3949,18 @@ BOOST_AUTO_TEST_CASE( jsonrpcVersionInResponseHeader ) {
     BOOST_REQUIRE( joAnswer["jsonrpc"] == "2.0" );
 }
 
+BOOST_AUTO_TEST_CASE( getZeroBlock ) {
+    JsonRpcFixture fixture;
+
+    Json::Value block = fixture.rpcClient->eth_getBlockByNumber( "0", "false" );
+    BOOST_REQUIRE( block["number"] == string( "0x0" ) );
+
+    string blockHash = block["hash"].asString();
+    Json::Value blockByHash = fixture.rpcClient->eth_getBlockByHash( blockHash, "false" );
+    BOOST_REQUIRE( blockByHash["number"] == string( "0x0" ) );
+    BOOST_REQUIRE( blockByHash["hash"] == blockHash );
+}
+
 BOOST_AUTO_TEST_CASE( etherbase_generation2 ) {
     JsonRpcFixture fixture( c_genesisGeneration2ConfigString, false, false, true );
     string etherbase = fixture.rpcClient->eth_coinbase();


### PR DESCRIPTION
## Description

This PR addresses a bug in the handling of the zero block (genesis block) across all build types. Specifically, it fixes the behavior of `getBlockByNumber(0)` for historic builds and `getBlockByHash` when querying the zero block. These functions now correctly return the zero block as expected.

## Tests

- Added a new unit test: `getZeroBlock`
- Verified on a local skaled

## Performance Impact

No impact
