### PR TITLE
Feature/2148 validate bite transactions

### DIFF
--- a/libethcore/CMakeLists.txt
+++ b/libethcore/CMakeLists.txt
@@ -16,3 +16,6 @@ target_link_libraries( ethcore PUBLIC
 	devcore
 	skale
 	)
+if (BITE)
+    target_link_libraries( ethcore PUBLIC te )
+endif()

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -110,5 +110,10 @@ DEV_SIMPLE_EXCEPTION( UnknownAccount );
 
 DEV_SIMPLE_EXCEPTION( TooBigResponse );
 
+#ifdef BITE
+DEV_SIMPLE_EXCEPTION( InvalidBITETransaction );
+DEV_SIMPLE_EXCEPTION( BITETransactionTooShort );
+#endif
+
 }  // namespace eth
 }  // namespace dev

--- a/libethcore/TransactionBase.cpp
+++ b/libethcore/TransactionBase.cpp
@@ -610,13 +610,12 @@ void TransactionBase::checkAndValidateBITETransaction() const {
     if ( m_data.size() < BITE_MAGIC_SIZE + BITE_EPOCH_ID_LEN + BITE_ENCRYPTED_AES_KEY_LEN + 64 )
         BOOST_THROW_EXCEPTION( BITETransactionTooShort()
                                << errinfo_comment( "BITE transaction's data is too short." ) );
-    // validate encrypted AES key
     std::array< uint8_t, BITE_ENCRYPTED_AES_KEY_LEN > cipheredKeyBytes;
     std::copy( m_data.begin() + BITE_MAGIC_SIZE + BITE_EPOCH_ID_LEN,
         m_data.begin() + BITE_MAGIC_SIZE + BITE_EPOCH_ID_LEN + BITE_ENCRYPTED_AES_KEY_LEN,
         cipheredKeyBytes.begin() );
     try {
-        // it does 3 pairings instead of 2 - can be optimized
+        // validate encrypted AES key
         auto cipheredKey = libBLS::CipheredKey::fromBytes( cipheredKeyBytes );
         libBLS::ThresholdEncryption::validateEncryption( cipheredKey );
         return;

--- a/libethcore/TransactionBase.cpp
+++ b/libethcore/TransactionBase.cpp
@@ -32,7 +32,10 @@
 
 #include <libdevcore/microprofile.h>
 
+#include <libconsensus/libBLS/threshold_encryption/ThresholdEncryption.h>
 using namespace std;
+#include <libconsensus/node/ConsensusInterface.h>
+
 using namespace dev;
 using namespace dev::eth;
 
@@ -595,5 +598,36 @@ bytes const& TransactionBase::decryptedData() const {
     if ( !m_decryptedData )
         return data();
     return *m_decryptedData;
+}
+
+void TransactionBase::checkAndValidateBITETransaction() const {
+    // if a txn does not match MAGIC return false
+    if ( m_data.empty() || m_data.size() < BITE_MAGIC_SIZE ||
+         !std::equal( BITE_MAGIC_AS_BYTE_ARRAY, BITE_MAGIC_AS_BYTE_ARRAY + BITE_MAGIC_SIZE,
+             m_data.begin() ) )
+        return;
+    // minimum size of an encrypted with AES key message is 64 bytes
+    if ( m_data.size() < BITE_MAGIC_SIZE + BITE_EPOCH_ID_LEN + BITE_ENCRYPTED_AES_KEY_LEN + 64 )
+        BOOST_THROW_EXCEPTION( BITETransactionTooShort()
+                               << errinfo_comment( "BITE transaction's data is too short." ) );
+    // validate encrypted AES key
+    std::array< uint8_t, BITE_ENCRYPTED_AES_KEY_LEN > cipheredKeyBytes;
+    std::copy( m_data.begin() + BITE_MAGIC_SIZE + BITE_EPOCH_ID_LEN,
+        m_data.begin() + BITE_MAGIC_SIZE + BITE_EPOCH_ID_LEN + BITE_ENCRYPTED_AES_KEY_LEN,
+        cipheredKeyBytes.begin() );
+    try {
+        // it does 3 pairings instead of 2 - can be optimized
+        auto cipheredKey = libBLS::CipheredKey::fromBytes( cipheredKeyBytes );
+        libBLS::ThresholdEncryption::validateEncryption( cipheredKey );
+        return;
+    } catch ( libBLS::ThresholdUtils::IncorrectInput& ex ) {
+        BOOST_THROW_EXCEPTION(
+            InvalidBITETransaction()
+            << errinfo_comment( std::string( "BITE transaction's data is invalid" ) + ex.what() ) );
+    } catch ( libBLS::ThresholdUtils::IsNotWellFormed& ex ) {
+        BOOST_THROW_EXCEPTION(
+            InvalidBITETransaction()
+            << errinfo_comment( std::string( "BITE transaction's data is invalid" ) + ex.what() ) );
+    }
 }
 #endif

--- a/libethcore/TransactionBase.h
+++ b/libethcore/TransactionBase.h
@@ -157,6 +157,8 @@ public:
 
     /// @returns the decrypted data associated with this (BITE) transaction.
     bytes const& decryptedData() const;
+
+    void checkAndValidateBITETransaction() const;
 #endif
 
     /// @throws TransactionIsUnsigned if signature was not initialized

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -1117,6 +1117,13 @@ h256 Client::importTransaction( Transaction const& _t, TransactionBroadcast _txO
         bc().number() ? this->blockInfo( bc().currentHash() ) : bc().genesis(), state,
         chainParams(), 0, gasBidPrice, chainParams().sChain.multiTransactionMode );
 
+    // invalid BITE transactions should not be added to txn queue
+#ifdef BITE
+    // only validate in production setup
+    if ( !chainParams().nodeInfo.testSignatures )
+        _t.checkAndValidateBITETransaction();
+#endif
+
     ImportResult res;
     if ( chainParams().sChain.multiTransactionMode && state.getNonce( _t.sender() ) < _t.nonce() &&
          m_tq.maxCurrentNonce( _t.sender() ) != _t.nonce() ) {

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -3988,7 +3988,7 @@ BOOST_AUTO_TEST_CASE( importInvalidBITETransaction ) {
     auto formTransactionData = []( const std::string& magic, const std::string& epoch,
                                    const std::string& encryptedKey,
             const std::string& encryptedData ) {
-        return "0x" + magic + epoch + encryptedData + encryptedKey;
+        return "0x" + magic + epoch + encryptedKey + encryptedData;
     };
 
     size_t nonce = 0;
@@ -4024,7 +4024,7 @@ BOOST_AUTO_TEST_CASE( importInvalidBITETransaction ) {
     std::copy( encryptedKeyByteArray.begin(), encryptedKeyByteArray.end(), encryptedKeyBytes.begin() );
     auto encryptedKey = libBLS::ThresholdUtils::bytesToHexString( encryptedKeyBytes );
 
-    auto validBITEData = formTransactionData( magicNumber, epochId, encryptedData, encryptedKey );
+    auto validBITEData = formTransactionData( magicNumber, epochId, encryptedKey, encryptedData );
     auto validBITETransactionRlp = formTransactionRlp( validBITEData );
 
     BOOST_REQUIRE_NO_THROW( fixture.rpcClient->eth_sendRawTransaction( validBITETransactionRlp ) );
@@ -4064,7 +4064,7 @@ BOOST_AUTO_TEST_CASE( importInvalidBITETransaction ) {
     auto randomEncryptedKeyByteArray = randomEncryptedKeyObj.toBytes();
     std::vector< uint8_t > randomEncryptedKeyBytes( libBLS::CipheredKey::CIPHERED_KEY_SIZE_BYTES );
     std::copy( randomEncryptedKeyByteArray.begin(), randomEncryptedKeyByteArray.end(), randomEncryptedKeyBytes.begin() );
-    auto randomEncryptedKey = libBLS::ThresholdUtils::bytesToHexString( encryptedKeyBytes );
+    auto randomEncryptedKey = libBLS::ThresholdUtils::bytesToHexString( randomEncryptedKeyBytes );
 
     invalidBITEData = formTransactionData( magicNumber, epochId, randomEncryptedKey, encryptedData );
     invalidBITETransactionRlp = formTransactionRlp( invalidBITEData );
@@ -4078,7 +4078,7 @@ BOOST_AUTO_TEST_CASE( importInvalidBITETransaction ) {
     randomEncryptedKeyBytes.clear();
     randomEncryptedKeyBytes.resize( libBLS::CipheredKey::CIPHERED_KEY_SIZE_BYTES );
     std::copy( randomEncryptedKeyByteArray.begin(), randomEncryptedKeyByteArray.end(), randomEncryptedKeyBytes.begin() );
-    randomEncryptedKey = libBLS::ThresholdUtils::bytesToHexString( encryptedKeyBytes );
+    randomEncryptedKey = libBLS::ThresholdUtils::bytesToHexString( randomEncryptedKeyBytes );
 
     invalidBITEData = formTransactionData( magicNumber, epochId, randomEncryptedKey, encryptedData );
     invalidBITETransactionRlp = formTransactionRlp( invalidBITEData );

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -3979,6 +3979,114 @@ std::string formEncryptedMessageMockup( const std::string& message ) {
 
 }
 
+BOOST_AUTO_TEST_CASE( importInvalidBITETransaction ) {
+    JsonRpcFixture fixture( c_genesisGeneration2ConfigString, false, false, true, true );
+
+    dev::eth::simulateMining( *( fixture.client ), 20 );
+    string senderAddress = toJS( fixture.coinbase.address() );
+
+    auto formTransactionData = []( const std::string& magic, const std::string& epoch,
+                                   const std::string& encryptedKey,
+            const std::string& encryptedData ) {
+        return "0x" + magic + epoch + encryptedData + encryptedKey;
+    };
+
+    size_t nonce = 0;
+
+    auto formTransactionRlp = [&senderAddress, &fixture, &nonce]( const std::string& data ) {
+        Json::Value txEncryptedData;
+        txEncryptedData["to"] = "0x5EdF1e852fdD1B0Bc47C0307EF755C76f4B9c251";
+        txEncryptedData["from"] = senderAddress;
+        txEncryptedData["gas"] = "100000";
+        txEncryptedData["gasPrice"] = fixture.rpcClient->eth_gasPrice();
+        txEncryptedData["data"] = data;
+        txEncryptedData["nonce"] = nonce++;
+
+        TransactionSkeleton ts = toTransactionSkeleton( txEncryptedData );
+        ts = fixture.client->populateTransactionWithDefaults( ts );
+        pair< bool, Secret > ar = fixture.accountHolder->authenticate( ts );
+        Transaction tx( ts, ar.second );
+
+        return dev::toHexPrefixed( tx.toBytes() );
+    };
+
+    std::string magicNumber = "f3a9c7b1e4d5f28c7b1e9a3f5d2c8b00";
+    std::string epochId = "0000000000000000";
+    std::string hex = "0123456789abcdef";
+
+    auto messageBytes = libBLS::ThresholdUtils::hexCStringToBytes( h256::random().hex().c_str() );
+    auto blsPublicKey = fixture.rpcClient->skale_getCommonPublicKey();
+
+    auto encryptedMessage = libBLS::ThresholdEncryption::encrypt( messageBytes, libBLS::TEPublicKey( blsPublicKey ) );
+    auto encryptedData = libBLS::ThresholdUtils::bytesToHexString( encryptedMessage.getData() );
+    auto encryptedKeyByteArray = encryptedMessage.key.toBytes();
+    std::vector< uint8_t > encryptedKeyBytes( libBLS::CipheredKey::CIPHERED_KEY_SIZE_BYTES );
+    std::copy( encryptedKeyByteArray.begin(), encryptedKeyByteArray.end(), encryptedKeyBytes.begin() );
+    auto encryptedKey = libBLS::ThresholdUtils::bytesToHexString( encryptedKeyBytes );
+
+    auto validBITEData = formTransactionData( magicNumber, epochId, encryptedData, encryptedKey );
+    auto validBITETransactionRlp = formTransactionRlp( validBITEData );
+
+    BOOST_REQUIRE_NO_THROW( fixture.rpcClient->eth_sendRawTransaction( validBITETransactionRlp ) );
+
+    auto spoiledMagicNumber = magicNumber;
+    size_t idxToSpoil = rand() % 16;
+    size_t idxSubstitute = rand() % 16;
+    while ( spoiledMagicNumber[ idxToSpoil ] == hex[idxSubstitute] )
+        idxSubstitute = rand() % 16;
+
+    spoiledMagicNumber[ idxToSpoil ] = hex[idxSubstitute];
+    auto validNonBITEData = formTransactionData( spoiledMagicNumber, epochId, encryptedKey, encryptedData );
+    auto validNonBITETransactionRlp = formTransactionRlp( validNonBITEData );
+
+    // should not throw any excpetion because txn is not BITE-formatted
+    BOOST_REQUIRE_NO_THROW( fixture.rpcClient->eth_sendRawTransaction( validNonBITETransactionRlp ) );
+
+    auto invalidBITEData = formTransactionData( magicNumber, "", "", "" );
+    auto invalidBITETransactionRlp = formTransactionRlp( invalidBITEData );
+    // data is too short - should throw an exception
+    BOOST_REQUIRE_THROW( fixture.client->importTransaction( Transaction( dev::jsToBytes( invalidBITETransactionRlp ), CheckTransaction::None, false ) ), dev::eth::BITETransactionTooShort );
+    BOOST_REQUIRE_THROW( fixture.rpcClient->eth_sendRawTransaction( invalidBITETransactionRlp ), jsonrpc::JsonRpcException );
+
+    invalidBITEData = formTransactionData( magicNumber, epochId, "", "" );
+    invalidBITETransactionRlp = formTransactionRlp( invalidBITEData );
+    // data is too short - should throw an exception
+    BOOST_REQUIRE_THROW( fixture.client->importTransaction( Transaction( dev::jsToBytes( invalidBITETransactionRlp ), CheckTransaction::None, false ) ), dev::eth::BITETransactionTooShort );
+    BOOST_REQUIRE_THROW( fixture.rpcClient->eth_sendRawTransaction( invalidBITETransactionRlp ), jsonrpc::JsonRpcException );
+
+    invalidBITEData = formTransactionData( magicNumber, epochId, encryptedKey, "" );
+    invalidBITETransactionRlp = formTransactionRlp( invalidBITEData );
+    // data is too short - should throw an exception
+    BOOST_REQUIRE_THROW( fixture.client->importTransaction( Transaction( dev::jsToBytes( invalidBITETransactionRlp ), CheckTransaction::None, false ) ), dev::eth::BITETransactionTooShort );
+    BOOST_REQUIRE_THROW( fixture.rpcClient->eth_sendRawTransaction( invalidBITETransactionRlp ), jsonrpc::JsonRpcException );
+
+    auto randomEncryptedKeyObj = libBLS::CipheredKey( libff::alt_bn128_G2::random_element(), encryptedMessage.key.V, libff::alt_bn128_G1::random_element() );
+    auto randomEncryptedKeyByteArray = randomEncryptedKeyObj.toBytes();
+    std::vector< uint8_t > randomEncryptedKeyBytes( libBLS::CipheredKey::CIPHERED_KEY_SIZE_BYTES );
+    std::copy( randomEncryptedKeyByteArray.begin(), randomEncryptedKeyByteArray.end(), randomEncryptedKeyBytes.begin() );
+    auto randomEncryptedKey = libBLS::ThresholdUtils::bytesToHexString( encryptedKeyBytes );
+
+    invalidBITEData = formTransactionData( magicNumber, epochId, randomEncryptedKey, encryptedData );
+    invalidBITETransactionRlp = formTransactionRlp( invalidBITEData );
+    // encrypted key elements dont correspond to each other - should throw an exception
+    BOOST_REQUIRE_THROW( fixture.client->importTransaction( Transaction( dev::jsToBytes( invalidBITETransactionRlp ), CheckTransaction::None, false ) ), dev::eth::InvalidBITETransaction );
+    BOOST_REQUIRE_THROW( fixture.rpcClient->eth_sendRawTransaction( invalidBITETransactionRlp ), jsonrpc::JsonRpcException );
+
+    randomEncryptedKeyObj.U.X.c0 = libff::alt_bn128_Fq::random_element();
+    randomEncryptedKeyObj.W.Y = libff::alt_bn128_Fq::random_element();
+    randomEncryptedKeyByteArray = randomEncryptedKeyObj.toBytes();
+    randomEncryptedKeyBytes.clear();
+    randomEncryptedKeyBytes.resize( libBLS::CipheredKey::CIPHERED_KEY_SIZE_BYTES );
+    std::copy( randomEncryptedKeyByteArray.begin(), randomEncryptedKeyByteArray.end(), randomEncryptedKeyBytes.begin() );
+    randomEncryptedKey = libBLS::ThresholdUtils::bytesToHexString( encryptedKeyBytes );
+
+    invalidBITEData = formTransactionData( magicNumber, epochId, randomEncryptedKey, encryptedData );
+    invalidBITETransactionRlp = formTransactionRlp( invalidBITEData );
+    // encrypted key is not well formed - should throw an exception
+    BOOST_REQUIRE_THROW( fixture.client->importTransaction( Transaction( dev::jsToBytes( invalidBITETransactionRlp ), CheckTransaction::None, false ) ), dev::eth::InvalidBITETransaction );
+    BOOST_REQUIRE_THROW( fixture.rpcClient->eth_sendRawTransaction( invalidBITETransactionRlp ), jsonrpc::JsonRpcException );
+}
+
 BOOST_AUTO_TEST_CASE( getDecryptedTransactionData ) {
     JsonRpcFixture fixture;
 
@@ -4008,7 +4116,6 @@ BOOST_AUTO_TEST_CASE( getDecryptedTransactionData ) {
     BOOST_REQUIRE( txEncryptedResponse["input"].asString() == encryptedData );
 
     auto txDecryptedResponse = fixture.rpcClient->skale_getDecryptedTransactionData( txHash );
-    std::cout << plaintext << ' ' << txDecryptedResponse << '\n';
     BOOST_REQUIRE( txDecryptedResponse == "0x" + plaintext );
 
     //    pragma solidity >=0.8.2 <0.9.0;


### PR DESCRIPTION
fixes #2148

validate BITE transactions coming through JSON-RPC or broadcast. transactions coming through consensus are already validated
added new unit test

to test:
try spoiling one of 3 fields in BITE transaction data field described here https://github.com/skalenetwork/skaled/blob/v4.1.0/docs/bite-transactions.md#ciphertext-format (spoiled **Encrypted Original Data** field can only be detected later in consensus) 
transaction should not be added to pending queue