### PR TITLE
Feature/is 1161 constant gas price agent

### DIFF
--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -184,6 +184,10 @@ public:
 #endif
     size_t t = 1;
 
+#ifdef MIRAGE
+    uint64_t constantGasPrice = 100000;
+#endif
+
     // key is patch name
     // public - for tests, don't access it directly
     std::vector< time_t > _patchTimestamps =

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -323,6 +323,11 @@ void ChainParams::processSkaleConfigItems( ChainParams& cp, json_spirit::mObject
     if ( sChainObj.count( "multiTransactionMode" ) )
         s.multiTransactionMode = sChainObj.at( "multiTransactionMode" ).get_bool();
 
+#ifdef MIRAGE
+    if ( sChainObj.count( "constantGasPrice" ) )
+        s.constantGasPrice = sChainObj.at( "constantGasPrice" ).get_uint64();
+#endif
+
     // extract all "*PatchTimestamp" records
     for ( const auto& it : sChainObj ) {
         const string& key = it.first;

--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -275,7 +275,12 @@ void validateConfigJson( js::mObject const& _obj ) {
             { "maxSkaledLeveldbStorageBytes", { { js::int_type }, JsonFieldPresence::Optional } },
             { "freeContractDeployment", { { js::bool_type }, JsonFieldPresence::Optional } },
             { "multiTransactionMode", { { js::bool_type }, JsonFieldPresence::Optional } },
-            { "nodeGroups", { { js::obj_type }, JsonFieldPresence::Optional } } },
+            { "nodeGroups", { { js::obj_type }, JsonFieldPresence::Optional } }
+#ifdef MIRAGE
+            ,
+            { "constantGasPrice", { { js::int_type }, JsonFieldPresence::Optional } }
+#endif
+        },
         []( const string& _key ) {
             // function fow allowing fields
             // exception means bad name

--- a/test/unittests/mapreduce_consensus/ConsensusEngine.cpp
+++ b/test/unittests/mapreduce_consensus/ConsensusEngine.cpp
@@ -414,7 +414,11 @@ BOOST_AUTO_TEST_CASE( gasPriceIncrease ) {
     u256 price2 = m_consensus->getPriceForBlockId( 2 );
 
     BOOST_REQUIRE_EQUAL( price0, price1 );
+#ifndef MIRAGE
     BOOST_REQUIRE_GT( price2, price1 );
+#else
+    BOOST_REQUIRE_EQUAL( price2, price1 );
+#endif
 
     // block 3
 
@@ -424,7 +428,11 @@ BOOST_AUTO_TEST_CASE( gasPriceIncrease ) {
     BOOST_REQUIRE_EQUAL( gasPrice, price2 );
     u256 price3 = m_consensus->getPriceForBlockId( 3 );
 
+#ifndef MIRAGE
     BOOST_REQUIRE_LT( price3, price2 );
+#else
+    BOOST_REQUIRE_EQUAL( price3, price2 );
+#endif
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skaled/issues/2151 and https://github.com/skalenetwork/internal-support/issues/1161

add `constantGasPriceAgent` to consensus
gas price value is set via `skaleConfig/sChain/constantGasPrice` config variable