### PR TITLE
IS-1199 Disable Oracle for MIRAGE

### DIFF
--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -1455,6 +1455,8 @@ uint64_t Client::getHistoricRootsDbUsage() const {
 }
 #endif  // HISTORIC_STATE
 
+
+#ifndef MIRAGE
 uint64_t Client::submitOracleRequest(
     const string& _spec, string& _receipt, string& _errorMessage ) {
     assert( m_skaleHost );
@@ -1475,6 +1477,7 @@ uint64_t Client::checkOracleResult( const string& _receipt, string& _result ) {
         throw runtime_error( "Instance of SkaleHost was not properly created." );
     return status;
 }
+#endif
 
 const dev::h256 Client::empty_str_hash =
     dev::h256( "66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925" );

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -369,8 +369,10 @@ public:
     uint64_t getHistoricRootsDbUsage() const;
 #endif  // HISTORIC_STATE
 
+#ifndef MIRAGE
     uint64_t submitOracleRequest( const string& _spec, string& _receipt, string& _errorMessage );
     uint64_t checkOracleResult( const string& _receipt, string& _result );
+#endif
 
     SkaleDebugInterface::handler getDebugHandler() const { return m_debugHandler; }
 

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -898,6 +898,7 @@ std::string SkaleHost::getHistoricNodePublicKey( unsigned _idx ) const {
     return m_client.getHistoricNodePublicKey( _idx );
 }
 
+#ifndef MIRAGE
 uint64_t SkaleHost::submitOracleRequest(
     const string& _spec, string& _receipt, string& _errorMessage ) {
     return m_consensus->submitOracleRequest( _spec, _receipt, _errorMessage );
@@ -906,6 +907,7 @@ uint64_t SkaleHost::submitOracleRequest(
 uint64_t SkaleHost::checkOracleResult( const string& _receipt, string& _result ) {
     return m_consensus->checkOracleResult( _receipt, _result );
 }
+#endif
 
 void SkaleHost::forceEmptyBlock() {
     assert( !this->emptyBlockIntervalMsForRestore.has_value() );

--- a/libethereum/SkaleHost.h
+++ b/libethereum/SkaleHost.h
@@ -143,8 +143,10 @@ public:
     // get public key for historic node in chain
     std::string getHistoricNodePublicKey( unsigned _idx ) const;
 
+#ifndef MIRAGE
     uint64_t submitOracleRequest( const string& _spec, string& _receipt, string& _errorMessage );
     uint64_t checkOracleResult( const string& _receipt, string& _result );
+#endif
 
     void pauseConsensus( bool _pause ) {
         if ( _pause && !m_consensusPaused ) {

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -535,6 +535,7 @@ Json::Value Skale::skale_getDBUsage() {
     return response;
 }
 
+#ifndef MIRAGE
 std::string Skale::oracle_submitRequest( std::string& request ) {
     try {
         if ( m_client.chainParams().nodeInfo.syncNode )
@@ -580,6 +581,7 @@ std::string Skale::oracle_checkResult( std::string& receipt ) {
         throw jsonrpc::JsonRpcException( ORACLE_INTERNAL_SERVER_ERROR, e.what() );
     }
 }
+#endif
 
 #ifdef BITE
 std::string Skale::skale_getCommonPublicKey() {

--- a/libweb3jsonrpc/Skale.h
+++ b/libweb3jsonrpc/Skale.h
@@ -75,8 +75,10 @@ public:
     std::string skale_getLatestBlockNumber() override;
     Json::Value skale_getDBUsage() override;
 
+#ifndef MIRAGE
     std::string oracle_submitRequest( std::string& request ) override;
     std::string oracle_checkResult( std::string& receipt ) override;
+#endif
 
 #ifdef BITE
     std::string skale_getCommonPublicKey() override;

--- a/libweb3jsonrpc/SkaleFace.h
+++ b/libweb3jsonrpc/SkaleFace.h
@@ -80,6 +80,7 @@ class SkaleFace : public ServerInterface< SkaleFace > {
         response = this->skale_getDBUsage();
     }
 
+#ifndef MIRAGE
     inline virtual void oracle_submitRequestI( const Json::Value& request, Json::Value& response ) {
         std::string strRequest = request[0u].asString();
         response = this->oracle_submitRequest( strRequest );
@@ -89,6 +90,8 @@ class SkaleFace : public ServerInterface< SkaleFace > {
         std::string receipt = request[0u].asString();
         response = this->oracle_checkResult( receipt );
     }
+#endif
+
 #ifdef BITE
     inline virtual void skale_getCommonPublicKeyI(
         const Json::Value& request, Json::Value& response ) {
@@ -111,8 +114,11 @@ class SkaleFace : public ServerInterface< SkaleFace > {
     virtual std::string skale_getLatestSnapshotBlockNumber() = 0;
     virtual std::string skale_getLatestBlockNumber() = 0;
     virtual Json::Value skale_getDBUsage() = 0;
+#ifndef MIRAGE
     virtual std::string oracle_submitRequest( std::string& request ) = 0;
     virtual std::string oracle_checkResult( std::string& receipt ) = 0;
+#endif
+
 #ifdef BITE
     virtual std::string skale_getCommonPublicKey() = 0;
     virtual std::string skale_getDecryptedTransactionData( const std::string& request ) = 0;
@@ -152,12 +158,14 @@ public:
         this->bindAndAddMethod( jsonrpc::Procedure( "skale_getDBUsage", jsonrpc::PARAMS_BY_POSITION,
                                     jsonrpc::JSON_INTEGER, NULL ),
             &dev::rpc::SkaleFace::skale_getDBUsageI );
+#ifndef MIRAGE
         this->bindAndAddMethod( jsonrpc::Procedure( "oracle_submitRequest",
                                     jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, NULL ),
             &dev::rpc::SkaleFace::oracle_submitRequestI );
         this->bindAndAddMethod( jsonrpc::Procedure( "oracle_checkResult",
                                     jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, NULL ),
             &dev::rpc::SkaleFace::oracle_checkResultI );
+#endif
 #ifdef BITE
         this->bindAndAddMethod( jsonrpc::Procedure( "skale_getCommonPublicKey",
                                     jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, NULL ),

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -40,7 +40,11 @@
 #include <libweb3jsonrpc/JsonHelper.h>
 #include "SkaledFixture.h"
 #include <libconsensus/SkaleCommon.h>
+
+#ifndef MIRAGE
 #include <libconsensus/oracle/OracleRequestSpec.h>
+#endif
+
 #include "genesisGeneration2Config.h"
 #include <libweb3jsonrpc/Debug.h>
 #include <libweb3jsonrpc/Eth.h>
@@ -3171,6 +3175,7 @@ BOOST_AUTO_TEST_CASE( setSchainExitTime ) {
         fixture.rpcClient->setSchainExitTime( requestJson ), jsonrpc::JsonRpcException );
 }
 
+#ifndef MIRAGE
 /*
 BOOST_AUTO_TEST_CASE( oracle, *boost::unit_test::disabled() ) {
 
@@ -3199,6 +3204,7 @@ current, i); auto os = make_shared<OracleRequestSpec>(request); if ( os->verifyP
 
 
 }*/
+#endif
 
 BOOST_AUTO_TEST_CASE( doDbCompactionDebugCall ) {
     JsonRpcFixture fixture;


### PR DESCRIPTION
## Description
- Oracle was disabled for MIRAGE build. 

## Tests

- "Deleting" the code (disabling for MIRAGE build) covered by existing unit tests and the fact that the build was successful. 

## Performance Impact

- No performance related changes were made. 
