### PR TITLE
Disable config controller MIRAGE

### DIFF
--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -179,13 +179,13 @@ public:
     std::vector< NodeGroup > nodeGroups;
 #ifndef MIRAGE
     s256 contractStorageLimit = 1000000000;
+    bool freeContractDeployment = false;
 #endif
     uint64_t dbStorageLimit = 0;
     uint64_t consensusStorageLimit = 5000000000;  // default consensus storage limit
     int snapshotIntervalSec = -1;
     time_t snapshotDownloadTimeout = 3600;
     time_t snapshotDownloadInactiveTimeout = 60;
-    bool freeContractDeployment = false;
     bool multiTransactionMode = false;
     int emptyBlockIntervalMs = -1;
     int64_t levelDBReopenIntervalMs = -1;

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -179,7 +179,6 @@ public:
     std::vector< NodeGroup > nodeGroups;
 #ifndef MIRAGE
     s256 contractStorageLimit = 1000000000;
-    bool freeContractDeployment = false;
 #endif
     uint64_t dbStorageLimit = 0;
     uint64_t consensusStorageLimit = 5000000000;  // default consensus storage limit

--- a/libethcore/Common.cpp
+++ b/libethcore/Common.cpp
@@ -61,7 +61,9 @@ const bytes c_blockhashContractCode( fromHex(
     "a75761010083019250610100820491506101008104905061006d565b610100811215156100bd57600060a052602060"
     "a0f35b610100820683015460c052602060c0f350506100df565b600060e052602060e0f35b5b50" ) );
 
+#ifndef MIRAGE
 const Address c_configControllerContractAddress( "D2002000000000000000000000000000000000D2" );
+#endif
 
 Address toAddress( std::string const& _s ) {
     try {

--- a/libethcore/Common.h
+++ b/libethcore/Common.h
@@ -55,8 +55,10 @@ extern const Address c_blockhashContractAddress;
 /// Code of the special contract for block hash storage defined in EIP96
 extern const bytes c_blockhashContractCode;
 
+#ifndef MIRAGE
 /// Address of the special contract for deployment control
 extern const Address c_configControllerContractAddress;
+#endif
 
 /// Generating call data for deployment control contract
 bytes isAddressWhitelistedCallData( Address const& _deployer );

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -309,6 +309,9 @@ void ChainParams::processSkaleConfigItems( ChainParams& cp, json_spirit::mObject
     s.contractStorageLimit = sChainObj.count( "contractStorageLimit" ) ?
                                  sChainObj.at( "contractStorageLimit" ).get_int64() :
                                  0;
+
+    if ( sChainObj.count( "freeContractDeployment" ) )
+        s.freeContractDeployment = sChainObj.at( "freeContractDeployment" ).get_bool();
 #endif
 
     s.dbStorageLimit =
@@ -318,9 +321,6 @@ void ChainParams::processSkaleConfigItems( ChainParams& cp, json_spirit::mObject
     if ( sChainObj.count( "maxConsensusStorageBytes" ) ) {
         s.consensusStorageLimit = sChainObj.at( "maxConsensusStorageBytes" ).get_int64();
     }
-
-    if ( sChainObj.count( "freeContractDeployment" ) )
-        s.freeContractDeployment = sChainObj.at( "freeContractDeployment" ).get_bool();
 
     if ( sChainObj.count( "multiTransactionMode" ) )
         s.multiTransactionMode = sChainObj.at( "multiTransactionMode" ).get_bool();
@@ -607,9 +607,9 @@ const std::string& ChainParams::getOriginalJson() const {
     sChainObj["schainID"] = ( int64_t ) sChain.id;
     sChainObj["emptyBlockIntervalMs"] = sChain.emptyBlockIntervalMs;
     sChainObj["snpshotIntervalMs"] = sChain.snapshotIntervalSec;
-    sChainObj["freeContractDeployment"] = sChain.freeContractDeployment;
     sChainObj["multiTransactionMode"] = sChain.multiTransactionMode;
 #ifndef MIRAGE
+    sChainObj["freeContractDeployment"] = sChain.freeContractDeployment;
     sChainObj["contractStorageLimit"] = ( int64_t ) sChain.contractStorageLimit;
 #endif
     sChainObj["dbStorageLimit"] = sChain.dbStorageLimit;

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -309,9 +309,6 @@ void ChainParams::processSkaleConfigItems( ChainParams& cp, json_spirit::mObject
     s.contractStorageLimit = sChainObj.count( "contractStorageLimit" ) ?
                                  sChainObj.at( "contractStorageLimit" ).get_int64() :
                                  0;
-
-    if ( sChainObj.count( "freeContractDeployment" ) )
-        s.freeContractDeployment = sChainObj.at( "freeContractDeployment" ).get_bool();
 #endif
 
     s.dbStorageLimit =
@@ -609,7 +606,6 @@ const std::string& ChainParams::getOriginalJson() const {
     sChainObj["snpshotIntervalMs"] = sChain.snapshotIntervalSec;
     sChainObj["multiTransactionMode"] = sChain.multiTransactionMode;
 #ifndef MIRAGE
-    sChainObj["freeContractDeployment"] = sChain.freeContractDeployment;
     sChainObj["contractStorageLimit"] = ( int64_t ) sChain.contractStorageLimit;
 #endif
     sChainObj["dbStorageLimit"] = sChain.dbStorageLimit;

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -487,6 +487,7 @@ bool Executive::go( OnOpFunc const& _onOp ) {
             // Create VM instance. Force Interpreter if tracing requested.
             auto vm = VMFactory::create();
             if ( m_isCreation ) {
+#ifndef MIRAGE
                 // Checking whether deployment is allowed via ConfigController contract
                 bytes calldata;
                 if ( FlexibleDeploymentPatch::isEnabledWhen(
@@ -504,7 +505,7 @@ bool Executive::go( OnOpFunc const& _onOp ) {
                 if ( !deploymentCallOutput.empty() && u256( deploymentCallOutput ) == 0 ) {
                     BOOST_THROW_EXCEPTION( InvalidContractDeployer() );
                 }
-
+#endif
                 auto out = vm->exec( m_gas, *m_ext, _onOp );
                 if ( m_res ) {
                     m_res->gasForDeposit = m_gas;

--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -268,8 +268,6 @@ void validateConfigJson( js::mObject const& _obj ) {
             { "rotateAfterBlock", { { js::int_type }, JsonFieldPresence::Optional } },
 #ifndef MIRAGE
             { "contractStorageLimit", { { js::int_type }, JsonFieldPresence::Optional } },
-            { "freeContractDeployment", { { js::bool_type }, JsonFieldPresence::Optional } },
-
 #endif
             { "dbStorageLimit", { { js::int_type }, JsonFieldPresence::Optional } },
             { "nodes", { { js::array_type }, JsonFieldPresence::Required } },

--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -268,6 +268,8 @@ void validateConfigJson( js::mObject const& _obj ) {
             { "rotateAfterBlock", { { js::int_type }, JsonFieldPresence::Optional } },
 #ifndef MIRAGE
             { "contractStorageLimit", { { js::int_type }, JsonFieldPresence::Optional } },
+            { "freeContractDeployment", { { js::bool_type }, JsonFieldPresence::Optional } },
+
 #endif
             { "dbStorageLimit", { { js::int_type }, JsonFieldPresence::Optional } },
             { "nodes", { { js::array_type }, JsonFieldPresence::Required } },
@@ -275,7 +277,6 @@ void validateConfigJson( js::mObject const& _obj ) {
             { "maxFileStorageBytes", { { js::int_type }, JsonFieldPresence::Optional } },
             { "maxReservedStorageBytes", { { js::int_type }, JsonFieldPresence::Optional } },
             { "maxSkaledLeveldbStorageBytes", { { js::int_type }, JsonFieldPresence::Optional } },
-            { "freeContractDeployment", { { js::bool_type }, JsonFieldPresence::Optional } },
             { "multiTransactionMode", { { js::bool_type }, JsonFieldPresence::Optional } },
             { "nodeGroups", { { js::obj_type }, JsonFieldPresence::Optional } }
 #ifdef MIRAGE

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -1021,10 +1021,17 @@ BOOST_AUTO_TEST_CASE( deploy_contract_not_from_owner ) {
     dev::eth::mineTransaction( *( fixture.client ), 1 );
 
     Json::Value receipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
+#ifdef MIRAGE
+    BOOST_CHECK_EQUAL( receipt["status"], string( "0x1" ) );
+    Json::Value code =
+        fixture.rpcClient->eth_getCode( receipt["contractAddress"].asString(), "latest" );
+    BOOST_REQUIRE( code.asString() == "0x608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063b3de648b146044575b600080fd5b3415604e57600080fd5b606a600480360381019080803590602001909291905050506080565b6040518082815260200191505060405180910390f35b60006007820290509190505600a165627a7a72305820f294e834212334e2978c6dd090355312a3f0f9476b8eb98fb480406fc2728a960029" );
+#else
     BOOST_CHECK_EQUAL( receipt["status"], string( "0x0" ) );
     Json::Value code =
         fixture.rpcClient->eth_getCode( receipt["contractAddress"].asString(), "latest" );
     BOOST_REQUIRE( code.asString() == "0x" );
+#endif
 }
 
 BOOST_AUTO_TEST_CASE( deploy_contract_without_controller ) {
@@ -1071,6 +1078,7 @@ BOOST_AUTO_TEST_CASE( deploy_contract_without_controller ) {
     BOOST_REQUIRE( code.asString().substr( 2 ) == compiled.substr( 58 ) );
 }
 
+#ifndef MIRAGE
 BOOST_AUTO_TEST_CASE( deploy_contract_with_controller ) {
     JsonRpcFixture fixture( c_genesisConfigString, false );
     auto senderAddress = fixture.coinbase.address();
@@ -1107,6 +1115,8 @@ BOOST_AUTO_TEST_CASE( deploy_contract_with_controller ) {
         fixture.rpcClient->eth_getCode( receipt["contractAddress"].asString(), "latest" );
     BOOST_REQUIRE( code.asString() == "0x" );
 }
+#endif
+
 
 BOOST_AUTO_TEST_CASE( create_opcode ) {
     JsonRpcFixture fixture( c_genesisConfigString );


### PR DESCRIPTION
## Description

- Disable config controller for MIRAGE build
- Remove deprecated freeContractDeployment config option from entire codebase

## Tests

- Modified existing unit tests
- Tested locally 

## Performance Impact

- No performance related changes were made 