### PR TITLE
Feature/1845 chain params non copyable

### DIFF
--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -133,7 +133,7 @@ void Ethash::verify( Strictness _s, BlockHeader const& _bi, BlockHeader const& _
 u256 Ethash::childGasLimit( BlockHeader const& _bi, u256 const& _gasFloorTarget ) const {
     u256 gasFloorTarget = _gasFloorTarget == Invalid256 ? 3141562 : _gasFloorTarget;
     u256 gasLimit = _bi.gasLimit();
-    u256 boundDivisor = chainParams().gasLimitBoundDivisor;
+    u256 boundDivisor = chainParams().getGasLimitBoundDivisor();
     if ( gasLimit < gasFloorTarget )
         return min< u256 >( gasFloorTarget, gasLimit + gasLimit / boundDivisor - 1 );
     else
@@ -150,12 +150,12 @@ u256 Ethash::calculateDifficulty( BlockHeader const& _bi, BlockHeader const& _pa
 
     if ( !_bi.number() )
         throw GenesisBlockCannotBeCalculated();
-    auto const& minimumDifficulty = chainParams().minimumDifficulty;
-    auto const& difficultyBoundDivisor = chainParams().difficultyBoundDivisor;
-    auto const& durationLimit = chainParams().durationLimit;
+    auto const& minimumDifficulty = chainParams().getMinimumDifficulty();
+    auto const& difficultyBoundDivisor = chainParams().getDifficultyBoundDivisor();
+    auto const& durationLimit = chainParams().getDurationLimit();
 
     bigint target;  // stick to a bigint for the target. Don't want to risk going negative.
-    if ( _bi.number() < chainParams().homesteadForkBlock )
+    if ( _bi.number() < chainParams().getHomesteadForkBlock() )
         // Frontier-era difficulty adjustment
         target = _bi.timestamp() >= _parent.timestamp() + durationLimit ?
                      _parent.difficulty() - ( _parent.difficulty() / difficultyBoundDivisor ) :
@@ -163,7 +163,7 @@ u256 Ethash::calculateDifficulty( BlockHeader const& _bi, BlockHeader const& _pa
     else {
         bigint const timestampDiff = bigint( _bi.timestamp() ) - _parent.timestamp();
         bigint const adjFactor =
-            _bi.number() < chainParams().byzantiumForkBlock ?
+            _bi.number() < chainParams().getByzantiumForkBlock() ?
                 max< bigint >( 1 - timestampDiff / 10, -99 ) :  // Homestead-era difficulty
                                                                   // adjustment
                 max< bigint >( ( _parent.hasUncles() ? 2 : 1 ) - timestampDiff / 9,
@@ -176,14 +176,14 @@ u256 Ethash::calculateDifficulty( BlockHeader const& _bi, BlockHeader const& _pa
     unsigned exponentialIceAgeBlockNumber = unsigned( _parent.number() + 1 );
 
     // EIP-1234 Constantinople Ice Age delay
-    if ( _bi.number() >= chainParams().constantinopleForkBlock ) {
+    if ( _bi.number() >= chainParams().getConstantinopleForkBlock() ) {
         if ( exponentialIceAgeBlockNumber >= 5000000 )
             exponentialIceAgeBlockNumber -= 5000000;
         else
             exponentialIceAgeBlockNumber = 0;
     }
     // EIP-649 Byzantium Ice Age delay
-    else if ( _bi.number() >= chainParams().byzantiumForkBlock ) {
+    else if ( _bi.number() >= chainParams().getByzantiumForkBlock() ) {
         if ( exponentialIceAgeBlockNumber >= 3000000 )
             exponentialIceAgeBlockNumber -= 3000000;
         else
@@ -202,7 +202,7 @@ u256 Ethash::calculateDifficulty( BlockHeader const& _bi, BlockHeader const& _pa
 void Ethash::populateFromParent( BlockHeader& _bi, BlockHeader const& _parent ) const {
     SealEngineFace::populateFromParent( _bi, _parent );
     _bi.setDifficulty( calculateDifficulty( _bi, _parent ) );
-    _bi.setGasLimit( childGasLimit( _parent, chainParams().minGasLimit ) );
+    _bi.setGasLimit( childGasLimit( _parent, chainParams().getMinGasLimit() ) );
 }
 
 bool Ethash::quickVerifySeal( BlockHeader const& _blockHeader ) const {

--- a/libethashseal/EthashClient.cpp
+++ b/libethashseal/EthashClient.cpp
@@ -43,7 +43,7 @@ EthashClient* dev::eth::asEthashClient( Interface* _c ) {
 
 DEV_SIMPLE_EXCEPTION( ChainParamsNotEthash );
 
-EthashClient::EthashClient( ChainParams const& _params, int _networkID,
+EthashClient::EthashClient( std::shared_ptr< const ChainParams > _params, int _networkID,
     std::shared_ptr< GasPricer > _gpForAdoption,
     std::shared_ptr< SnapshotManager > _snapshotManager,
     std::shared_ptr< InstanceMonitor > _instanceMonitor, fs::path const& _dbPath,

--- a/libethashseal/EthashClient.h
+++ b/libethashseal/EthashClient.h
@@ -37,7 +37,7 @@ DEV_SIMPLE_EXCEPTION( InvalidSealEngine );
 class EthashClient : public Client {
 public:
     /// Trivial forwarding constructor.
-    EthashClient( ChainParams const& _params, int _networkID,
+    EthashClient( std::shared_ptr< const ChainParams > _params, int _networkID,
         std::shared_ptr< GasPricer > _gpForAdoption,
         std::shared_ptr< SnapshotManager > _snapshotManager,
         std::shared_ptr< InstanceMonitor > _instanceMonitor,

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -38,7 +38,19 @@
 #include "libethcore/Common.h"
 #include "libethcore/EVMSchedule.h"
 
+class TestClientFixture;
+struct SkaleHostFixture;
+class ConsensusExtFaceFixture;
+class SingleNodeConsensusFixture;
+namespace  {
+struct SnapshotHashingFixture;
+struct JsonRpcFixture;
+}
+
 namespace dev {
+namespace test {
+class SnapshotHashAgentTest;
+}
 namespace eth {
 
 class PrecompiledContract {
@@ -87,6 +99,7 @@ public:
     std::string name;
     u256 id;
     std::string ip;
+
     uint16_t port;
     std::string ip6;
     uint16_t port6;
@@ -221,18 +234,18 @@ public:
     }
 };
 
-
 struct ChainOperationParams {
     ChainOperationParams();
 
+    friend class ::TestClientFixture;
+    friend struct ::SnapshotHashingFixture;
+    friend struct ::JsonRpcFixture;
+    friend struct ::SkaleHostFixture;
+    friend class ::ConsensusExtFaceFixture;
+    friend class ::SingleNodeConsensusFixture;
+    friend class dev::test::SnapshotHashAgentTest;
+
     explicit operator bool() const { return accountStartNonce != Invalid256; }
-
-    /// The chain sealer name: e.g. Ethash, NoProof, BasicAuthority
-    std::string sealEngineName = "NoProof";
-
-    /// General chain params.
-private:
-    u256 m_blockReward;
 
 public:
     EVMSchedule const makeEvmSchedule(
@@ -240,6 +253,80 @@ public:
     u256 blockReward( EVMSchedule const& _schedule ) const;
     u256 blockReward( time_t _committedBlockTimestamp, u256 const& _workingBlockNumber ) const;
     void setBlockReward( u256 const& _newBlockReward );
+
+    time_t getPatchTimestamp( SchainPatchEnum _patchEnum ) const;
+
+    bool isPrecompiled( Address const& _a, u256 const& _blockNumber ) const {
+        return precompiled.count( _a ) != 0 && _blockNumber >= precompiled.at( _a ).startingBlock();
+    }
+    bigint costOfPrecompiled(
+        Address const& _a, bytesConstRef _in, u256 const& _blockNumber ) const {
+        return precompiled.at( _a ).cost( _in, *this, _blockNumber );
+    }
+    std::pair< bool, bytes > executePrecompiled( Address const& _a, bytesConstRef _in, u256 const&,
+        skale::OverlayFS* _overlayFS = nullptr ) const {
+        return precompiled.at( _a ).execute( _in, _overlayFS );
+    }
+    bool precompiledExecutionAllowedFrom(
+        Address const& _a, Address const& _from, bool _readOnly ) const {
+        return precompiled.at( _a ).executionAllowedFrom( _from, _readOnly );
+    }
+
+    const PrecompiledContract& getPrecompiledContract( const dev::Address& _a ) const {
+        return precompiled.at( _a );
+    }
+
+    // SETTERS
+
+    void setExperimentalForkBlock( u256 _bn ) { experimentalForkBlock = _bn; }
+
+    void setHomesteadForkBlock( u256 _bn ) { homesteadForkBlock = _bn; }
+
+    void setByzantiumForkBlock( u256 _bn ) { byzantiumForkBlock = _bn; }
+
+    // GENERAL CHAIN GETTERS
+
+    uint64_t getChainId() const { return chainID; }
+
+    std::string getSealEngineName() const { return sealEngineName; }
+
+    u256 getGasLimitBoundDivisor() const { return gasLimitBoundDivisor; }
+
+    u256 getMinimumDifficulty() const { return minimumDifficulty; }
+
+    u256 getDifficultyBoundDivisor() const { return difficultyBoundDivisor; }
+
+    u256 getDurationLimit() const { return durationLimit; }
+
+    u256 getMinGasLimit() const { return minGasLimit; }
+
+    u256 getMaxGasLimit() const { return maxGasLimit; }
+
+    u256 getMaximumExtraDataSize() const { return maximumExtraDataSize; }
+
+    u256 getHomesteadForkBlock() const { return homesteadForkBlock; }
+
+    u256 getByzantiumForkBlock() const { return byzantiumForkBlock; }
+
+    u256 getConstantinopleForkBlock() const { return constantinopleForkBlock; }
+
+    u256 getExperimentalForkBlock() const { return experimentalForkBlock; }
+
+    u256 getIstanbulForkBlock() const { return istanbulForkBlock; }
+
+    u256 getEIP158ForkBlock() const { return EIP158ForkBlock; }
+
+    u256 getDaoHardforkBlock() const { return daoHardforkBlock; }
+
+    bool isChainIdCheckEnabled() const { return !skaleDisableChainIdCheck; }
+
+    /// General chain params.
+protected:
+    /// The chain sealer name: e.g. Ethash, NoProof, BasicAuthority
+    std::string sealEngineName = "NoProof";
+
+    u256 m_blockReward;
+
     u256 maximumExtraDataSize = 1024;
     u256 accountStartNonce = 0;
     bool tieBreakingGas = true;
@@ -284,25 +371,7 @@ public:
     u256 externalGasDifficulty = ~u256( 0 );
     typedef std::vector< std::string > vecAdminOrigins_t;
     vecAdminOrigins_t vecAdminOrigins;  // wildcard based folters for IP addresses
-    int getLogsBlocksLimit = -1;
-
-    time_t getPatchTimestamp( SchainPatchEnum _patchEnum ) const;
-
-    bool isPrecompiled( Address const& _a, u256 const& _blockNumber ) const {
-        return precompiled.count( _a ) != 0 && _blockNumber >= precompiled.at( _a ).startingBlock();
-    }
-    bigint costOfPrecompiled(
-        Address const& _a, bytesConstRef _in, u256 const& _blockNumber ) const {
-        return precompiled.at( _a ).cost( _in, *this, _blockNumber );
-    }
-    std::pair< bool, bytes > executePrecompiled( Address const& _a, bytesConstRef _in, u256 const&,
-        skale::OverlayFS* _overlayFS = nullptr ) const {
-        return precompiled.at( _a ).execute( _in, _overlayFS );
-    }
-    bool precompiledExecutionAllowedFrom(
-        Address const& _a, Address const& _from, bool _readOnly ) const {
-        return precompiled.at( _a ).executionAllowedFrom( _from, _readOnly );
-    }
+    int logsBlocksLimit = -1;
 };
 
 }  // namespace eth

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -42,15 +42,15 @@ class TestClientFixture;
 struct SkaleHostFixture;
 class ConsensusExtFaceFixture;
 class SingleNodeConsensusFixture;
-namespace  {
+namespace {
 struct SnapshotHashingFixture;
 struct JsonRpcFixture;
-}
+}  // namespace
 
 namespace dev {
 namespace test {
 class SnapshotHashAgentTest;
-}
+}  // namespace test
 namespace eth {
 
 class PrecompiledContract {

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -320,7 +320,7 @@ public:
 
     u256 getDaoHardforkBlock() const { return daoHardforkBlock; }
 
-    bool isChainIdCheckEnabled() const { return !skaleDisableChainIdCheck; }
+    bool isChainIdCheckDisabled() const { return skaleDisableChainIdCheck; }
 
     /// General chain params.
 protected:

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -45,6 +45,7 @@ class SingleNodeConsensusFixture;
 namespace {
 struct SnapshotHashingFixture;
 struct JsonRpcFixture;
+class InstructionTestFixture;
 }  // namespace
 
 namespace dev {
@@ -243,6 +244,7 @@ struct ChainOperationParams {
     friend struct ::SkaleHostFixture;
     friend class ::ConsensusExtFaceFixture;
     friend class ::SingleNodeConsensusFixture;
+    friend class ::InstructionTestFixture;
     friend class dev::test::SnapshotHashAgentTest;
 
     explicit operator bool() const { return accountStartNonce != Invalid256; }
@@ -276,7 +278,7 @@ public:
         return precompiled.at( _a );
     }
 
-    // SETTERS
+    // SETTERS, mostly for tests
 
     void setExperimentalForkBlock( u256 _bn ) { experimentalForkBlock = _bn; }
 

--- a/libethcore/SealEngine.cpp
+++ b/libethcore/SealEngine.cpp
@@ -151,7 +151,7 @@ void SealEngineFace::verifyTransaction( ChainOperationParams const& _chainParams
     if ( _ir & ImportRequirements::TransactionSignatures ) {
         if ( _header.number() >= _chainParams.getEIP158ForkBlock() ) {
             uint64_t chainID = _chainParams.getChainId();
-            _t.checkChainId( chainID, _chainParams.isChainIdCheckEnabled() );
+            _t.checkChainId( chainID, !_chainParams.isChainIdCheckEnabled() );
         }  // if
     }
 }

--- a/libethcore/SealEngine.cpp
+++ b/libethcore/SealEngine.cpp
@@ -151,7 +151,7 @@ void SealEngineFace::verifyTransaction( ChainOperationParams const& _chainParams
     if ( _ir & ImportRequirements::TransactionSignatures ) {
         if ( _header.number() >= _chainParams.getEIP158ForkBlock() ) {
             uint64_t chainID = _chainParams.getChainId();
-            _t.checkChainId( chainID, !_chainParams.isChainIdCheckEnabled() );
+            _t.checkChainId( chainID, _chainParams.isChainIdCheckDisabled() );
         }  // if
     }
 }

--- a/libethcore/SealEngine.cpp
+++ b/libethcore/SealEngine.cpp
@@ -40,29 +40,29 @@ void SealEngineFace::verify( Strictness _s, BlockHeader const& _bi, BlockHeader 
     _bi.verify( _s, _parent, _block );
 
     if ( _s != CheckNothingNew ) {
-        if ( _bi.difficulty() < chainParams().minimumDifficulty )
+        if ( _bi.difficulty() < chainParams().getMinimumDifficulty() )
             BOOST_THROW_EXCEPTION(
                 InvalidDifficulty() << RequirementError(
-                    bigint( chainParams().minimumDifficulty ), bigint( _bi.difficulty() ) ) );
+                    bigint( chainParams().getMinimumDifficulty() ), bigint( _bi.difficulty() ) ) );
 
-        if ( _bi.gasLimit() < chainParams().minGasLimit )
+        if ( _bi.gasLimit() < chainParams().getMinGasLimit() )
             BOOST_THROW_EXCEPTION(
                 InvalidGasLimit() << RequirementError(
-                    bigint( chainParams().minGasLimit ), bigint( _bi.gasLimit() ) ) );
+                    bigint( chainParams().getMinGasLimit() ), bigint( _bi.gasLimit() ) ) );
 
-        if ( _bi.gasLimit() > chainParams().maxGasLimit )
+        if ( _bi.gasLimit() > chainParams().getMaxGasLimit() )
             BOOST_THROW_EXCEPTION(
                 InvalidGasLimit() << RequirementError(
-                    bigint( chainParams().maxGasLimit ), bigint( _bi.gasLimit() ) ) );
+                    bigint( chainParams().getMaxGasLimit() ), bigint( _bi.gasLimit() ) ) );
 
-        if ( _bi.number() && _bi.extraData().size() > chainParams().maximumExtraDataSize ) {
+        if ( _bi.number() && _bi.extraData().size() > chainParams().getMaximumExtraDataSize() ) {
             BOOST_THROW_EXCEPTION(
-                ExtraDataTooBig() << RequirementError( bigint( chainParams().maximumExtraDataSize ),
+                ExtraDataTooBig() << RequirementError( bigint( chainParams().getMaximumExtraDataSize() ),
                                          bigint( _bi.extraData().size() ) )
                                   << errinfo_extraData( _bi.extraData() ) );
         }
 
-        u256 const& daoHardfork = chainParams().daoHardforkBlock;
+        u256 const& daoHardfork = chainParams().getDaoHardforkBlock();
         if ( daoHardfork != 0 && daoHardfork + 9 >= daoHardfork && _bi.number() >= daoHardfork &&
              _bi.number() <= daoHardfork + 9 )
             if ( _bi.extraData() != fromHex( "0x64616f2d686172642d666f726b" ) )
@@ -74,18 +74,18 @@ void SealEngineFace::verify( Strictness _s, BlockHeader const& _bi, BlockHeader 
     if ( _parent ) {
         auto gasLimit = _bi.gasLimit();
         auto parentGasLimit = _parent.gasLimit();
-        if ( gasLimit < chainParams().minGasLimit || gasLimit > chainParams().maxGasLimit ||
-             gasLimit <= parentGasLimit - parentGasLimit / chainParams().gasLimitBoundDivisor ||
-             gasLimit >= parentGasLimit + parentGasLimit / chainParams().gasLimitBoundDivisor )
+        if ( gasLimit < chainParams().getMinGasLimit() || gasLimit > chainParams().getMaxGasLimit() ||
+             gasLimit <= parentGasLimit - parentGasLimit / chainParams().getGasLimitBoundDivisor() ||
+             gasLimit >= parentGasLimit + parentGasLimit / chainParams().getGasLimitBoundDivisor() )
             BOOST_THROW_EXCEPTION(
                 InvalidGasLimit()
                 << errinfo_min( static_cast< bigint >(
                        static_cast< bigint >( parentGasLimit ) -
                        static_cast< bigint >(
-                           parentGasLimit / chainParams().gasLimitBoundDivisor ) ) )
+                           parentGasLimit / chainParams().getGasLimitBoundDivisor() ) ) )
                 << errinfo_got( static_cast< bigint >( gasLimit ) )
                 << errinfo_max( static_cast< bigint >( static_cast< bigint >(
-                       parentGasLimit + parentGasLimit / chainParams().gasLimitBoundDivisor ) ) ) );
+                       parentGasLimit + parentGasLimit / chainParams().getGasLimitBoundDivisor() ) ) ) );
     }
     MICROPROFILE_LEAVE();
 }
@@ -109,22 +109,22 @@ void SealEngineFace::verifyTransaction( ChainOperationParams const& _chainParams
 
     MICROPROFILE_SCOPEI( "SealEngineFace", "verifyTransaction", MP_ORCHID );
     if ( ( _ir & ImportRequirements::TransactionSignatures ) &&
-         _header.number() < _chainParams.EIP158ForkBlock && _t.isReplayProtected() )
+         _header.number() < _chainParams.getEIP158ForkBlock() && _t.isReplayProtected() )
         BOOST_THROW_EXCEPTION( InvalidSignature() );
 
     if ( ( _ir & ImportRequirements::TransactionSignatures ) &&
-         _header.number() < _chainParams.experimentalForkBlock && _t.hasZeroSignature() )
+         _header.number() < _chainParams.getExperimentalForkBlock() && _t.hasZeroSignature() )
         BOOST_THROW_EXCEPTION( InvalidSignature() );
 
     if ( ( _ir & ImportRequirements::TransactionBasic ) &&
-         _header.number() >= _chainParams.experimentalForkBlock && _t.hasZeroSignature() &&
+         _header.number() >= _chainParams.getExperimentalForkBlock() && _t.hasZeroSignature() &&
          ( _t.value() != 0 || _t.gasPrice() != 0 || _t.nonce() != 0 ) )
         BOOST_THROW_EXCEPTION( InvalidZeroSignatureTransaction()
                                << errinfo_got( static_cast< bigint >( _t.gasPrice() ) )
                                << errinfo_got( static_cast< bigint >( _t.value() ) )
                                << errinfo_got( static_cast< bigint >( _t.nonce() ) ) );
 
-    if ( _header.number() >= _chainParams.homesteadForkBlock &&
+    if ( _header.number() >= _chainParams.getHomesteadForkBlock() &&
          ( _ir & ImportRequirements::TransactionSignatures ) && _t.hasSignature() )
         _t.checkLowS();
 
@@ -145,15 +145,15 @@ void SealEngineFace::verifyTransaction( ChainOperationParams const& _chainParams
                                    string( "_gasUsed + (bigint)_t.gas() > _header.gasLimit()" ) ) );
 
     if ( _ir & ImportRequirements::TransactionSignatures ) {
-        if ( _header.number() >= _chainParams.EIP158ForkBlock ) {
-            uint64_t chainID = _chainParams.chainID;
-            _t.checkChainId( chainID, _chainParams.skaleDisableChainIdCheck );
+        if ( _header.number() >= _chainParams.getEIP158ForkBlock() ) {
+            uint64_t chainID = _chainParams.getChainId();
+            _t.checkChainId( chainID, _chainParams.isChainIdCheckEnabled() );
         }  // if
     }
 }
 
 SealEngineFace* SealEngineRegistrar::create( ChainOperationParams const& _params ) {
-    SealEngineFace* ret = create( _params.sealEngineName );
+    SealEngineFace* ret = create( _params.getSealEngineName() );
     assert( ret && "Seal engine not found." );
     if ( ret )
         ret->setChainParams( _params );

--- a/libethcore/SealEngine.cpp
+++ b/libethcore/SealEngine.cpp
@@ -56,10 +56,11 @@ void SealEngineFace::verify( Strictness _s, BlockHeader const& _bi, BlockHeader 
                     bigint( chainParams().getMaxGasLimit() ), bigint( _bi.gasLimit() ) ) );
 
         if ( _bi.number() && _bi.extraData().size() > chainParams().getMaximumExtraDataSize() ) {
-            BOOST_THROW_EXCEPTION(
-                ExtraDataTooBig() << RequirementError( bigint( chainParams().getMaximumExtraDataSize() ),
-                                         bigint( _bi.extraData().size() ) )
-                                  << errinfo_extraData( _bi.extraData() ) );
+            BOOST_THROW_EXCEPTION( ExtraDataTooBig()
+                                   << RequirementError(
+                                          bigint( chainParams().getMaximumExtraDataSize() ),
+                                          bigint( _bi.extraData().size() ) )
+                                   << errinfo_extraData( _bi.extraData() ) );
         }
 
         u256 const& daoHardfork = chainParams().getDaoHardforkBlock();
@@ -74,8 +75,10 @@ void SealEngineFace::verify( Strictness _s, BlockHeader const& _bi, BlockHeader 
     if ( _parent ) {
         auto gasLimit = _bi.gasLimit();
         auto parentGasLimit = _parent.gasLimit();
-        if ( gasLimit < chainParams().getMinGasLimit() || gasLimit > chainParams().getMaxGasLimit() ||
-             gasLimit <= parentGasLimit - parentGasLimit / chainParams().getGasLimitBoundDivisor() ||
+        if ( gasLimit < chainParams().getMinGasLimit() ||
+             gasLimit > chainParams().getMaxGasLimit() ||
+             gasLimit <=
+                 parentGasLimit - parentGasLimit / chainParams().getGasLimitBoundDivisor() ||
              gasLimit >= parentGasLimit + parentGasLimit / chainParams().getGasLimitBoundDivisor() )
             BOOST_THROW_EXCEPTION(
                 InvalidGasLimit()
@@ -85,7 +88,8 @@ void SealEngineFace::verify( Strictness _s, BlockHeader const& _bi, BlockHeader 
                            parentGasLimit / chainParams().getGasLimitBoundDivisor() ) ) )
                 << errinfo_got( static_cast< bigint >( gasLimit ) )
                 << errinfo_max( static_cast< bigint >( static_cast< bigint >(
-                       parentGasLimit + parentGasLimit / chainParams().getGasLimitBoundDivisor() ) ) ) );
+                       parentGasLimit +
+                       parentGasLimit / chainParams().getGasLimitBoundDivisor() ) ) ) );
     }
     MICROPROFILE_LEAVE();
 }

--- a/libethcore/SealEngine.h
+++ b/libethcore/SealEngine.h
@@ -100,21 +100,20 @@ public:
         time_t _committedBlockTimestamp, u256 const& _workingBlockNumber ) const = 0;
 
     virtual bool isPrecompiled( Address const& _a, u256 const& _blockNumber ) const {
-        return m_params.precompiled.count( _a ) != 0 &&
-               _blockNumber >= m_params.precompiled.at( _a ).startingBlock();
+        return m_params.isPrecompiled( _a, _blockNumber );
     }
     virtual bigint costOfPrecompiled(
         Address const& _a, bytesConstRef _in, u256 const& _blockNumber ) const {
-        return m_params.precompiled.at( _a ).cost( _in, m_params, _blockNumber );
+        return m_params.getPrecompiledContract( _a ).cost( _in, m_params, _blockNumber );
     }
     virtual std::pair< bool, bytes > executePrecompiled(
         Address const& _a, bytesConstRef _in, u256 const& ) const {
-        return m_params.precompiled.at( _a ).execute( _in );
+        return m_params.getPrecompiledContract( _a ).execute( _in );
     }
 
     virtual bool precompiledExecutionAllowedFrom(
         Address const& _a, Address const& _from, bool _readOnly ) const {
-        return m_params.precompiled.at( _a ).executionAllowedFrom( _from, _readOnly );
+        return m_params.precompiledExecutionAllowedFrom( _a, _from, _readOnly );
     }
 
 protected:

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -573,7 +573,8 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
         auto reward = _bc.sealEngine()->blockReward( blockTimestamp, m_currentBlock.number() );
         rewardBlockAuthorForNonDefaultBlock( reward );
         m_state.safeSetLastRewardedBlockNumber( m_currentBlock.number() );
-        bool removeEmptyAccounts = m_currentBlock.number() >= _bc.chainParams().getEIP158ForkBlock();
+        bool removeEmptyAccounts =
+            m_currentBlock.number() >= _bc.chainParams().getEIP158ForkBlock();
         m_state.commit( removeEmptyAccounts ? dev::eth::CommitBehaviour::RemoveEmptyAccounts :
                                               dev::eth::CommitBehaviour::KeepEmptyAccounts );
     }
@@ -944,8 +945,8 @@ ExecutionResult Block::execute( LastBlockHashesFace const& _lh, Transaction cons
     uncommitToSeal();
 
 
-    EnvInfo envInfo = EnvInfo(
-        info(), _lh, previousInfo().timestamp(), gasUsed(), m_sealEngine->chainParams().getChainId() );
+    EnvInfo envInfo = EnvInfo( info(), _lh, previousInfo().timestamp(), gasUsed(),
+        m_sealEngine->chainParams().getChainId() );
 
     // "bad" transaction receipt for failed transactions
     TransactionReceipt const null_receipt =

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -896,7 +896,7 @@ ExecutionResult Block::executeHistoricCall( LastBlockHashesFace const& _lh, Tran
             _transactionIndex ? receipt( _transactionIndex - 1 ).cumulativeGasUsed() : 0;
 
         EnvInfo const envInfo( info(), _lh, this->previousInfo().timestamp(), gasUsed,
-            m_sealEngine->chainParams().chainID );
+            m_sealEngine->chainParams().getChainId() );
 
         if ( _tracer ) {
             try {

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -192,8 +192,8 @@ SealEngineFace* Block::sealEngine() const {
 
 void Block::noteChain( BlockChain const& _bc ) {
     if ( !m_sealEngine ) {
-        m_state.noteAccountStartNonce( _bc.chainParams().accountStartNonce );
-        m_precommit.noteAccountStartNonce( _bc.chainParams().accountStartNonce );
+        m_state.noteAccountStartNonce( _bc.chainParams().getAccountStartNonce() );
+        m_precommit.noteAccountStartNonce( _bc.chainParams().getAccountStartNonce() );
         m_sealEngine = _bc.sealEngine();
     }
 }
@@ -527,7 +527,7 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
                     // TODO deduplicate
                     // "bad" transaction receipt for failed transactions
                     TransactionReceipt const null_receipt =
-                        info().number() >= sealEngine()->chainParams().byzantiumForkBlock ?
+                        info().number() >= sealEngine()->chainParams().getByzantiumForkBlock() ?
                             TransactionReceipt( 0, info().gasUsed(), LogEntries() ) :
                             TransactionReceipt( EmptyTrie, info().gasUsed(), LogEntries() );
 
@@ -573,7 +573,7 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
         auto reward = _bc.sealEngine()->blockReward( blockTimestamp, m_currentBlock.number() );
         rewardBlockAuthorForNonDefaultBlock( reward );
         m_state.safeSetLastRewardedBlockNumber( m_currentBlock.number() );
-        bool removeEmptyAccounts = m_currentBlock.number() >= _bc.chainParams().EIP158ForkBlock;
+        bool removeEmptyAccounts = m_currentBlock.number() >= _bc.chainParams().getEIP158ForkBlock();
         m_state.commit( removeEmptyAccounts ? dev::eth::CommitBehaviour::RemoveEmptyAccounts :
                                               dev::eth::CommitBehaviour::KeepEmptyAccounts );
     }
@@ -854,7 +854,7 @@ u256 Block::enact( VerifiedBlockRef const& _block, BlockChain const& _bc ) {
 
     // Commit all cached state changes to the state trie.
     bool removeEmptyAccounts =
-        m_currentBlock.number() >= _bc.chainParams().EIP158ForkBlock;  // TODO: use EVMSchedule
+        m_currentBlock.number() >= _bc.chainParams().getEIP158ForkBlock();  // TODO: use EVMSchedule
     DEV_TIMED_ABOVE( "commit", 500 )
     m_state.commit( removeEmptyAccounts ? dev::eth::CommitBehaviour::RemoveEmptyAccounts :
                                           dev::eth::CommitBehaviour::KeepEmptyAccounts );
@@ -945,11 +945,11 @@ ExecutionResult Block::execute( LastBlockHashesFace const& _lh, Transaction cons
 
 
     EnvInfo envInfo = EnvInfo(
-        info(), _lh, previousInfo().timestamp(), gasUsed(), m_sealEngine->chainParams().chainID );
+        info(), _lh, previousInfo().timestamp(), gasUsed(), m_sealEngine->chainParams().getChainId() );
 
     // "bad" transaction receipt for failed transactions
     TransactionReceipt const null_receipt =
-        envInfo.number() >= sealEngine()->chainParams().byzantiumForkBlock ?
+        envInfo.number() >= sealEngine()->chainParams().getByzantiumForkBlock() ?
             TransactionReceipt( 0, envInfo.gasUsed(), LogEntries() ) :
             TransactionReceipt( EmptyTrie, envInfo.gasUsed(), LogEntries() );
 
@@ -1031,7 +1031,7 @@ void Block::applyRewards(
 }
 
 void Block::performIrregularModifications() {
-    u256 const& daoHardfork = m_sealEngine->chainParams().daoHardforkBlock;
+    u256 const& daoHardfork = m_sealEngine->chainParams().getDaoHardforkBlock();
     if ( daoHardfork != 0 && info().number() == daoHardfork ) {
         Address recipient( "0xbf4ed7b27f1d666546e30d74d50d173d20bca754" );
         Addresses allDAOs = childDaos();
@@ -1044,7 +1044,7 @@ void Block::performIrregularModifications() {
 void Block::updateBlockhashContract() {
     u256 const& blockNumber = info().number();
 
-    u256 const& forkBlock = m_sealEngine->chainParams().experimentalForkBlock;
+    u256 const& forkBlock = m_sealEngine->chainParams().getExperimentalForkBlock();
     if ( blockNumber == forkBlock ) {
         if ( m_state.addressInUse( c_blockhashContractAddress ) ) {
             if ( m_state.code( c_blockhashContractAddress ) != c_blockhashContractCode ) {

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -234,7 +234,7 @@ void BlockChain::open( fs::path const& _path, bool _applyPatches, WithExisting _
     try {
         fs::create_directories( chainPath / fs::path( "blocks_and_extras" ) );
         m_rotator = std::make_shared< batched_io::rotating_db_io >(
-            chainPath / fs::path( "blocks_and_extras" ), 5, chainParams().nodeInfo.archiveMode );
+            chainPath / fs::path( "blocks_and_extras" ), 5, chainParams().isArchiveModeEnabled() );
         m_rotating_db = std::make_shared< db::ManuallyRotatingLevelDB >( m_rotator );
         auto db = std::make_shared< batched_io::batched_db >();
         db->open( m_rotating_db );

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -181,7 +181,7 @@ string BlockChain::getChainDirName( const ChainParams& _cp ) {
 }
 
 BlockChain::BlockChain( std::shared_ptr< const ChainParams > _p, fs::path const& _dbPath,
-                        bool _applyPatches, WithExisting _we ) try
+    bool _applyPatches, WithExisting _we ) try
     : m_lastBlockHashes( new LastBlockHashes( *this ) ), m_dbPath( _dbPath ) {
     init( _p );
     open( _dbPath, _applyPatches, _we );
@@ -315,7 +315,8 @@ void BlockChain::open( fs::path const& _path, bool _applyPatches, WithExisting _
         TotalStorageUsedPatch::initOnChain( *this );
 }
 
-void BlockChain::reopen( std::shared_ptr< const ChainParams > _p, bool _applyPatches, WithExisting _we ) {
+void BlockChain::reopen(
+    std::shared_ptr< const ChainParams > _p, bool _applyPatches, WithExisting _we ) {
     close();
     init( _p );
     open( m_dbPath, _applyPatches, _we );

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -315,13 +315,6 @@ void BlockChain::open( fs::path const& _path, bool _applyPatches, WithExisting _
         TotalStorageUsedPatch::initOnChain( *this );
 }
 
-void BlockChain::reopen(
-    std::shared_ptr< const ChainParams > _p, bool _applyPatches, WithExisting _we ) {
-    close();
-    init( _p );
-    open( m_dbPath, _applyPatches, _we );
-}
-
 void BlockChain::close() {
     LOG( m_loggerTrace ) << "Closing blockchain DB";
     // Not thread safe...

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -180,8 +180,8 @@ string BlockChain::getChainDirName( const ChainParams& _cp ) {
     return toHex( BlockHeader( _cp.genesisBlock() ).hash().ref().cropped( 0, 4 ) );
 }
 
-BlockChain::BlockChain(
-    ChainParams const& _p, fs::path const& _dbPath, bool _applyPatches, WithExisting _we ) try
+BlockChain::BlockChain( std::shared_ptr< const ChainParams > _p, fs::path const& _dbPath,
+                        bool _applyPatches, WithExisting _we ) try
     : m_lastBlockHashes( new LastBlockHashes( *this ) ), m_dbPath( _dbPath ) {
     init( _p );
     open( _dbPath, _applyPatches, _we );
@@ -196,7 +196,7 @@ BlockChain::~BlockChain() {
 BlockHeader const& BlockChain::genesis() const {
     UpgradableGuard l( x_genesis );
     if ( !m_genesis ) {
-        auto gb = m_params.genesisBlock();
+        auto gb = m_params->genesisBlock();
         UpgradeGuard ul( l );
         m_genesis = BlockHeader( gb );
         m_genesisHeaderBytes = BlockHeader::extractHeader( &gb ).data().toBytes();
@@ -205,7 +205,7 @@ BlockHeader const& BlockChain::genesis() const {
     return m_genesis;
 }
 
-void BlockChain::init( ChainParams const& _p ) {
+void BlockChain::init( std::shared_ptr< const ChainParams > _p ) {
     clockLastDbRotation_ = clock();
     // initialise deathrow.
     m_cacheUsage.resize( c_collectionQueueSize );
@@ -213,14 +213,14 @@ void BlockChain::init( ChainParams const& _p ) {
 
     // Initialise with the genesis as the last block on the longest chain.
     m_params = _p;
-    m_sealEngine.reset( m_params.createSealEngine() );
+    m_sealEngine.reset( const_cast< ChainParams* >( m_params.get() )->createSealEngine() );
     m_genesis.clear();
     genesis();
 }
 
 void BlockChain::open( fs::path const& _path, bool _applyPatches, WithExisting _we ) {
     fs::path path = _path.empty() ? Defaults::get()->m_dbPath : _path;
-    fs::path chainPath = path / getChainDirName( m_params );
+    fs::path chainPath = path / getChainDirName( *m_params );
     fs::path extrasPath = chainPath / fs::path( toString( c_databaseVersion ) );
 
     fs::create_directories( extrasPath );
@@ -269,9 +269,9 @@ void BlockChain::open( fs::path const& _path, bool _applyPatches, WithExisting _
         AmsterdamFixPatch::initOnChain( *m_blocksDB, *m_extrasDB, *m_db, chainParams() );
 
     if ( _we != WithExisting::Verify && !details( m_genesisHash ) ) {
-        BlockHeader gb( m_params.genesisBlock() );
+        BlockHeader gb( m_params->genesisBlock() );
         // Insert details of genesis block.
-        bytes const& genesisBlockBytes = m_params.genesisBlock();
+        bytes const& genesisBlockBytes = m_params->genesisBlock();
         BlockDetails details( 0, gb.difficulty(), h256(), {}, genesisBlockBytes.size() );
         auto r = details.rlp();
         details.size = r.size();
@@ -288,7 +288,7 @@ void BlockChain::open( fs::path const& _path, bool _applyPatches, WithExisting _
     // HACK Unfortunate crash can leave us with rotated DB but not added pieceUsageBytes, best and
     // genesis! So, finish possibly unfinished rotation ( though better to do it in batched_*
     // classes :( )
-    if ( m_params.sChain.dbStorageLimit > 0 &&
+    if ( m_params->getDbStorageLimit() > 0 &&
          !m_rotating_db->currentPiece()->exists( ( db::Slice ) "pieceUsageBytes" ) ) {
         // re-insert genesis
         BlockDetails details = this->details( m_genesisHash );
@@ -315,7 +315,7 @@ void BlockChain::open( fs::path const& _path, bool _applyPatches, WithExisting _
         TotalStorageUsedPatch::initOnChain( *this );
 }
 
-void BlockChain::reopen( ChainParams const& _p, bool _applyPatches, WithExisting _we ) {
+void BlockChain::reopen( std::shared_ptr< const ChainParams > _p, bool _applyPatches, WithExisting _we ) {
     close();
     init( _p );
     open( m_dbPath, _applyPatches, _we );
@@ -640,7 +640,7 @@ void BlockChain::checkBlockIsNew( VerifiedBlockRef const& _block ) const {
 
 void BlockChain::checkBlockTimestamp( BlockHeader const& _header ) const {
     // Check it's not crazy
-    if ( _header.timestamp() > utcTime() && !m_params.allowFutureBlocks ) {
+    if ( _header.timestamp() > utcTime() && !m_params->isAllowFutureBlocks() ) {
         LOG( m_loggerTrace ) << _header.hash() << " : Future time " << _header.timestamp()
                              << " (now at " << utcTime() << ")";
         // Block has a timestamp in the future. This is no good.
@@ -650,10 +650,10 @@ void BlockChain::checkBlockTimestamp( BlockHeader const& _header ) const {
 
 bool BlockChain::rotateDBIfNeeded( uint64_t pieceUsageBytes ) {
     bool isRotate = false;
-    if ( m_params.sChain.dbStorageLimit > 0 ) {
+    if ( m_params->getDbStorageLimit() > 0 ) {
         // account for size of 1 piece
         isRotate =
-            ( pieceUsageBytes > m_params.sChain.dbStorageLimit / m_rotating_db->piecesCount() ) ?
+            ( pieceUsageBytes > m_params->getDbStorageLimit() / m_rotating_db->piecesCount() ) ?
                 true :
                 false;
         if ( isRotate ) {
@@ -1625,7 +1625,7 @@ bool BlockChain::isKnown( h256 const& _hash, bool _isCurrent ) const {
 
 bytes BlockChain::block( h256 const& _hash ) const {
     if ( _hash == m_genesisHash )
-        return m_params.genesisBlock();
+        return m_params->genesisBlock();
 
     {
         ReadGuard l( x_blocks );
@@ -1681,17 +1681,17 @@ Block BlockChain::genesisBlock(
 
     ret.noteChain( *this );
 
-    ret.mutableState().populateFrom( m_params.genesisState );
+    ret.mutableState().populateFrom( m_params->getGenesisState() );
     ret.mutableState().commit();
 
-    ret.m_previousBlock = BlockHeader( m_params.genesisBlock() );
+    ret.m_previousBlock = BlockHeader( m_params->genesisBlock() );
     ret.resetCurrent();
     return ret;
 }
 
 Block BlockChain::genesisBlock( const State& _state ) const {
     Block ret( *this, m_genesisHash, _state, skale::BaseState::PreExisting );
-    ret.m_previousBlock = BlockHeader( m_params.genesisBlock() );
+    ret.m_previousBlock = BlockHeader( m_params->genesisBlock() );
     ret.resetCurrent();
     return ret;
 }

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -256,7 +256,10 @@ public:
 
     LastBlockHashesFace const& lastBlockHashes() const { return *m_lastBlockHashes; }
 
-    uint64_t chainID() const { return m_params->getChainId(); }
+    uint64_t chainID() const {
+        CHECK_EXPRESSION( m_params );
+        return m_params->getChainId();
+    }
 
     /** Get the block blooms for a number of blocks. Thread-safe.
      * @returns the object pertaining to the blocks:
@@ -445,7 +448,10 @@ public:
     /// Gives a dump of the blockchain database. For debug/test use only.
     std::string dumpDatabase() const;
 
-    ChainParams const& chainParams() const { return *m_params; }
+    ChainParams const& chainParams() const {
+        CHECK_EXPRESSION( m_params );
+        return *m_params;
+    }
 
     SealEngineFace* sealEngine() const { return m_sealEngine.get(); }
 

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -145,7 +145,7 @@ public:
         reopen( m_params, _applyPatches, _we );
     }
     void reopen( std::shared_ptr< const ChainParams > _p, bool _applyPatches = false,
-                 WithExisting _we = WithExisting::Trust );
+        WithExisting _we = WithExisting::Trust );
 
     /// (Potentially) renders invalid existing bytesConstRef returned by lastBlock.
     /// To be called from main loop every 100ms or so.

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -136,7 +136,7 @@ public:
 
     /// Doesn't open the database - if you want it open it's up to you to subclass this and open it
     /// in the constructor there.
-    BlockChain( ChainParams const& _p, boost::filesystem::path const& _path,
+    BlockChain( std::shared_ptr< const ChainParams > _p, boost::filesystem::path const& _path,
         bool _applyPatches = false, WithExisting _we = WithExisting::Trust );
     ~BlockChain();
 
@@ -144,8 +144,8 @@ public:
     void reopen( bool _applyPatches = false, WithExisting _we = WithExisting::Trust ) {
         reopen( m_params, _applyPatches, _we );
     }
-    void reopen(
-        ChainParams const& _p, bool _applyPatches = false, WithExisting _we = WithExisting::Trust );
+    void reopen( std::shared_ptr< const ChainParams > _p, bool _applyPatches = false,
+                 WithExisting _we = WithExisting::Trust );
 
     /// (Potentially) renders invalid existing bytesConstRef returned by lastBlock.
     /// To be called from main loop every 100ms or so.
@@ -263,7 +263,7 @@ public:
 
     LastBlockHashesFace const& lastBlockHashes() const { return *m_lastBlockHashes; }
 
-    uint64_t chainID() const { return m_params.chainID; }
+    uint64_t chainID() const { return m_params->getChainId(); }
 
     /** Get the block blooms for a number of blocks. Thread-safe.
      * @returns the object pertaining to the blocks:
@@ -452,7 +452,7 @@ public:
     /// Gives a dump of the blockchain database. For debug/test use only.
     std::string dumpDatabase() const;
 
-    ChainParams const& chainParams() const { return m_params; }
+    ChainParams const& chainParams() const { return *m_params; }
 
     SealEngineFace* sealEngine() const { return m_sealEngine.get(); }
 
@@ -479,7 +479,7 @@ private:
     }
 
     /// Initialise everything and ready for opening the database.
-    void init( ChainParams const& _p );
+    void init( std::shared_ptr< const ChainParams > _p );
     /// Open the database.
 public:
     void open( boost::filesystem::path const& _path, bool _applyPatches, WithExisting _we );
@@ -642,7 +642,7 @@ private:
     unsigned m_lastBlockNumber = 0;
     boost::filesystem::path m_chainPath;
 
-    ChainParams m_params;
+    std::shared_ptr< const ChainParams > m_params;
     std::shared_ptr< SealEngineFace > m_sealEngine;  // consider shared_ptr.
     mutable SharedMutex x_genesis;
     mutable BlockHeader m_genesis;       // mutable because they're effectively memos.

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -140,13 +140,6 @@ public:
         bool _applyPatches = false, WithExisting _we = WithExisting::Trust );
     ~BlockChain();
 
-    /// Reopen everything.
-    void reopen( bool _applyPatches = false, WithExisting _we = WithExisting::Trust ) {
-        reopen( m_params, _applyPatches, _we );
-    }
-    void reopen( std::shared_ptr< const ChainParams > _p, bool _applyPatches = false,
-        WithExisting _we = WithExisting::Trust );
-
     /// (Potentially) renders invalid existing bytesConstRef returned by lastBlock.
     /// To be called from main loop every 100ms or so.
     void process();

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -78,97 +78,93 @@ ChainParams::ChainParams() {
 }
 
 ChainParams::ChainParams( string const& _json ) {
-    *this = loadConfig( _json );
+    loadConfig( _json );
 }
 
-ChainParams ChainParams::loadConfig(
-    string const& _json, const boost::filesystem::path& _configPath ) const {
-    ChainParams cp( *this );
-    cp.originalJSON = _json;
+void ChainParams::loadConfig( string const& _json, const boost::filesystem::path& _configPath ) {
+    originalJSON = _json;
 
     js::mValue val;
     json_spirit::read_string_or_throw( _json, val );
     js::mObject obj = val.get_obj();
 
     validateConfigJson( obj );
-    cp.sealEngineName = obj[c_sealEngine].get_str();
+    sealEngineName = obj[c_sealEngine].get_str();
     // params
     js::mObject params = obj[c_params].get_obj();
     //    validateFieldNames(params, c_knownParamNames);
-    cp.accountStartNonce =
+    accountStartNonce =
         u256( fromBigEndian< u256 >( fromHex( params[c_accountStartNonce].get_str() ) ) );
-    cp.maximumExtraDataSize =
+    maximumExtraDataSize =
         u256( fromBigEndian< u256 >( fromHex( params[c_maximumExtraDataSize].get_str() ) ) );
-    cp.tieBreakingGas =
+    tieBreakingGas =
         params.count( c_tieBreakingGas ) ? params[c_tieBreakingGas].get_bool() : true;
-    cp.setBlockReward(
+    setBlockReward(
         u256( fromBigEndian< u256 >( fromHex( params[c_blockReward].get_str() ) ) ) );
-    cp.skaleDisableChainIdCheck = params.count( c_skaleDisableChainIdCheck ) ?
+    skaleDisableChainIdCheck = params.count( c_skaleDisableChainIdCheck ) ?
                                       params[c_skaleDisableChainIdCheck].get_bool() :
                                       false;
-    cp.getLogsBlocksLimit =
+    getLogsBlocksLimit =
         params.count( "getLogsBlocksLimit" ) ? params.at( "getLogsBlocksLimit" ).get_int() : -1;
 
     if ( obj.count( c_skaleConfig ) ) {
-        processSkaleConfigItems( cp, obj );
+        processSkaleConfigItems( obj );
     }
 
     auto setOptionalU256Parameter = [&params]( u256& _destination, string const& _name ) {
         if ( params.count( _name ) )
             _destination = u256( fromBigEndian< u256 >( fromHex( params.at( _name ).get_str() ) ) );
     };
-    setOptionalU256Parameter( cp.minGasLimit, c_minGasLimit );
-    setOptionalU256Parameter( cp.maxGasLimit, c_maxGasLimit );
-    setOptionalU256Parameter( cp.gasLimitBoundDivisor, c_gasLimitBoundDivisor );
-    setOptionalU256Parameter( cp.homesteadForkBlock, c_homesteadForkBlock );
-    setOptionalU256Parameter( cp.EIP150ForkBlock, c_EIP150ForkBlock );
-    setOptionalU256Parameter( cp.EIP158ForkBlock, c_EIP158ForkBlock );
-    setOptionalU256Parameter( cp.byzantiumForkBlock, c_byzantiumForkBlock );
-    setOptionalU256Parameter( cp.eWASMForkBlock, c_eWASMForkBlock );
-    setOptionalU256Parameter( cp.constantinopleForkBlock, c_constantinopleForkBlock );
-    setOptionalU256Parameter( cp.constantinopleFixForkBlock, c_constantinopleFixForkBlock );
-    setOptionalU256Parameter( cp.istanbulForkBlock, c_istanbulForkBlock );
-    setOptionalU256Parameter( cp.experimentalForkBlock, c_experimentalForkBlock );
+    setOptionalU256Parameter( minGasLimit, c_minGasLimit );
+    setOptionalU256Parameter( maxGasLimit, c_maxGasLimit );
+    setOptionalU256Parameter( gasLimitBoundDivisor, c_gasLimitBoundDivisor );
+    setOptionalU256Parameter( homesteadForkBlock, c_homesteadForkBlock );
+    setOptionalU256Parameter( EIP150ForkBlock, c_EIP150ForkBlock );
+    setOptionalU256Parameter( EIP158ForkBlock, c_EIP158ForkBlock );
+    setOptionalU256Parameter( byzantiumForkBlock, c_byzantiumForkBlock );
+    setOptionalU256Parameter( eWASMForkBlock, c_eWASMForkBlock );
+    setOptionalU256Parameter( constantinopleForkBlock, c_constantinopleForkBlock );
+    setOptionalU256Parameter( constantinopleFixForkBlock, c_constantinopleFixForkBlock );
+    setOptionalU256Parameter( istanbulForkBlock, c_istanbulForkBlock );
+    setOptionalU256Parameter( experimentalForkBlock, c_experimentalForkBlock );
 
-    setOptionalU256Parameter( cp.skale16ForkBlock, c_skale16ForkBlock );
-    setOptionalU256Parameter( cp.skale32ForkBlock, c_skale32ForkBlock );
-    setOptionalU256Parameter( cp.skale64ForkBlock, c_skale64ForkBlock );
-    setOptionalU256Parameter( cp.skale128ForkBlock, c_skale128ForkBlock );
-    setOptionalU256Parameter( cp.skale256ForkBlock, c_skale256ForkBlock );
-    setOptionalU256Parameter( cp.skale512ForkBlock, c_skale512ForkBlock );
-    setOptionalU256Parameter( cp.skale1024ForkBlock, c_skale1024ForkBlock );
-    setOptionalU256Parameter( cp.skaleUnlimitedForkBlock, c_skaleUnlimitedForkBlock );
+    setOptionalU256Parameter( skale16ForkBlock, c_skale16ForkBlock );
+    setOptionalU256Parameter( skale32ForkBlock, c_skale32ForkBlock );
+    setOptionalU256Parameter( skale64ForkBlock, c_skale64ForkBlock );
+    setOptionalU256Parameter( skale128ForkBlock, c_skale128ForkBlock );
+    setOptionalU256Parameter( skale256ForkBlock, c_skale256ForkBlock );
+    setOptionalU256Parameter( skale512ForkBlock, c_skale512ForkBlock );
+    setOptionalU256Parameter( skale1024ForkBlock, c_skale1024ForkBlock );
+    setOptionalU256Parameter( skaleUnlimitedForkBlock, c_skaleUnlimitedForkBlock );
 
-    setOptionalU256Parameter( cp.daoHardforkBlock, c_daoHardforkBlock );
-    setOptionalU256Parameter( cp.minimumDifficulty, c_minimumDifficulty );
-    setOptionalU256Parameter( cp.difficultyBoundDivisor, c_difficultyBoundDivisor );
-    setOptionalU256Parameter( cp.durationLimit, c_durationLimit );
-    setOptionalU256Parameter( cp.accountInitialFunds, c_accountInitialFunds );
-    setOptionalU256Parameter( cp.externalGasDifficulty, c_externalGasDifficulty );
+    setOptionalU256Parameter( daoHardforkBlock, c_daoHardforkBlock );
+    setOptionalU256Parameter( minimumDifficulty, c_minimumDifficulty );
+    setOptionalU256Parameter( difficultyBoundDivisor, c_difficultyBoundDivisor );
+    setOptionalU256Parameter( durationLimit, c_durationLimit );
+    setOptionalU256Parameter( accountInitialFunds, c_accountInitialFunds );
+    setOptionalU256Parameter( externalGasDifficulty, c_externalGasDifficulty );
 
     if ( params.count( c_chainID ) )
-        cp.chainID = uint64_t(
+        chainID = uint64_t(
             u256( fromBigEndian< u256 >( fromHex( params.at( c_chainID ).get_str() ) ) ) );
     if ( params.count( c_networkID ) )
-        cp.networkID =
+        networkID =
             int( u256( fromBigEndian< u256 >( fromHex( params.at( c_networkID ).get_str() ) ) ) );
-    cp.allowFutureBlocks = params.count( c_allowFutureBlocks );
-    if ( cp.externalGasDifficulty == 0 ) {
-        cp.externalGasDifficulty = -1;
+    allowFutureBlocks = params.count( c_allowFutureBlocks );
+    if ( externalGasDifficulty == 0 ) {
+        externalGasDifficulty = -1;
     }
 
     // genesis
     string genesisStr = json_spirit::write_string( obj[c_genesis], false );
-    cp = cp.loadGenesis( genesisStr );
+    loadGenesis( genesisStr );
     // genesis state
     string genesisStateStr = json_spirit::write_string( obj[c_accounts], false );
 
-    cp.genesisState = jsonToAccountMap(
-        genesisStateStr, cp.accountStartNonce, nullptr, &cp.precompiled, _configPath );
-
-    return cp;
+    genesisState = jsonToAccountMap(
+        genesisStateStr, accountStartNonce, nullptr, &precompiled, _configPath );
 }
-void ChainParams::processSkaleConfigItems( ChainParams& cp, json_spirit::mObject& obj ) {
+void ChainParams::processSkaleConfigItems( json_spirit::mObject& obj ) {
     auto skaleObj = obj[c_skaleConfig].get_obj();
 
     auto infoObj = skaleObj.at( "nodeInfo" ).get_obj();
@@ -211,11 +207,11 @@ void ChainParams::processSkaleConfigItems( ChainParams& cp, json_spirit::mObject
     }
 
     try {
-        cp.rotateAfterBlock_ = infoObj.at( "rotateAfterBlock" ).get_int();
+        rotateAfterBlock_ = infoObj.at( "rotateAfterBlock" ).get_int();
     } catch ( ... ) {
     }
-    if ( cp.rotateAfterBlock_ < 0 )
-        cp.rotateAfterBlock_ = 0;
+    if ( rotateAfterBlock_ < 0 )
+        rotateAfterBlock_ = 0;
 
     bool testSignatures = false;
     try {
@@ -258,7 +254,7 @@ void ChainParams::processSkaleConfigItems( ChainParams& cp, json_spirit::mObject
         }
     }
 
-    cp.nodeInfo = { nodeName, nodeID, ip, static_cast< uint16_t >( port ), ip6,
+    nodeInfo = { nodeName, nodeID, ip, static_cast< uint16_t >( port ), ip6,
         static_cast< uint16_t >( port6 ), sgxServerUrl, ecdsaKeyName, keyShareName, BLSPublicKeys,
         commonBLSPublicKeys, syncNode, archiveMode, syncFromCatchup, testSignatures };
 
@@ -426,52 +422,48 @@ void ChainParams::processSkaleConfigItems( ChainParams& cp, json_spirit::mObject
         }
         s.nodes.push_back( node );
     }
-    cp.sChain = s;
+    sChain = s;
 
-    cp.vecAdminOrigins.clear();
+    vecAdminOrigins.clear();
     if ( infoObj.count( "adminOrigins" ) ) {
-        for ( auto nodeOrigun : infoObj.at( "adminOrigins" ).get_array() ) {
-            string strOriginWildcardFilter = nodeOrigun.get_str();
-            cp.vecAdminOrigins.push_back( strOriginWildcardFilter );
+        for ( const auto& nodeOrigin : infoObj.at( "adminOrigins" ).get_array() ) {
+            string strOriginWildcardFilter = nodeOrigin.get_str();
+            vecAdminOrigins.push_back( strOriginWildcardFilter );
         }
     } else {
-        cp.vecAdminOrigins.push_back( "*" );
+        vecAdminOrigins.push_back( "*" );
     }
 }
 
-ChainParams ChainParams::loadGenesis( string const& _json ) const {
-    ChainParams cp( *this );
-
+void ChainParams::loadGenesis( string const& _json ) {
     js::mValue val;
     js::read_string( _json, val );
     js::mObject genesis = val.get_obj();
 
-    cp.parentHash = h256( 0 );  // required by the YP
-    cp.author = genesis.count( c_coinbase ) ? h160( genesis[c_coinbase].get_str() ) :
+    parentHash = h256( 0 );  // required by the YP
+    author = genesis.count( c_coinbase ) ? h160( genesis[c_coinbase].get_str() ) :
                                               h160( genesis[c_author].get_str() );
-    cp.difficulty =
+    difficulty =
         genesis.count( c_difficulty ) ?
             u256( fromBigEndian< u256 >( fromHex( genesis[c_difficulty].get_str() ) ) ) :
-            cp.minimumDifficulty;
-    cp.gasLimit = u256( fromBigEndian< u256 >( fromHex( genesis[c_gasLimit].get_str() ) ) );
-    cp.gasUsed = genesis.count( c_gasUsed ) ?
+            minimumDifficulty;
+    gasLimit = u256( fromBigEndian< u256 >( fromHex( genesis[c_gasLimit].get_str() ) ) );
+    gasUsed = genesis.count( c_gasUsed ) ?
                      u256( fromBigEndian< u256 >( fromHex( genesis[c_gasUsed].get_str() ) ) ) :
                      0;
-    cp.timestamp = u256( fromBigEndian< u256 >( fromHex( genesis[c_timestamp].get_str() ) ) );
-    cp.extraData = bytes( fromHex( genesis[c_extraData].get_str() ) );
+    timestamp = u256( fromBigEndian< u256 >( fromHex( genesis[c_timestamp].get_str() ) ) );
+    extraData = bytes( fromHex( genesis[c_extraData].get_str() ) );
 
     if ( genesis.count( c_stateRoot ) )
-        cp.stateRoot = h256( fromHex( genesis[c_stateRoot].get_str() ), h256::AlignRight );
+        stateRoot = h256( fromHex( genesis[c_stateRoot].get_str() ), h256::AlignRight );
 
     // magic code for handling ethash stuff:
     if ( genesis.count( c_mixHash ) && genesis.count( c_nonce ) ) {
         h256 mixHash( genesis[c_mixHash].get_str() );
         h64 nonce( genesis[c_nonce].get_str() );
-        cp.sealFields = 2;
-        cp.sealRLP = rlp( mixHash ) + rlp( nonce );
+        sealFields = 2;
+        sealRLP = rlp( mixHash ) + rlp( nonce );
     }
-
-    return cp;
 }
 
 SealEngineFace* ChainParams::createSealEngine() {
@@ -612,7 +604,7 @@ const std::string& ChainParams::getOriginalJson() const {
 
     js::mArray nodes;
 
-    for ( auto node : sChain.nodes ) {
+    for ( const auto& node : sChain.nodes ) {
         js::mObject nodeConfObj;
         nodeConfObj["nodeID"] = ( int64_t ) node.id;
         nodeConfObj["ip"] = node.ip;

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -97,13 +97,11 @@ void ChainParams::loadConfig( string const& _json, const boost::filesystem::path
         u256( fromBigEndian< u256 >( fromHex( params[c_accountStartNonce].get_str() ) ) );
     maximumExtraDataSize =
         u256( fromBigEndian< u256 >( fromHex( params[c_maximumExtraDataSize].get_str() ) ) );
-    tieBreakingGas =
-        params.count( c_tieBreakingGas ) ? params[c_tieBreakingGas].get_bool() : true;
-    setBlockReward(
-        u256( fromBigEndian< u256 >( fromHex( params[c_blockReward].get_str() ) ) ) );
+    tieBreakingGas = params.count( c_tieBreakingGas ) ? params[c_tieBreakingGas].get_bool() : true;
+    setBlockReward( u256( fromBigEndian< u256 >( fromHex( params[c_blockReward].get_str() ) ) ) );
     skaleDisableChainIdCheck = params.count( c_skaleDisableChainIdCheck ) ?
-                                      params[c_skaleDisableChainIdCheck].get_bool() :
-                                      false;
+                                   params[c_skaleDisableChainIdCheck].get_bool() :
+                                   false;
     logsBlocksLimit =
         params.count( "getLogsBlocksLimit" ) ? params.at( "getLogsBlocksLimit" ).get_int() : -1;
 
@@ -161,8 +159,8 @@ void ChainParams::loadConfig( string const& _json, const boost::filesystem::path
     // genesis state
     string genesisStateStr = json_spirit::write_string( obj[c_accounts], false );
 
-    genesisState = jsonToAccountMap(
-        genesisStateStr, accountStartNonce, nullptr, &precompiled, _configPath );
+    genesisState =
+        jsonToAccountMap( genesisStateStr, accountStartNonce, nullptr, &precompiled, _configPath );
 }
 void ChainParams::processSkaleConfigItems( json_spirit::mObject& obj ) {
     auto skaleObj = obj[c_skaleConfig].get_obj();
@@ -442,15 +440,14 @@ void ChainParams::loadGenesis( string const& _json ) {
 
     parentHash = h256( 0 );  // required by the YP
     author = genesis.count( c_coinbase ) ? h160( genesis[c_coinbase].get_str() ) :
-                                              h160( genesis[c_author].get_str() );
-    difficulty =
-        genesis.count( c_difficulty ) ?
-            u256( fromBigEndian< u256 >( fromHex( genesis[c_difficulty].get_str() ) ) ) :
-            minimumDifficulty;
+                                           h160( genesis[c_author].get_str() );
+    difficulty = genesis.count( c_difficulty ) ?
+                     u256( fromBigEndian< u256 >( fromHex( genesis[c_difficulty].get_str() ) ) ) :
+                     minimumDifficulty;
     gasLimit = u256( fromBigEndian< u256 >( fromHex( genesis[c_gasLimit].get_str() ) ) );
     gasUsed = genesis.count( c_gasUsed ) ?
-                     u256( fromBigEndian< u256 >( fromHex( genesis[c_gasUsed].get_str() ) ) ) :
-                     0;
+                  u256( fromBigEndian< u256 >( fromHex( genesis[c_gasUsed].get_str() ) ) ) :
+                  0;
     timestamp = u256( fromBigEndian< u256 >( fromHex( genesis[c_timestamp].get_str() ) ) );
     extraData = bytes( fromHex( genesis[c_extraData].get_str() ) );
 

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -104,7 +104,7 @@ void ChainParams::loadConfig( string const& _json, const boost::filesystem::path
     skaleDisableChainIdCheck = params.count( c_skaleDisableChainIdCheck ) ?
                                       params[c_skaleDisableChainIdCheck].get_bool() :
                                       false;
-    getLogsBlocksLimit =
+    logsBlocksLimit =
         params.count( "getLogsBlocksLimit" ) ? params.at( "getLogsBlocksLimit" ).get_int() : -1;
 
     if ( obj.count( c_skaleConfig ) ) {
@@ -655,6 +655,15 @@ bool ChainParams::checkAdminOriginAllowed( const std::string& origin ) const {
             return true;
     }
     return false;
+}
+
+void ChainParams::fillDefaultTestsParameters( size_t _port ) {
+    sealEngineName = NoProof::name();
+    allowFutureBlocks = true;
+    difficulty = getMinimumDifficulty();
+    gasLimit = getMaxGasLimit();
+    nodeInfo.port = nodeInfo.port6 = _port;
+    sChain.nodes[0].port = sChain.nodes[0].port6 = _port;
 }
 
 #ifdef MIRAGE

--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -46,8 +46,137 @@ struct ChainParams : public ChainOperationParams {
         populateFromGenesis( _genesisRLP, _state );
     }
 
+    friend struct ::SnapshotHashingFixture;
+    friend struct ::JsonRpcFixture;
+    friend struct ::SkaleHostFixture;
+    friend class ::ConsensusExtFaceFixture;
+    friend class ::SingleNodeConsensusFixture;
+
     SealEngineFace* createSealEngine();
 
+    /// Genesis block info.
+    bytes genesisBlock() const;
+
+    /// load config
+    void loadConfig( std::string const& _json, const boost::filesystem::path& _configPath = {} );
+
+    const std::string& getOriginalJson() const;
+    void resetJson() { originalJSON = ""; }
+
+    bool checkAdminOriginAllowed( const std::string& origin ) const;
+    void processSkaleConfigItems( json_spirit::mObject& _obj );
+
+    // ONLY FOR TESTS
+    void fillDefaultTestsParameters( size_t _port );
+
+    // SETTERS
+
+    void setSgxServerUrl( const std::string& _url ) { nodeInfo.sgxServerUrl = _url; }
+
+    // this setter is a workaround, use it carefully
+    void setSealEngineName( const std::string& _name ) { sealEngineName = _name; }
+
+    // GENERAL CHAIN GETTERS
+
+    bool isAllowFutureBlocks() const { return allowFutureBlocks; }
+
+    int getNetworkId() const { return networkID; }
+
+    dev::Address getBlockAuthor() const { return sChain.blockAuthor; }
+
+    std::string getSchainName() const { return sChain.name; }
+
+    u256 getExternalGasDifficulty() const { return externalGasDifficulty; }
+
+    u256 getGasLimit() const { return gasLimit; }
+
+    u256 getAccountStartNonce() const { return accountStartNonce; }
+
+    u256 getAccountInitialFunds() const { return accountInitialFunds; }
+
+    bool isMultiTransactionModeEnabled() const { return sChain.multiTransactionMode; }
+
+    const AccountMap& getGenesisState() const { return genesisState; }
+
+    uint64_t getDbStorageLimit() const { return sChain.dbStorageLimit; }
+
+    uint64_t getConsensusStorageLimit() const { return sChain.consensusStorageLimit; }
+
+    // GENERAL NODE GETTERS
+
+    u256 getSelfNodeId() const { return nodeInfo.id; }
+
+    std::string getSelfNodeIp() const { return nodeInfo.ip; }
+
+    std::string getSelfNodeIpV6() const { return nodeInfo.ip6; }
+
+    uint16_t getSelfNodePort() const { return nodeInfo.port; }
+
+    std::array< std::string, 4 > getSelfBlsPublicKey() const { return nodeInfo.BLSPublicKeys; }
+
+    std::array< std::string, 4 > getCommonBlsPublicKey() const { return nodeInfo.commonBLSPublicKeys; }
+
+    std::vector< sChainNode > getSchainNodes() const { return sChain.nodes; }
+
+    std::vector< NodeGroup > getNodeGroups() const { return sChain.nodeGroups; }
+
+    NodeGroup getNodeGroupByIndex( size_t _idx ) const { return sChain.nodeGroups.at( _idx ); }
+
+    sChainNode getNodeByIndex( size_t _idx ) const { return sChain.nodes.at( _idx ); }
+
+    int64_t getLevelDbReopenIntervalMs() const { return sChain.levelDBReopenIntervalMs; }
+
+    int getLogsBlocksLimit() const { return logsBlocksLimit; }
+
+    bool isSyncNode() const { return nodeInfo.syncNode; }
+
+    bool isArchiveModeEnabled() const { return nodeInfo.archiveMode; }
+
+    bool isSyncFromCatchupEnabled() const { return nodeInfo.syncFromCatchup; }
+
+#ifdef MIRAGE
+    Address getSChainNodeAddressByIndex( uint64_t sChainIndex ) const;
+#endif
+
+    size_t getNodesCount() const { return sChain.nodes.size(); }
+
+    size_t getThresholdCount() const { return sChain.t; }
+
+    // SGX GETTERS
+
+    bool isTestSignaturesEnabled() const { return nodeInfo.testSignatures; }
+
+    std::string getSgxServerUrl() const { return nodeInfo.sgxServerUrl; }
+
+    std::string getKeyShareName() const { return nodeInfo.keyShareName; }
+
+    // HISTORIC GROUP GETTERS
+
+    std::array< std::string, 4 > getBlsPublicKeyForHistoricGroup( unsigned _historicGroupIndex ) const {
+        return sChain.nodeGroups.at( _historicGroupIndex ).blsPublicKey;
+    }
+
+    u256 getHistoricNodeId( unsigned _historicGroupIndex, unsigned _nodeId ) const {
+        return sChain.nodeGroups.at( _historicGroupIndex ).nodes.at( _nodeId ).id;
+    }
+
+    u256 getHistoricNodeIndex( unsigned _historicGroupIndex, unsigned _nodeId ) const {
+        return sChain.nodeGroups.at( _historicGroupIndex ).nodes.at( _nodeId ).schainIndex;
+    }
+
+    std::string getHistoricNodePublicKey( unsigned _historicGroupIndex, unsigned _nodeId ) const {
+        return sChain.nodeGroups.at( _historicGroupIndex ).nodes.at( _nodeId ).publicKey;
+    }
+
+    // SNAPSHOTS GETTERS
+
+    int getSnapshotIntervalSec() const { return sChain.snapshotIntervalSec; }
+
+    time_t getSnapshotDownloadInactiveTimeout() const { return sChain.snapshotDownloadInactiveTimeout; }
+
+    time_t getSnapshotDownloadTimeout() const { return sChain.snapshotDownloadTimeout; }
+
+private:
     int rotateAfterBlock_ = 64;
 
     /// Genesis params.
@@ -65,59 +194,6 @@ struct ChainParams : public ChainOperationParams {
     unsigned sealFields = 0;
     bytes sealRLP;
 
-    /// Genesis block info.
-    bytes genesisBlock() const;
-
-    /// load config
-    void loadConfig( std::string const& _json, const boost::filesystem::path& _configPath = {} );
-
-    const std::string& getOriginalJson() const;
-    void resetJson() { originalJSON = ""; }
-
-    bool checkAdminOriginAllowed( const std::string& origin ) const;
-    void processSkaleConfigItems( json_spirit::mObject& _obj );
-
-#ifdef MIRAGE
-    Address getSChainNodeAddressByIndex( uint64_t sChainIndex ) const;
-#endif
-
-    int64_t getLevelDbReopenIntervalMs() const { return sChain.levelDBReopenIntervalMs; }
-
-    int getSnapshotIntervalSec() const { return sChain.snapshotIntervalSec; }
-
-    u256 getSelfNodeId() const { return nodeInfo.id; }
-
-    uint64_t getChainId() const { return chainID; }
-
-    uint64_t getDbStorageLimit() const { return sChain.dbStorageLimit; }
-
-    bool isAllowFutureBlocks() const { return allowFutureBlocks; }
-
-    const AccountMap& getGenesisState() const { return genesisState; }
-
-    bool isSyncNode() const { return nodeInfo.syncNode; }
-
-    time_t getSnapshotDownloadInactiveTimeout() const { return sChain.snapshotDownloadInactiveTimeout; }
-
-    bool isSyncFromCatchupEnabled() const { return nodeInfo.syncFromCatchup; }
-
-    int getNetworkId() const { return networkID; }
-
-    std::string getSealEngineName() const { return sealEngineName; }
-
-    dev::Address getBlockAuthor() const { return sChain.blockAuthor; }
-
-    std::string getSelfNodeIp() const { return nodeInfo.ip; }
-
-    std::string getSelfNodeIpV6() const { return nodeInfo.ip6; }
-
-    size_t getNodesCount() const { return sChain.nodes.size(); }
-
-    std::string getSgxServerUrl() const { return nodeInfo.sgxServerUrl; }
-
-    std::string getKeyShareName() const { return nodeInfo.keyShareName; }
-
-private:
     void populateFromGenesis( bytes const& _genesisRLP, AccountMap const& _state );
 
     /// load genesis

--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -68,6 +68,7 @@ struct ChainParams : public ChainOperationParams {
 
     // ONLY FOR TESTS
     void fillDefaultTestsParameters( size_t _port );
+    void setArchiveMode() { nodeInfo.archiveMode = true; }
 
     // SETTERS
 
@@ -101,6 +102,14 @@ struct ChainParams : public ChainOperationParams {
     uint64_t getDbStorageLimit() const { return sChain.dbStorageLimit; }
 
     uint64_t getConsensusStorageLimit() const { return sChain.consensusStorageLimit; }
+
+#ifdef HISTORIC_STATE
+    int64_t getMaxHistoricStateDbSize() const { return sChain.maxHistoricStateDbSize; }
+#endif
+
+#ifndef MIRAGE
+    s256 getContractStorageLimit() const { return sChain.contractStorageLimit; }
+#endif
 
     // GENERAL NODE GETTERS
 

--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -161,6 +161,8 @@ struct ChainParams : public ChainOperationParams {
 
     std::string getKeyShareName() const { return nodeInfo.keyShareName; }
 
+    std::string getEcdsaKeyName() const { return nodeInfo.ecdsaKeyName; }
+
     // HISTORIC GROUP GETTERS
 
     std::array< std::string, 4 > getBlsPublicKeyForHistoricGroup(

--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -114,7 +114,9 @@ struct ChainParams : public ChainOperationParams {
 
     std::array< std::string, 4 > getSelfBlsPublicKey() const { return nodeInfo.BLSPublicKeys; }
 
-    std::array< std::string, 4 > getCommonBlsPublicKey() const { return nodeInfo.commonBLSPublicKeys; }
+    std::array< std::string, 4 > getCommonBlsPublicKey() const {
+        return nodeInfo.commonBLSPublicKeys;
+    }
 
     std::vector< sChainNode > getSchainNodes() const { return sChain.nodes; }
 
@@ -152,7 +154,8 @@ struct ChainParams : public ChainOperationParams {
 
     // HISTORIC GROUP GETTERS
 
-    std::array< std::string, 4 > getBlsPublicKeyForHistoricGroup( unsigned _historicGroupIndex ) const {
+    std::array< std::string, 4 > getBlsPublicKeyForHistoricGroup(
+        unsigned _historicGroupIndex ) const {
         return sChain.nodeGroups.at( _historicGroupIndex ).blsPublicKey;
     }
 
@@ -172,7 +175,9 @@ struct ChainParams : public ChainOperationParams {
 
     int getSnapshotIntervalSec() const { return sChain.snapshotIntervalSec; }
 
-    time_t getSnapshotDownloadInactiveTimeout() const { return sChain.snapshotDownloadInactiveTimeout; }
+    time_t getSnapshotDownloadInactiveTimeout() const {
+        return sChain.snapshotDownloadInactiveTimeout;
+    }
 
     time_t getSnapshotDownloadTimeout() const { return sChain.snapshotDownloadTimeout; }
 

--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -35,7 +35,8 @@ class SealEngineFace;
 
 struct ChainParams : public ChainOperationParams {
     ChainParams();
-    ChainParams( ChainParams const& /*_org*/ ) = default;
+    ChainParams( ChainParams const& ) = delete;
+    ChainParams& operator=( ChainParams const& ) = delete;
     ChainParams( std::string const& _s );
     ChainParams( bytes const& _genesisRLP, AccountMap const& _state ) {
         populateFromGenesis( _genesisRLP, _state );
@@ -68,24 +69,59 @@ struct ChainParams : public ChainOperationParams {
     bytes genesisBlock() const;
 
     /// load config
-    ChainParams loadConfig(
-        std::string const& _json, const boost::filesystem::path& _configPath = {} ) const;
+    void loadConfig( std::string const& _json, const boost::filesystem::path& _configPath = {} );
 
     const std::string& getOriginalJson() const;
     void resetJson() { originalJSON = ""; }
 
     bool checkAdminOriginAllowed( const std::string& origin ) const;
-    static void processSkaleConfigItems( ChainParams& _cp, json_spirit::mObject& _obj );
+    void processSkaleConfigItems( json_spirit::mObject& _obj );
 
 #ifdef MIRAGE
     Address getSChainNodeAddressByIndex( uint64_t sChainIndex ) const;
 #endif
 
+    int64_t getLevelDbReopenIntervalMs() const { return sChain.levelDBReopenIntervalMs; }
+
+    int getSnapshotIntervalSec() const { return sChain.snapshotIntervalSec; }
+
+    u256 getSelfNodeId() const { return nodeInfo.id; }
+
+    uint64_t getChainId() const { return chainID; }
+
+    uint64_t getDbStorageLimit() const { return sChain.dbStorageLimit; }
+
+    bool isAllowFutureBlocks() const { return allowFutureBlocks; }
+
+    const AccountMap& getGenesisState() const { return genesisState; }
+
+    bool isSyncNode() const { return nodeInfo.syncNode; }
+
+    time_t getSnapshotDownloadInactiveTimeout() const { return sChain.snapshotDownloadInactiveTimeout; }
+
+    bool isSyncFromCatchupEnabled() const { return nodeInfo.syncFromCatchup; }
+
+    int getNetworkId() const { return networkID; }
+
+    std::string getSealEngineName() const { return sealEngineName; }
+
+    dev::Address getBlockAuthor() const { return sChain.blockAuthor; }
+
+    std::string getSelfNodeIp() const { return nodeInfo.ip; }
+
+    std::string getSelfNodeIpV6() const { return nodeInfo.ip6; }
+
+    size_t getNodesCount() const { return sChain.nodes.size(); }
+
+    std::string getSgxServerUrl() const { return nodeInfo.sgxServerUrl; }
+
+    std::string getKeyShareName() const { return nodeInfo.keyShareName; }
+
 private:
     void populateFromGenesis( bytes const& _genesisRLP, AccountMap const& _state );
 
     /// load genesis
-    ChainParams loadGenesis( std::string const& _json ) const;
+    void loadGenesis( std::string const& _json );
 
     mutable std::string originalJSON;
 

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -258,7 +258,7 @@ void Client::initStateFromDiskOrGenesis() {
         chainParams().getContractStorageLimit()
 #endif
 #ifdef HISTORIC_STATE
-        ,
+            ,
         chainParams().getMaxHistoricStateDbSize()
 #endif
     );

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -128,9 +128,9 @@ Client::Client( std::shared_ptr< const ChainParams > _params, int _networkID,
       m_bc( _params, _dbPath, true, _forceAction ),
       m_tq( _l ),
       m_gp( _gpForAdoption ? _gpForAdoption : make_shared< TrivialGasPricer >() ),
-      m_preSeal( chainParams().accountStartNonce ),
-      m_postSeal( chainParams().accountStartNonce ),
-      m_working( chainParams().accountStartNonce ),
+      m_preSeal( chainParams().getAccountStartNonce() ),
+      m_postSeal( chainParams().getAccountStartNonce() ),
+      m_working( chainParams().getAccountStartNonce() ),
       m_snapshotAgent( make_shared< SnapshotAgent >(
           _params->getSnapshotIntervalSec(), _snapshotManager, m_debugTracer ) ),
       m_instanceMonitor( _instanceMonitor ),
@@ -235,7 +235,7 @@ void Client::populateNewChainStateFromGenesis() {
     m_state.mutableHistoricState().db().commit();
 
 #else
-    m_state.populateFrom( bc().chainParams().genesisState );
+    m_state.populateFrom( bc().chainParams().getGenesisState() );
     m_state = m_state.createStateCopyAndClearCaches();
 #endif
 }
@@ -251,8 +251,8 @@ void Client::initStateFromDiskOrGenesis() {
         fs::path( std::string( m_dbPath.string() ).append( "/" ).append( HISTORIC_STATE_DIR ) ) );
 #endif
 
-    m_state = State( chainParams().accountStartNonce, m_dbPath, bc().genesisHash(),
-        BaseState::PreExisting, chainParams().accountInitialFunds
+    m_state = State( chainParams().getAccountStartNonce(), m_dbPath, bc().genesisHash(),
+        BaseState::PreExisting, chainParams().getAccountInitialFunds()
 #ifndef MIRAGE
         ,
         chainParams().sChain.contractStorageLimit
@@ -319,7 +319,7 @@ void Client::init( WithExisting _forceAction, u256 _networkId ) {
     if ( m_dbPath.size() )
         Defaults::setDBPath( m_dbPath );
 
-    if ( chainParams().sChain.nodeGroups.size() > 0 ) {
+    if ( chainParams().getNodeGroups().size() > 0 ) {
         initHistoricGroupIndex();
     } else {
         LOG( m_loggerInfo ) << "Empty node groups in config. "
@@ -583,7 +583,7 @@ size_t Client::importTransactionsAsBlock( const Transactions& _transactions,
     } else
         LOG( m_loggerWarning ) << "Warning: UnsafeRegion still active!";
 
-    if ( chainParams().sChain.nodeGroups.size() > 0 )
+    if ( chainParams().getNodeGroups().size() > 0 )
         updateHistoricGroupIndex();
 
 #ifdef MIRAGE
@@ -697,7 +697,7 @@ void Client::resyncStateFromChain() {
 
 void Client::restartMining() {
     bool preChanged = false;
-    Block newPreMine( chainParams().accountStartNonce );
+    Block newPreMine( chainParams().getAccountStartNonce() );
     DEV_READ_GUARDED( x_preSeal )
     newPreMine = m_preSeal;
 
@@ -729,7 +729,7 @@ void Client::restartMining() {
 }
 
 void Client::resetState() {
-    Block newPreMine( chainParams().accountStartNonce );
+    Block newPreMine( chainParams().getAccountStartNonce() );
     DEV_READ_GUARDED( x_preSeal )
     newPreMine = m_preSeal;
 
@@ -1145,17 +1145,17 @@ h256 Client::importTransaction( Transaction const& _t, TransactionBroadcast _txO
 
     Executive::verifyTransaction( _t, bc().info().timestamp(),
         bc().number() ? this->blockInfo( bc().currentHash() ) : bc().genesis(), state,
-        chainParams(), 0, gasBidPrice, chainParams().sChain.multiTransactionMode );
+        chainParams(), 0, gasBidPrice, chainParams().isMultiTransactionModeEnabled() );
 
     // invalid BITE transactions should not be added to txn queue
 #ifdef BITE
     // only validate in production setup
-    if ( !chainParams().nodeInfo.testSignatures )
+    if ( !chainParams().isTestSignaturesEnabled() )
         _t.checkAndValidateBITETransaction();
 #endif
 
     ImportResult res;
-    if ( chainParams().sChain.multiTransactionMode && state.getNonce( _t.sender() ) < _t.nonce() &&
+    if ( chainParams().isMultiTransactionModeEnabled() && state.getNonce( _t.sender() ) < _t.nonce() &&
          m_tq.maxCurrentNonce( _t.sender() ) != _t.nonce() ) {
         res = m_tq.import( _t, IfDropped::Ignore, true );
     } else {
@@ -1237,7 +1237,7 @@ ExecutionResult Client::call( Address const& _from, u256 _value, Address _dest, 
         u256 gasPrice = _gasPrice == Invalid256 ? gasBidPrice() : _gasPrice;
         Transaction t( _value, gasPrice, gasLimit, _dest, _data, nonce );
         t.forceSender( _from );
-        t.forceChainId( chainParams().chainID );
+        t.forceChainId( chainParams().getChainId() );
         t.ignoreExternalGas();
         if ( _ff == FudgeFactor::Lenient )
             temp.mutableState().addBalance( _from, ( u256 )( t.gas() * t.gasPrice() + t.value() ) );
@@ -1362,36 +1362,38 @@ void Client::initHistoricGroupIndex() {
         return;
     }
 
+    auto nodeGroups = chainParams().getNodeGroups();
+
     uint64_t currentBlockTimestamp = blockInfo( hashFromNumber( number() ) ).timestamp();
     uint64_t previousBlockTimestamp = blockInfo( hashFromNumber( number() - 1 ) ).timestamp();
 
     // always returns it != end() because current finish ts equals to uint64_t(-1)
-    auto it = std::find_if( chainParams().sChain.nodeGroups.begin(),
-        chainParams().sChain.nodeGroups.end(),
+    auto it = std::find_if( nodeGroups.begin(), nodeGroups.end(),
         [&currentBlockTimestamp](
             const dev::eth::NodeGroup& ng ) { return currentBlockTimestamp <= ng.finishTs; } );
 
-    if ( it == chainParams().sChain.nodeGroups.end() ) {
+    if ( it == nodeGroups.end() ) {
         BOOST_THROW_EXCEPTION(
             std::runtime_error( "Assertion failed: it == chainParams().sChain.nodeGroups.end()" ) );
     }
 
-    if ( it != chainParams().sChain.nodeGroups.begin() ) {
+    if ( it != nodeGroups.begin() ) {
         auto prevIt = std::prev( it );
         if ( currentBlockTimestamp >= prevIt->finishTs &&
              previousBlockTimestamp < prevIt->finishTs )
             it = prevIt;
     }
 
-    historicGroupIndex = std::distance( chainParams().sChain.nodeGroups.begin(), it );
+    historicGroupIndex = std::distance( nodeGroups.begin(), it );
 }
 
 void Client::updateHistoricGroupIndex() {
+    auto nodeGroups = chainParams().getNodeGroups();
     uint64_t blockTimestamp = blockInfo( hashFromNumber( number() ) ).timestamp();
-    uint64_t currentFinishTs = chainParams().sChain.nodeGroups.at( historicGroupIndex ).finishTs;
+    uint64_t currentFinishTs = nodeGroups.at( historicGroupIndex ).finishTs;
     if ( blockTimestamp >= currentFinishTs )
         ++historicGroupIndex;
-    if ( historicGroupIndex >= chainParams().sChain.nodeGroups.size() ) {
+    if ( historicGroupIndex >= nodeGroups.size() ) {
         BOOST_THROW_EXCEPTION( std::runtime_error(
             "Assertion failed: historicGroupIndex >= chainParams().sChain.nodeGroups.size())" ) );
     }

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -254,7 +254,7 @@ void Client::initStateFromDiskOrGenesis() {
     m_state = State( chainParams().getAccountStartNonce(), m_dbPath, bc().genesisHash(),
         BaseState::PreExisting, chainParams().getAccountInitialFunds()
 #ifndef MIRAGE
-        ,
+                                    ,
         chainParams().sChain.contractStorageLimit
 #endif
 #ifdef HISTORIC_STATE
@@ -1155,7 +1155,8 @@ h256 Client::importTransaction( Transaction const& _t, TransactionBroadcast _txO
 #endif
 
     ImportResult res;
-    if ( chainParams().isMultiTransactionModeEnabled() && state.getNonce( _t.sender() ) < _t.nonce() &&
+    if ( chainParams().isMultiTransactionModeEnabled() &&
+         state.getNonce( _t.sender() ) < _t.nonce() &&
          m_tq.maxCurrentNonce( _t.sender() ) != _t.nonce() ) {
         res = m_tq.import( _t, IfDropped::Ignore, true );
     } else {

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -119,7 +119,7 @@ std::ostream& dev::eth::operator<<( std::ostream& _out, ActivityReport const& _r
     return _out;
 }
 
-Client::Client( ChainParams const& _params, int _networkID,
+Client::Client( std::shared_ptr< const ChainParams > _params, int _networkID,
     std::shared_ptr< GasPricer > _gpForAdoption,
     std::shared_ptr< SnapshotManager > _snapshotManager,
     std::shared_ptr< InstanceMonitor > _instanceMonitor, fs::path const& _dbPath,
@@ -132,7 +132,7 @@ Client::Client( ChainParams const& _params, int _networkID,
       m_postSeal( chainParams().accountStartNonce ),
       m_working( chainParams().accountStartNonce ),
       m_snapshotAgent( make_shared< SnapshotAgent >(
-          _params.sChain.snapshotIntervalSec, _snapshotManager, m_debugTracer ) ),
+          _params->getSnapshotIntervalSec(), _snapshotManager, m_debugTracer ) ),
       m_instanceMonitor( _instanceMonitor ),
       m_dbPath( _dbPath )
 #ifdef HISTORIC_STATE

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -229,7 +229,7 @@ void Client::populateNewChainStateFromGenesis() {
     DEV_GUARDED( m_blockImportMutex )
 #ifdef HISTORIC_STATE
     m_state = m_state.createStateCopyAndClearCaches();
-    m_state.populateFrom( bc().chainParams().genesisState );
+    m_state.populateFrom( bc().chainParams().getGenesisState() );
     m_state.mutableHistoricState().saveRootForBlockNumber( 0 );  // TODO is it safe to assume
                                                                  // it's 0?
     m_state.mutableHistoricState().db().commit();
@@ -255,11 +255,11 @@ void Client::initStateFromDiskOrGenesis() {
         BaseState::PreExisting, chainParams().getAccountInitialFunds()
 #ifndef MIRAGE
                                     ,
-        chainParams().sChain.contractStorageLimit
+        chainParams().getContractStorageLimit()
 #endif
 #ifdef HISTORIC_STATE
         ,
-        chainParams().sChain.maxHistoricStateDbSize
+        chainParams().getMaxHistoricStateDbSize()
 #endif
     );
 
@@ -1212,7 +1212,7 @@ ExecutionResult Client::call( Address const& _from, u256 _value, Address _dest, 
                 u256 gasPrice = _gasPrice == Invalid256 ? gasBidPrice() : _gasPrice;
                 Transaction t( _value, gasPrice, gasLimit, _dest, _data, nonce );
                 t.forceSender( _from );
-                t.forceChainId( chainParams().chainID );
+                t.forceChainId( chainParams().getChainId() );
                 t.ignoreExternalGas();
                 // if we are in a call, we add to the balance of the account
                 // value needed for the call to guaranteed pass
@@ -1296,7 +1296,7 @@ Transaction Client::createTransactionForCallOrTraceCall( const Address& _from, c
     // if call or trace call request did not specify from address, zero address is used
     auto from = _from ? _from : ZeroAddress;
     t.forceSender( from );
-    t.forceChainId( chainParams().chainID );
+    t.forceChainId( chainParams().getChainId() );
     // call and traceCall do not use PoW
     t.ignoreExternalGas();
     return t;

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -330,25 +330,22 @@ public:
     }
 
     std::array< std::string, 4 > getCurrentBLSPublicKey() const {
-        return chainParams().sChain.nodeGroups.at( historicGroupIndex ).blsPublicKey;
+        return chainParams().getBlsPublicKeyForHistoricGroup( historicGroupIndex );
     }
 
     // get node id for historic node in chain
     std::string getHistoricNodeId( unsigned _id ) const {
-        return chainParams().sChain.nodeGroups.at( historicGroupIndex ).nodes.at( _id ).id.str();
+        return chainParams().getHistoricNodeId( historicGroupIndex, _id ).str();
     }
 
     // get schain index for historic node in chain
     std::string getHistoricNodeIndex( unsigned _idx ) const {
-        return chainParams()
-            .sChain.nodeGroups.at( historicGroupIndex )
-            .nodes.at( _idx )
-            .schainIndex.str();
+        return chainParams().getHistoricNodeIndex( historicGroupIndex, _idx ).str();
     }
 
     // get node owner for historic node in chain
     std::string getHistoricNodePublicKey( unsigned _idx ) const {
-        return chainParams().sChain.nodeGroups.at( historicGroupIndex ).nodes.at( _idx ).publicKey;
+        return chainParams().getHistoricNodePublicKey( historicGroupIndex, _idx );
     }
 
     void doStateDbCompaction() const { m_state.getOriginalDb()->doCompaction(); }

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -91,7 +91,8 @@ class Client : public ClientBase, protected Worker {
     friend class ::SkaleHost;
 
 public:
-    Client( std::shared_ptr< const ChainParams > _params, int _networkID, std::shared_ptr< GasPricer > _gpForAdoption,
+    Client( std::shared_ptr< const ChainParams > _params, int _networkID,
+        std::shared_ptr< GasPricer > _gpForAdoption,
         std::shared_ptr< SnapshotManager > _snapshotManager,
         std::shared_ptr< InstanceMonitor > _instanceMonitor,
         boost::filesystem::path const& _dbPath = boost::filesystem::path(),

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -91,7 +91,7 @@ class Client : public ClientBase, protected Worker {
     friend class ::SkaleHost;
 
 public:
-    Client( ChainParams const& _params, int _networkID, std::shared_ptr< GasPricer > _gpForAdoption,
+    Client( std::shared_ptr< const ChainParams > _params, int _networkID, std::shared_ptr< GasPricer > _gpForAdoption,
         std::shared_ptr< SnapshotManager > _snapshotManager,
         std::shared_ptr< InstanceMonitor > _instanceMonitor,
         boost::filesystem::path const& _dbPath = boost::filesystem::path(),

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -94,7 +94,7 @@ std::pair< bool, ExecutionResult > ClientBase::estimateGasStep( int64_t _gas, Bl
     t.forceChainId( chainId() );
     t.ignoreExternalGas();
     EnvInfo const env( _pendingBlock.info(), bc().lastBlockHashes(),
-        _pendingBlock.previousInfo().timestamp(), 0, _gas, bc().chainParams().chainID );
+        _pendingBlock.previousInfo().timestamp(), 0, _gas, bc().chainParams().getChainId() );
     // Make a copy of the state, it will be deleted after this step
     State tempState = _latestBlock.mutableState();
     tempState.addBalance( _from, ( u256 )( t.gas() * t.gasPrice() + t.value() ) );
@@ -198,7 +198,7 @@ LocalisedLogEntries ClientBase::logs( LogFilter const& _f ) const {
     unsigned begin = min( bc().number() + 1, ( unsigned ) _f.latest() );
     unsigned end = min( bc().number(), min( begin, ( unsigned ) _f.earliest() ) );
 
-    if ( begin >= end && begin - end > ( uint64_t ) bc().chainParams().getLogsBlocksLimit )
+    if ( begin >= end && begin - end > ( uint64_t ) bc().chainParams().getLogsBlocksLimit() )
         BOOST_THROW_EXCEPTION( TooBigResponse() );
 
     // Handle pending transactions differently as they're not on the block chain.
@@ -605,7 +605,7 @@ Block ClientBase::latestBlock() const {
 }
 
 uint64_t ClientBase::chainId() const {
-    return bc().chainParams().chainID;
+    return bc().chainParams().getChainId();
 }
 
 

--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -55,7 +55,7 @@ ClientTest::~ClientTest() {
 }
 
 void ClientTest::modifyTimestamp( int64_t _timestamp ) {
-    Block block( chainParams().accountStartNonce );
+    Block block( chainParams().getAccountStartNonce() );
     DEV_READ_GUARDED( x_preSeal )
     block = m_preSeal;
 

--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -41,7 +41,7 @@ ClientTest* dev::eth::asClientTest( Interface* _c ) {
     return &dynamic_cast< ClientTest& >( *_c );
 }
 
-ClientTest::ClientTest( ChainParams const& _params, int _networkID,
+ClientTest::ClientTest( std::shared_ptr< const ChainParams > _params, int _networkID,
     std::shared_ptr< GasPricer > _gpForAdoption,
     std::shared_ptr< SnapshotManager > _snapshotManager,
     std::shared_ptr< InstanceMonitor > _instanceMonitor, fs::path const& _dbPath,

--- a/libethereum/ClientTest.h
+++ b/libethereum/ClientTest.h
@@ -36,7 +36,7 @@ DEV_SIMPLE_EXCEPTION( ImportBlockFailed );
 class ClientTest : public Client {
 public:
     /// Trivial forwarding constructor.
-    ClientTest( ChainParams const& _params, int _networkID,
+    ClientTest( std::shared_ptr< const ChainParams > _params, int _networkID,
         std::shared_ptr< GasPricer > _gpForAdoption,
         std::shared_ptr< SnapshotManager > _snapshotManager,
         std::shared_ptr< InstanceMonitor > _instanceMonitor,

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -176,7 +176,7 @@ Executive::Executive( Block& _s, LastBlockHashesFace const& _lh, const u256& _ga
     unsigned _level, bool _readOnly )
     : m_s( _s.mutableState() ),
       m_envInfo( _s.info(), _lh, _s.previousInfo().timestamp(), 0,
-          _s.sealEngine()->chainParams().chainID ),
+          _s.sealEngine()->chainParams().getChainId() ),
       m_depth( _level ),
       m_readOnly( _readOnly ),
       m_chainParams( _s.sealEngine()->chainParams() ),
@@ -320,7 +320,7 @@ bool Executive::call( CallParameters const& _p, u256 const& _gasPrice, Address c
         //        for the transaction.
         // Increment associated nonce for sender.
         if ( _p.senderAddress != MaxAddress ||
-             m_envInfo.number() < m_chainParams.constantinopleForkBlock ) {  // EIP86
+             m_envInfo.number() < m_chainParams.getConstantinopleForkBlock() ) {  // EIP86
             MICROPROFILE_SCOPEI( "Executive", "call-incNonce", MP_SEAGREEN );
             m_s.incNonce( _p.senderAddress );
         }
@@ -343,7 +343,7 @@ bool Executive::call( CallParameters const& _p, u256 const& _gasPrice, Address c
             // https://github.com/ethereum/go-ethereum/pull/3341/files#diff-2433aa143ee4772026454b8abd76b9dd
             // We mark the account as touched here, so that is can be removed among other touched
             // empty accounts (after tx finalization)
-            if ( m_envInfo.number() >= m_chainParams.EIP158ForkBlock )
+            if ( m_envInfo.number() >= m_chainParams.getEIP158ForkBlock() )
                 m_s.addBalance( _p.codeAddress, 0 );
 
             return true;  // true actually means "all finished - nothing more to be done regarding
@@ -412,7 +412,7 @@ bool Executive::executeCreate( Address const& _sender, u256 const& _endowment,
     u256 const& _gasPrice, u256 const& _gas, bytesConstRef _init, Address const& _origin,
     u256 const& _version ) {
     if ( _sender != MaxAddress ||
-         m_envInfo.number() < m_chainParams.experimentalForkBlock )  // EIP86
+         m_envInfo.number() < m_chainParams.getExperimentalForkBlock() )  // EIP86
         m_s.incNonce( _sender );
 
     m_savepoint = m_s.savepoint();
@@ -439,7 +439,7 @@ bool Executive::executeCreate( Address const& _sender, u256 const& _endowment,
     m_s.transferBalance( _sender, m_newAddress, _endowment );
 
     u256 newNonce = m_s.requireAccountStartNonce();
-    if ( m_envInfo.number() >= m_chainParams.EIP158ForkBlock )
+    if ( m_envInfo.number() >= m_chainParams.getEIP158ForkBlock() )
         newNonce += 1;
     m_s.setNonce( m_newAddress, newNonce );
 

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -185,7 +185,7 @@ h256 ExtVM::blockHash( u256 _number ) {
     if ( _number >= currentNumber || _number < ( std::max< u256 >( 256, currentNumber ) - 256 ) )
         return h256();
 
-    if ( currentNumber < m_chainParams.experimentalForkBlock + 256 ) {
+    if ( currentNumber < m_chainParams.getExperimentalForkBlock() + 256 ) {
         h256 const parentHash = envInfo().header().parentHash();
         h256s const lastHashes = envInfo().lastHashes().precedingHashes( parentHash );
 

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -214,7 +214,7 @@ ETH_REGISTER_PRECOMPILED( alt_bn128_G1_add )( bytesConstRef _in ) {
 
 ETH_REGISTER_PRECOMPILED_PRICER( alt_bn128_G1_add )
 ( bytesConstRef /*_in*/, ChainOperationParams const& _chainParams, u256 const& _blockNumber ) {
-    return _blockNumber < _chainParams.istanbulForkBlock ? 500 : 150;
+    return _blockNumber < _chainParams.getIstanbulForkBlock() ? 500 : 150;
 }
 
 ETH_REGISTER_PRECOMPILED( alt_bn128_G1_mul )( bytesConstRef _in ) {
@@ -223,7 +223,7 @@ ETH_REGISTER_PRECOMPILED( alt_bn128_G1_mul )( bytesConstRef _in ) {
 
 ETH_REGISTER_PRECOMPILED_PRICER( alt_bn128_G1_mul )
 ( bytesConstRef /*_in*/, ChainOperationParams const& _chainParams, u256 const& _blockNumber ) {
-    return _blockNumber < _chainParams.istanbulForkBlock ? 40000 : 6000;
+    return _blockNumber < _chainParams.getIstanbulForkBlock() ? 40000 : 6000;
 }
 
 ETH_REGISTER_PRECOMPILED( alt_bn128_pairing_product )( bytesConstRef _in ) {
@@ -233,7 +233,7 @@ ETH_REGISTER_PRECOMPILED( alt_bn128_pairing_product )( bytesConstRef _in ) {
 ETH_REGISTER_PRECOMPILED_PRICER( alt_bn128_pairing_product )
 ( bytesConstRef _in, ChainOperationParams const& _chainParams, u256 const& _blockNumber ) {
     auto const k = _in.size() / 192;
-    return _blockNumber < _chainParams.istanbulForkBlock ? 100000 + k * 80000 : 45000 + k * 34000;
+    return _blockNumber < _chainParams.getIstanbulForkBlock() ? 100000 + k * 80000 : 45000 + k * 34000;
 }
 
 static Logger& getLogger( int a_severity = VerbosityTrace ) {

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -233,7 +233,8 @@ ETH_REGISTER_PRECOMPILED( alt_bn128_pairing_product )( bytesConstRef _in ) {
 ETH_REGISTER_PRECOMPILED_PRICER( alt_bn128_pairing_product )
 ( bytesConstRef _in, ChainOperationParams const& _chainParams, u256 const& _blockNumber ) {
     auto const k = _in.size() / 192;
-    return _blockNumber < _chainParams.getIstanbulForkBlock() ? 100000 + k * 80000 : 45000 + k * 34000;
+    return _blockNumber < _chainParams.getIstanbulForkBlock() ? 100000 + k * 80000 :
+                                                                45000 + k * 34000;
 }
 
 static Logger& getLogger( int a_severity = VerbosityTrace ) {

--- a/libethereum/SchainPatch.cpp
+++ b/libethereum/SchainPatch.cpp
@@ -106,9 +106,9 @@ const std::unordered_set< SchainPatchEnum > SchainPatch::preDisabledForMIRAGE = 
 
 void SchainPatch::init( const dev::eth::ChainOperationParams& _cp ) {
     chainParams = _cp;
-    for ( size_t i = 0; i < _cp.sChain._patchTimestamps.size(); ++i ) {
+    for ( size_t i = 0; i < static_cast< size_t>( SchainPatchEnum::PatchesCount ); ++i ) {
         printInfo( getPatchNameForEnum( static_cast< SchainPatchEnum >( i ) ),
-            _cp.sChain._patchTimestamps[i] );
+            _cp.getPatchTimestamp( static_cast< SchainPatchEnum >( i ) ) );
     }
 }
 

--- a/libethereum/SchainPatch.cpp
+++ b/libethereum/SchainPatch.cpp
@@ -106,7 +106,7 @@ const std::unordered_set< SchainPatchEnum > SchainPatch::preDisabledForMIRAGE = 
 
 void SchainPatch::init( const dev::eth::ChainOperationParams& _cp ) {
     chainParams = _cp;
-    for ( size_t i = 0; i < static_cast< size_t>( SchainPatchEnum::PatchesCount ); ++i ) {
+    for ( size_t i = 0; i < static_cast< size_t >( SchainPatchEnum::PatchesCount ); ++i ) {
         printInfo( getPatchNameForEnum( static_cast< SchainPatchEnum >( i ) ),
             _cp.getPatchTimestamp( static_cast< SchainPatchEnum >( i ) ) );
     }

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -132,7 +132,7 @@ void DefaultConsensusFactory::fillSgxInfo( ConsensusEngine& consensus ) const tr
         sgxSSLCertFilePath = sgx_cert_path + sgx_cert_filename;
     }
 
-    std::string ecdsaKeyName = m_client.chainParams().getKeyShareName();
+    std::string ecdsaKeyName = m_client.chainParams().getEcdsaKeyName();
 
     std::string blsKeyName = m_client.chainParams().getKeyShareName();
 

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -87,9 +87,9 @@ std::unique_ptr< ConsensusInterface > DefaultConsensusFactory::create(
 #endif
 
     auto consensus_engine_ptr = make_unique< ConsensusEngine >( _extFace, m_client.number(), ts, 0,
-        patchTimeStamps, m_client.chainParams().sChain.consensusStorageLimit );
+        patchTimeStamps, m_client.chainParams().getConsensusStorageLimit() );
 
-    if ( m_client.chainParams().nodeInfo.sgxServerUrl != "" ) {
+    if ( m_client.chainParams().getSgxServerUrl() != "" ) {
         this->fillSgxInfo( *consensus_engine_ptr );
     }
 
@@ -108,7 +108,7 @@ std::unique_ptr< ConsensusInterface > DefaultConsensusFactory::create(
 
 #if CONSENSUS
 void DefaultConsensusFactory::fillSgxInfo( ConsensusEngine& consensus ) const try {
-    const std::string sgxServerUrl = m_client.chainParams().nodeInfo.sgxServerUrl;
+    const std::string sgxServerUrl = m_client.chainParams().getSgxServerUrl();
 
     std::string sgx_cert_path = getenv( "SGX_CERT_FOLDER" ) ? getenv( "SGX_CERT_FOLDER" ) : "";
     if ( sgx_cert_path.empty() )
@@ -132,9 +132,9 @@ void DefaultConsensusFactory::fillSgxInfo( ConsensusEngine& consensus ) const tr
         sgxSSLCertFilePath = sgx_cert_path + sgx_cert_filename;
     }
 
-    std::string ecdsaKeyName = m_client.chainParams().nodeInfo.ecdsaKeyName;
+    std::string ecdsaKeyName = m_client.chainParams().getKeyShareName();
 
-    std::string blsKeyName = m_client.chainParams().nodeInfo.keyShareName;
+    std::string blsKeyName = m_client.chainParams().getKeyShareName();
 
     consensus.setSGXKeyInfo(
         sgxServerUrl, sgxSSLKeyFilePath, sgxSSLCertFilePath, ecdsaKeyName, blsKeyName );
@@ -145,31 +145,32 @@ void DefaultConsensusFactory::fillSgxInfo( ConsensusEngine& consensus ) const tr
 }
 
 void DefaultConsensusFactory::fillPublicKeyInfo( ConsensusEngine& consensus ) const try {
-    if ( m_client.chainParams().nodeInfo.testSignatures )
+    if ( m_client.chainParams().isTestSignaturesEnabled() )
         // no keys in tests
         return;
 
-    const std::string sgxServerUrl = m_client.chainParams().nodeInfo.sgxServerUrl;
+    const std::string sgxServerUrl = m_client.chainParams().getSgxServerUrl();
 
     std::shared_ptr< std::vector< std::string > > ecdsaPublicKeys =
         std::make_shared< std::vector< std::string > >();
-    for ( const auto& node : m_client.chainParams().sChain.nodes ) {
+    for ( const auto& node : m_client.chainParams().getSchainNodes() ) {
         ecdsaPublicKeys->push_back( node.publicKey.substr( 2 ) );
     }
 
     std::vector< std::shared_ptr< std::vector< std::string > > > blsPublicKeys;
-    for ( const auto& node : m_client.chainParams().sChain.nodes ) {
+    for ( const auto& node : m_client.chainParams().getSchainNodes() ) {
         std::vector< std::string > public_key_share( 4 );
-        if ( node.id != this->m_client.chainParams().nodeInfo.id ) {
+        if ( node.id != this->m_client.chainParams().getSelfNodeId() ) {
             public_key_share[0] = node.blsPublicKey.at( 0 );
             public_key_share[1] = node.blsPublicKey.at( 1 );
             public_key_share[2] = node.blsPublicKey.at( 2 );
             public_key_share[3] = node.blsPublicKey.at( 3 );
         } else {
-            public_key_share[0] = m_client.chainParams().nodeInfo.BLSPublicKeys.at( 0 );
-            public_key_share[1] = m_client.chainParams().nodeInfo.BLSPublicKeys.at( 1 );
-            public_key_share[2] = m_client.chainParams().nodeInfo.BLSPublicKeys.at( 2 );
-            public_key_share[3] = m_client.chainParams().nodeInfo.BLSPublicKeys.at( 3 );
+            auto blsPublicKey = m_client.chainParams().getSelfBlsPublicKey();
+            public_key_share[0] = blsPublicKey.at( 0 );
+            public_key_share[1] = blsPublicKey.at( 1 );
+            public_key_share[2] = blsPublicKey.at( 2 );
+            public_key_share[3] = blsPublicKey.at( 3 );
         }
 
         blsPublicKeys.push_back(
@@ -180,11 +181,11 @@ void DefaultConsensusFactory::fillPublicKeyInfo( ConsensusEngine& consensus ) co
         std::make_shared< std::vector< std::shared_ptr< std::vector< std::string > > > >(
             blsPublicKeys );
 
-    size_t n = m_client.chainParams().sChain.nodes.size();
+    size_t n = m_client.chainParams().getNodesCount();
     size_t t = ( 2 * n + 1 ) / 3;
 
     consensus.setPublicKeyInfo(
-        ecdsaPublicKeys, blsPublicKeysPtr, t, n, m_client.chainParams().nodeInfo.syncNode );
+        ecdsaPublicKeys, blsPublicKeysPtr, t, n, m_client.chainParams().isSyncNode() );
 } catch ( ... ) {
     std::throw_with_nested( std::runtime_error( "Error filling public keys info (nodeGroups)" ) );
 }
@@ -195,7 +196,7 @@ void DefaultConsensusFactory::fillRotationHistory( ConsensusEngine& consensus ) 
     std::map< uint64_t, std::string > historicECDSAKeys;
     std::map< uint64_t, std::vector< uint64_t > > historicNodeGroups;
     auto u256toUint64 = []( const dev::u256& u ) { return std::stoull( u.str() ); };
-    for ( const auto& nodeGroup : m_client.chainParams().sChain.nodeGroups ) {
+    for ( const auto& nodeGroup : m_client.chainParams().getNodeGroups() ) {
         std::vector< string > commonBLSPublicKey = { nodeGroup.blsPublicKey.at( 0 ),
             nodeGroup.blsPublicKey.at( 1 ), nodeGroup.blsPublicKey.at( 2 ),
             nodeGroup.blsPublicKey.at( 3 ) };
@@ -441,7 +442,7 @@ ConsensusExtFace::transactions_vector SkaleHost::pendingTransactions(
                 m_pending_createMutex.lock();
 
             try {
-                bool isMtmEnabled = m_client.chainParams().sChain.multiTransactionMode;
+                bool isMtmEnabled = m_client.chainParams().isMultiTransactionModeEnabled();
                 Executive::verifyTransaction( tx, latestInfo.timestamp(), latestInfo,
                     m_client.state().createReadOnlySnapBasedCopy(), m_client.chainParams(), 0,
                     getGasPrice(), isMtmEnabled );
@@ -464,7 +465,7 @@ ConsensusExtFace::transactions_vector SkaleHost::pendingTransactions(
     std::lock_guard< std::recursive_mutex > lock( m_pending_createMutex, std::adopt_lock );
 
     // drop by block gas limit
-    u256 blockGasLimit = this->m_client.chainParams().gasLimit;
+    u256 blockGasLimit = this->m_client.chainParams().getGasLimit();
     u256 gasAcc = 0;
     auto first_to_drop_it = txns.begin();
     for ( ; first_to_drop_it != txns.end(); ++first_to_drop_it ) {
@@ -541,7 +542,7 @@ void SkaleHost::createBlock( const ConsensusExtFace::transactions_vector& _appro
     // convert bytes back to transactions (using caching), delete them from q and push results into
     // blockchain
 
-    if ( this->m_client.chainParams().sChain.snapshotIntervalSec > 0 ) {
+    if ( this->m_client.chainParams().getSnapshotIntervalSec() > 0 ) {
         dev::h256 stCurrent =
             this->m_client.blockInfo( this->m_client.hashFromNumber( _blockID - 1 ) ).stateRoot();
 

--- a/libethereum/Transaction.cpp
+++ b/libethereum/Transaction.cpp
@@ -199,7 +199,7 @@ u256 Transaction::gasPrice() const {
 
 void Transaction::checkOutExternalGas(
     const ChainParams& _cp, time_t _committedBlockTimestamp, uint64_t _committedBlockNumber ) {
-    u256 const& difficulty = _cp.externalGasDifficulty;
+    u256 const& difficulty = _cp.getExternalGasDifficulty();
     assert( difficulty > 0 );
     if ( !isInvalid() ) {
         h256 hash;

--- a/libethereum/db_repair.cpp
+++ b/libethereum/db_repair.cpp
@@ -58,7 +58,7 @@ void dump_blocks_and_extras_db( const BlockChain& _bc, size_t _startBlock ) {
 
 void dump_blocks_and_extras_db( boost::filesystem::path const& _path, size_t _startBlock ) {
     std::shared_ptr< ChainParams > dummy_cp;
-    dummy_cp->sealEngineName = NoProof::name();
+    dummy_cp->setSealEngineName( NoProof::name() );
     BlockChain bc( dummy_cp, _path, false, WithExisting::Trust );
     dump_blocks_and_extras_db( bc, _startBlock );
 }

--- a/libethereum/db_repair.cpp
+++ b/libethereum/db_repair.cpp
@@ -57,8 +57,8 @@ void dump_blocks_and_extras_db( const BlockChain& _bc, size_t _startBlock ) {
 }
 
 void dump_blocks_and_extras_db( boost::filesystem::path const& _path, size_t _startBlock ) {
-    ChainParams dummy_cp;
-    dummy_cp.sealEngineName = NoProof::name();
+    std::shared_ptr< ChainParams > dummy_cp;
+    dummy_cp->sealEngineName = NoProof::name();
     BlockChain bc( dummy_cp, _path, false, WithExisting::Trust );
     dump_blocks_and_extras_db( bc, _startBlock );
 }

--- a/libhistoric/AlethExecutive.cpp
+++ b/libhistoric/AlethExecutive.cpp
@@ -160,7 +160,7 @@ bool AlethExecutive::call(
         //        for the transaction.
         // Increment associated nonce for sender.
         if ( _p.senderAddress != MaxAddress ||
-             m_envInfo.number() < m_chainParams.experimentalForkBlock )  // EIP86
+             m_envInfo.number() < m_chainParams.getExperimentalForkBlock() )  // EIP86
             m_s.incNonce( _p.senderAddress );
     }
 
@@ -256,7 +256,7 @@ bool AlethExecutive::executeCreate( Address const& _sender, u256 const& _endowme
     u256 const& _gasPrice, u256 const& _gas, bytesConstRef _init, Address const& _origin,
     u256 const& _version ) {
     if ( _sender != MaxAddress ||
-         m_envInfo.number() < m_chainParams.experimentalForkBlock )  // EIP86
+         m_envInfo.number() < m_chainParams.getExperimentalForkBlock() )  // EIP86
         m_s.incNonce( _sender );
 
     m_savepoint = m_s.savepoint();
@@ -283,7 +283,7 @@ bool AlethExecutive::executeCreate( Address const& _sender, u256 const& _endowme
     m_s.transferBalance( _sender, m_newAddress, _endowment );
 
     u256 newNonce = m_s.requireAccountStartNonce();
-    if ( m_envInfo.number() >= m_chainParams.EIP158ForkBlock )
+    if ( m_envInfo.number() >= m_chainParams.getEIP158ForkBlock() )
         newNonce += 1;
     m_s.setNonce( m_newAddress, newNonce );
 

--- a/libhistoric/AlethExtVM.cpp
+++ b/libhistoric/AlethExtVM.cpp
@@ -177,7 +177,7 @@ h256 AlethExtVM::blockHash( u256 _number ) {
     if ( _number >= currentNumber || _number < ( std::max< u256 >( 256, currentNumber ) - 256 ) )
         return h256();
 
-    if ( currentNumber < m_chainParams.experimentalForkBlock + 256 ) {
+    if ( currentNumber < m_chainParams.getExperimentalForkBlock() + 256 ) {
         h256 const parentHash = envInfo().header().parentHash();
         h256s const lastHashes = envInfo().lastHashes().precedingHashes( parentHash );
 

--- a/libhistoric/HistoricState.cpp
+++ b/libhistoric/HistoricState.cpp
@@ -644,7 +644,7 @@ std::pair< ExecutionResult, TransactionReceipt > HistoricState::execute( EnvInfo
     }
 
     TransactionReceipt const receipt =
-        _envInfo.number() >= _chainParams.byzantiumForkBlock ?
+        _envInfo.number() >= _chainParams.getByzantiumForkBlock() ?
             TransactionReceipt( statusCode, startGasUsed + e.gasUsed(), e.logs() ) :
             TransactionReceipt( globalRoot(), startGasUsed + e.gasUsed(), e.logs() );
 

--- a/libskale/AmsterdamFixPatch.cpp
+++ b/libskale/AmsterdamFixPatch.cpp
@@ -264,7 +264,8 @@ bool AmsterdamFixPatch::snapshotHashCheckingEnabled( const dev::eth::ChainParams
         return true;
 
     std::vector< size_t > majority = majorityNodesIds();
-    bool found = majority.end() != std::find( majority.begin(), majority.end(), _cp.getSelfNodeId() );
+    bool found =
+        majority.end() != std::find( majority.begin(), majority.end(), _cp.getSelfNodeId() );
 
     // disable checking on minority
     return found;

--- a/libskale/AmsterdamFixPatch.cpp
+++ b/libskale/AmsterdamFixPatch.cpp
@@ -34,7 +34,7 @@ size_t AmsterdamFixPatch::lastGoodBlock( const ChainParams& _chainParams ) {
     if ( lgb_str )
         return strtoul( lgb_str, nullptr, 10 );
 
-    switch ( _chainParams.chainID ) {
+    switch ( _chainParams.getChainId() ) {
     case 0xd2ba743e9fef4:
         return 1981742;  // checked on http://18.130.254.6:10003 and http://88.99.209.96:10003
     case 0x292a2c91ca6a3:
@@ -75,7 +75,7 @@ bool AmsterdamFixPatch::isInitOnChainNeeded(
 bool AmsterdamFixPatch::isEnabled( const Client& _client ) {
     //_client.call();
     // return _client.number() < lastBlockToModify;
-    auto chainID = _client.chainParams().chainID;
+    auto chainID = _client.chainParams().getChainId();
     bool res = ( chainID == 0xd2ba743e9fef4 || chainID == 0x292a2c91ca6a3 ||
                    chainID == 0x1c6fa7f59eeac || chainID == 0x4b127e9c2f7de ) &&
                _client.countAt( magicAddress ) == 0;
@@ -234,7 +234,7 @@ void AmsterdamFixPatch::initOnChain( batched_io::db_operations_face& _blocksDB,
     }  // for
 }
 bool AmsterdamFixPatch::stateRootCheckingEnabled( const Client& _client ) {
-    uint64_t chainID = _client.chainParams().chainID;
+    uint64_t chainID = _client.chainParams().getChainId();
     if ( !isEnabled( _client ) )
         return true;
 
@@ -259,12 +259,12 @@ h256 AmsterdamFixPatch::overrideStateRoot( const Client& _client ) {
 }
 
 bool AmsterdamFixPatch::snapshotHashCheckingEnabled( const dev::eth::ChainParams& _cp ) {
-    if ( _cp.chainID != 0xd2ba743e9fef4 && _cp.chainID != 0x292a2c91ca6a3 &&
-         _cp.chainID != 0x1c6fa7f59eeac && _cp.chainID != 0x4b127e9c2f7de )
+    if ( _cp.getChainId() != 0xd2ba743e9fef4 && _cp.getChainId() != 0x292a2c91ca6a3 &&
+         _cp.getChainId() != 0x1c6fa7f59eeac && _cp.getChainId() != 0x4b127e9c2f7de )
         return true;
 
     std::vector< size_t > majority = majorityNodesIds();
-    bool found = majority.end() != std::find( majority.begin(), majority.end(), _cp.nodeInfo.id );
+    bool found = majority.end() != std::find( majority.begin(), majority.end(), _cp.getSelfNodeId() );
 
     // disable checking on minority
     return found;

--- a/libskale/SnapshotHashAgent.cpp
+++ b/libskale/SnapshotHashAgent.cpp
@@ -63,14 +63,10 @@ SnapshotHashAgent::SnapshotHashAgent( const dev::eth::ChainParams& chainParams,
 
 void SnapshotHashAgent::readPublicKeyFromConfig() {
     auto commonBlsPublicKeyArray = chainParams_.getCommonBlsPublicKey();
-    this->commonPublicKey_.X.c0 =
-        libff::alt_bn128_Fq( commonBlsPublicKeyArray[0].c_str() );
-    this->commonPublicKey_.X.c1 =
-        libff::alt_bn128_Fq( commonBlsPublicKeyArray[1].c_str() );
-    this->commonPublicKey_.Y.c0 =
-        libff::alt_bn128_Fq( commonBlsPublicKeyArray[2].c_str() );
-    this->commonPublicKey_.Y.c1 =
-        libff::alt_bn128_Fq( commonBlsPublicKeyArray[3].c_str() );
+    this->commonPublicKey_.X.c0 = libff::alt_bn128_Fq( commonBlsPublicKeyArray[0].c_str() );
+    this->commonPublicKey_.X.c1 = libff::alt_bn128_Fq( commonBlsPublicKeyArray[1].c_str() );
+    this->commonPublicKey_.Y.c0 = libff::alt_bn128_Fq( commonBlsPublicKeyArray[2].c_str() );
+    this->commonPublicKey_.Y.c1 = libff::alt_bn128_Fq( commonBlsPublicKeyArray[3].c_str() );
     this->commonPublicKey_.Z = libff::alt_bn128_Fq2::one();
 }
 

--- a/libskale/SnapshotHashAgent.cpp
+++ b/libskale/SnapshotHashAgent.cpp
@@ -37,7 +37,7 @@ SnapshotHashAgent::SnapshotHashAgent( const dev::eth::ChainParams& chainParams,
     const std::array< std::string, 4 >& common_public_key,
     const std::string& urlToDownloadSnapshotFrom )
     : chainParams_( chainParams ),
-      n_( chainParams.sChain.nodes.size() ),
+      n_( chainParams.getNodesCount() ),
       urlToDownloadSnapshotFrom_( urlToDownloadSnapshotFrom ) {
     this->hashes_.resize( n_ );
     this->signatures_.resize( n_ );
@@ -62,21 +62,22 @@ SnapshotHashAgent::SnapshotHashAgent( const dev::eth::ChainParams& chainParams,
 }
 
 void SnapshotHashAgent::readPublicKeyFromConfig() {
+    auto commonBlsPublicKeyArray = chainParams_.getCommonBlsPublicKey();
     this->commonPublicKey_.X.c0 =
-        libff::alt_bn128_Fq( chainParams_.nodeInfo.commonBLSPublicKeys[0].c_str() );
+        libff::alt_bn128_Fq( commonBlsPublicKeyArray[0].c_str() );
     this->commonPublicKey_.X.c1 =
-        libff::alt_bn128_Fq( chainParams_.nodeInfo.commonBLSPublicKeys[1].c_str() );
+        libff::alt_bn128_Fq( commonBlsPublicKeyArray[1].c_str() );
     this->commonPublicKey_.Y.c0 =
-        libff::alt_bn128_Fq( chainParams_.nodeInfo.commonBLSPublicKeys[2].c_str() );
+        libff::alt_bn128_Fq( commonBlsPublicKeyArray[2].c_str() );
     this->commonPublicKey_.Y.c1 =
-        libff::alt_bn128_Fq( chainParams_.nodeInfo.commonBLSPublicKeys[3].c_str() );
+        libff::alt_bn128_Fq( commonBlsPublicKeyArray[3].c_str() );
     this->commonPublicKey_.Z = libff::alt_bn128_Fq2::one();
 }
 
 size_t SnapshotHashAgent::verifyAllData() const {
     size_t verified = 0;
     for ( size_t i = 0; i < this->n_; ++i ) {
-        if ( this->chainParams_.nodeInfo.id == this->chainParams_.sChain.nodes.at( i ).id ) {
+        if ( this->chainParams_.getSelfNodeId() == this->chainParams_.getNodeByIndex( i ).id ) {
             continue;
         }
 
@@ -115,7 +116,7 @@ bool SnapshotHashAgent::voteForHash() {
     const std::lock_guard< std::mutex > lock( this->hashesMutex );
 
     for ( size_t i = 0; i < this->n_; ++i ) {
-        if ( this->chainParams_.nodeInfo.id == this->chainParams_.sChain.nodes.at( i ).id ) {
+        if ( this->chainParams_.getSelfNodeId() == this->chainParams_.getNodeByIndex( i ).id ) {
             continue;
         }
 
@@ -134,7 +135,7 @@ bool SnapshotHashAgent::voteForHash() {
         std::vector< size_t > idx;
         std::vector< libff::alt_bn128_G1 > signatures;
         for ( size_t i = 0; i < this->n_; ++i ) {
-            if ( this->chainParams_.nodeInfo.id == this->chainParams_.sChain.nodes.at( i ).id ) {
+            if ( this->chainParams_.getSelfNodeId() == this->chainParams_.getNodeByIndex( i ).id ) {
                 continue;
             }
 
@@ -177,15 +178,16 @@ bool SnapshotHashAgent::voteForHash() {
                    "common public key specified in command line. Trying again with "
                    "common public key from config";
 
+            auto commonBlsPublicKeyArray = chainParams_.getCommonBlsPublicKey();
             libff::alt_bn128_G2 commonPublicKey_from_config;
             commonPublicKey_from_config.X.c0 =
-                libff::alt_bn128_Fq( this->chainParams_.nodeInfo.commonBLSPublicKeys[0].c_str() );
+                libff::alt_bn128_Fq( commonBlsPublicKeyArray[0].c_str() );
             commonPublicKey_from_config.X.c1 =
-                libff::alt_bn128_Fq( this->chainParams_.nodeInfo.commonBLSPublicKeys[1].c_str() );
+                libff::alt_bn128_Fq( commonBlsPublicKeyArray[1].c_str() );
             commonPublicKey_from_config.Y.c0 =
-                libff::alt_bn128_Fq( this->chainParams_.nodeInfo.commonBLSPublicKeys[2].c_str() );
+                libff::alt_bn128_Fq( commonBlsPublicKeyArray[2].c_str() );
             commonPublicKey_from_config.Y.c1 =
-                libff::alt_bn128_Fq( this->chainParams_.nodeInfo.commonBLSPublicKeys[3].c_str() );
+                libff::alt_bn128_Fq( commonBlsPublicKeyArray[3].c_str() );
             commonPublicKey_from_config.Z = libff::alt_bn128_Fq2::one();
             LOG( m_loggerDebug ) << "NEW BLS COMMON PUBLIC KEY:";
             commonPublicKey_from_config.print_coordinates();
@@ -285,15 +287,15 @@ std::vector< std::string > SnapshotHashAgent::getNodesToDownloadSnapshotFrom(
 
     if ( urlToDownloadSnapshotFrom_.empty() ) {
         for ( size_t i = 0; i < this->n_; ++i ) {
-            if ( this->chainParams_.nodeInfo.id == this->chainParams_.sChain.nodes.at( i ).id ) {
+            if ( this->chainParams_.getSelfNodeId() == this->chainParams_.getNodeByIndex( i ).id ) {
                 continue;
             }
 
             threads.push_back( std::thread( [this, i, blockNumber]() {
                 try {
-                    std::string nodeUrl = "http://" + this->chainParams_.sChain.nodes.at( i ).ip +
+                    std::string nodeUrl = "http://" + this->chainParams_.getNodeByIndex( i ).ip +
                                           ':' +
-                                          ( this->chainParams_.sChain.nodes.at( i ).port + 3 )
+                                          ( this->chainParams_.getNodeByIndex( i ).port + 3 )
                                               .convert_to< std::string >();
                     auto snapshotData = askNodeForHash( nodeUrl, blockNumber );
                     if ( std::get< 0 >( snapshotData ).size > 0 ) {
@@ -331,7 +333,7 @@ std::vector< std::string > SnapshotHashAgent::getNodesToDownloadSnapshotFrom(
             if ( !this->isReceived_.at( pos ) )
                 continue;
 
-            u256 id = this->chainParams_.sChain.nodes.at( pos ).id;
+            u256 id = this->chainParams_.getNodeByIndex( pos ).id;
             bool good = majorityNodesIds.end() !=
                         std::find( majorityNodesIds.begin(), majorityNodesIds.end(), id );
             if ( !good )
@@ -369,9 +371,9 @@ std::vector< std::string > SnapshotHashAgent::getNodesToDownloadSnapshotFrom(
     std::vector< std::string > ret;
     for ( const size_t idx : this->nodesToDownloadSnapshotFrom_ ) {
         std::string ret_value =
-            std::string( "http://" ) + std::string( this->chainParams_.sChain.nodes.at( idx ).ip ) +
+            std::string( "http://" ) + std::string( this->chainParams_.getNodeByIndex( idx ).ip ) +
             std::string( ":" ) +
-            ( this->chainParams_.sChain.nodes.at( idx ).port + 3 ).convert_to< std::string >();
+            ( this->chainParams_.getNodeByIndex( idx ).port + 3 ).convert_to< std::string >();
         ret.push_back( ret_value );
     }
 

--- a/libskale/SnapshotHashAgent.h
+++ b/libskale/SnapshotHashAgent.h
@@ -76,7 +76,7 @@ public:
     friend class dev::test::SnapshotHashAgentTest;
 
 private:
-    dev::eth::ChainParams chainParams_;
+    const dev::eth::ChainParams& chainParams_;
     unsigned n_;
     std::string urlToDownloadSnapshotFrom_;
     std::shared_ptr< libBLS::Bls > bls_;

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -54,13 +54,13 @@ const std::string SnapshotManager::snapshotHashFileName = "snapshot_hash.txt";
 // - bad data dir
 // - not btrfs
 // - volumes don't exist
-SnapshotManager::SnapshotManager( const dev::eth::ChainParams& _chainParams,
+SnapshotManager::SnapshotManager( std::shared_ptr< const dev::eth::ChainParams > _chainParams,
     const fs::path& _dataDir, const std::string& _diffsDir )
     : chainParams( _chainParams ) {
     dataDir = _dataDir;
-    coreVolumes = { dev::eth::BlockChain::getChainDirName( chainParams ), "filestorage",
-        "prices_" + chainParams.nodeInfo.id.str() + ".db",
-        "blocks_" + chainParams.nodeInfo.id.str() + ".db" };
+    coreVolumes = { dev::eth::BlockChain::getChainDirName( *chainParams ), "filestorage",
+        "prices_" + chainParams->getSelfNodeId().str() + ".db",
+        "blocks_" + chainParams->getSelfNodeId().str() + ".db" };
 
 #ifdef HISTORIC_STATE
     archiveVolumes = { "historic_roots", "historic_state" };

--- a/libskale/SnapshotManager.h
+++ b/libskale/SnapshotManager.h
@@ -152,7 +152,7 @@ public:
     /////////////// MORE INTERESTING STUFF ////////////////
 
 public:
-    SnapshotManager( const dev::eth::ChainParams& _chainParams,
+    SnapshotManager( std::shared_ptr< const dev::eth::ChainParams > _chainParams,
         const boost::filesystem::path& _dataDir, const std::string& diffs_dir = std::string() );
     void doSnapshot( unsigned _blockNumber );
     void restoreSnapshot( unsigned _blockNumber );
@@ -187,7 +187,7 @@ private:
     static const std::string snapshotHashFileName;
     mutable std::mutex hashFileMutex;
 
-    dev::eth::ChainParams chainParams;
+    std::shared_ptr< const dev::eth::ChainParams > chainParams;
 
     void cleanupDirectory(
         const boost::filesystem::path& p, const boost::filesystem::path& _keepDirectory = "" );

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -1119,7 +1119,7 @@ std::pair< ExecutionResult, TransactionReceipt > State::execute( EnvInfo const& 
 #endif
     u256 const startGasUsed = _envInfo.gasUsed();
     bool statusCodeTmp = false;
-    if ( _p == Permanence::Committed && ifShouldSkipExecution( _chainParams.chainID, _t.sha3() ) ) {
+    if ( _p == Permanence::Committed && ifShouldSkipExecution( _chainParams.getChainId(), _t.sha3() ) ) {
         e.initialize( _t );
         e.execute();
         statusCodeTmp = false;
@@ -1170,12 +1170,12 @@ std::pair< ExecutionResult, TransactionReceipt > State::execute( EnvInfo const& 
         TransactionReceipt receipt =
             TransactionReceipt( statusCode, startGasUsed + e.gasUsed(), e.logs() );
         if ( _p == Permanence::Committed &&
-             ifShouldSkipExecution( _chainParams.chainID, _t.sha3() ) ) {
+             ifShouldSkipExecution( _chainParams.getChainId(), _t.sha3() ) ) {
             receipt = TransactionReceipt( statusCode,
-                startGasUsed + getGasUsedForSkippedTransaction( _chainParams.chainID, _t.sha3() ),
+                startGasUsed + getGasUsedForSkippedTransaction( _chainParams.getChainId(), _t.sha3() ),
                 e.logs() );
         } else {
-            receipt = _envInfo.number() >= _chainParams.byzantiumForkBlock ?
+            receipt = _envInfo.number() >= _chainParams.getByzantiumForkBlock() ?
                           TransactionReceipt( statusCode, startGasUsed + e.gasUsed(), e.logs() ) :
                           TransactionReceipt( EmptyTrie, startGasUsed + e.gasUsed(), e.logs() );
         }
@@ -1191,7 +1191,7 @@ std::pair< ExecutionResult, TransactionReceipt > State::execute( EnvInfo const& 
 
         m_fs_ptr->commit();
 
-        removeEmptyAccounts = _envInfo.number() >= _chainParams.EIP158ForkBlock;
+        removeEmptyAccounts = _envInfo.number() >= _chainParams.getEIP158ForkBlock();
         commit( removeEmptyAccounts ? dev::eth::CommitBehaviour::RemoveEmptyAccounts :
                                       dev::eth::CommitBehaviour::KeepEmptyAccounts );
 
@@ -1224,12 +1224,12 @@ std::pair< ExecutionResult, TransactionReceipt > State::execute( EnvInfo const& 
 
     TransactionReceipt receipt =
         TransactionReceipt( statusCode, startGasUsed + e.gasUsed(), e.logs() );
-    if ( _p == Permanence::Committed && ifShouldSkipExecution( _chainParams.chainID, _t.sha3() ) ) {
+    if ( _p == Permanence::Committed && ifShouldSkipExecution( _chainParams.getChainId(), _t.sha3() ) ) {
         receipt = TransactionReceipt( statusCode,
-            startGasUsed + getGasUsedForSkippedTransaction( _chainParams.chainID, _t.sha3() ),
+            startGasUsed + getGasUsedForSkippedTransaction( _chainParams.getChainId(), _t.sha3() ),
             e.logs() );
     } else {
-        receipt = _envInfo.number() >= _chainParams.byzantiumForkBlock ?
+        receipt = _envInfo.number() >= _chainParams.getByzantiumForkBlock() ?
                       TransactionReceipt( statusCode, startGasUsed + e.gasUsed(), e.logs() ) :
                       TransactionReceipt( EmptyTrie, startGasUsed + e.gasUsed(), e.logs() );
     }

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -1119,7 +1119,8 @@ std::pair< ExecutionResult, TransactionReceipt > State::execute( EnvInfo const& 
 #endif
     u256 const startGasUsed = _envInfo.gasUsed();
     bool statusCodeTmp = false;
-    if ( _p == Permanence::Committed && ifShouldSkipExecution( _chainParams.getChainId(), _t.sha3() ) ) {
+    if ( _p == Permanence::Committed &&
+         ifShouldSkipExecution( _chainParams.getChainId(), _t.sha3() ) ) {
         e.initialize( _t );
         e.execute();
         statusCodeTmp = false;
@@ -1172,7 +1173,8 @@ std::pair< ExecutionResult, TransactionReceipt > State::execute( EnvInfo const& 
         if ( _p == Permanence::Committed &&
              ifShouldSkipExecution( _chainParams.getChainId(), _t.sha3() ) ) {
             receipt = TransactionReceipt( statusCode,
-                startGasUsed + getGasUsedForSkippedTransaction( _chainParams.getChainId(), _t.sha3() ),
+                startGasUsed +
+                    getGasUsedForSkippedTransaction( _chainParams.getChainId(), _t.sha3() ),
                 e.logs() );
         } else {
             receipt = _envInfo.number() >= _chainParams.getByzantiumForkBlock() ?
@@ -1224,7 +1226,8 @@ std::pair< ExecutionResult, TransactionReceipt > State::execute( EnvInfo const& 
 
     TransactionReceipt receipt =
         TransactionReceipt( statusCode, startGasUsed + e.gasUsed(), e.logs() );
-    if ( _p == Permanence::Committed && ifShouldSkipExecution( _chainParams.getChainId(), _t.sha3() ) ) {
+    if ( _p == Permanence::Committed &&
+         ifShouldSkipExecution( _chainParams.getChainId(), _t.sha3() ) ) {
         receipt = TransactionReceipt( statusCode,
             startGasUsed + getGasUsedForSkippedTransaction( _chainParams.getChainId(), _t.sha3() ),
             e.logs() );

--- a/libskale/broadcaster.cpp
+++ b/libskale/broadcaster.cpp
@@ -37,13 +37,12 @@
 Broadcaster::~Broadcaster() {}
 
 HttpBroadcaster::HttpBroadcaster( dev::eth::Client& _client ) : m_client( _client ) {
-    const dev::eth::ChainParams& ch = _client.chainParams();
-    initClients( ch.sChain, ch.nodeInfo );
+    initClients( m_client.chainParams() );
 }
 
-void HttpBroadcaster::initClients( dev::eth::SChain sChain, dev::eth::NodeInfo nodeInfo ) {
-    for ( const auto& node : sChain.nodes ) {
-        if ( nodeInfo.id == node.id ) {
+void HttpBroadcaster::initClients( const dev::eth::ChainParams& _chainParams ) {
+    for ( const auto& node : _chainParams.getSchainNodes() ) {
+        if ( _chainParams.getSelfNodeId() == node.id ) {
             continue;
         }
         auto c = new jsonrpc::HttpClient( getHttpUrl( node ) );
@@ -104,8 +103,8 @@ void* ZmqBroadcaster::server_socket() const {
         const dev::eth::ChainParams& ch = m_client.chainParams();
 
         // connect server to clients
-        for ( const auto& node : ch.sChain.nodes ) {
-            if ( node.id == ch.nodeInfo.id )
+        for ( const auto& node : ch.getSchainNodes() ) {
+            if ( node.id == ch.getSelfNodeId() )
                 continue;
             int res = zmq_connect( m_zmq_server_socket, getZmqUrl( node ).c_str() );
             if ( res != 0 ) {
@@ -138,7 +137,7 @@ void* ZmqBroadcaster::client_socket() const {
 
         // start listen as client
         std::string listen_addr =
-            "tcp://" + ch.nodeInfo.ip + ":" + std::to_string( ch.nodeInfo.port + 5 );
+            "tcp://" + ch.getSelfNodeIp() + ":" + std::to_string( ch.getSelfNodePort() + 5 );
         int res = zmq_bind( m_zmq_client_socket, listen_addr.c_str() );
         if ( res ) {
             throw StartupException(

--- a/libskale/broadcaster.h
+++ b/libskale/broadcaster.h
@@ -72,7 +72,7 @@ private:
     dev::eth::Client& m_client;
     std::vector< std::shared_ptr< SkaleClient > > m_nodeClients;
 
-    void initClients( dev::eth::SChain, dev::eth::NodeInfo );
+    void initClients( const dev::eth::ChainParams& _chainParams );
     std::string getHttpUrl( const dev::eth::sChainNode& );
 
     dev::Logger m_loggerInfo{ dev::createLogger( dev::VerbosityInfo, "HttpBroadcaster" ) };

--- a/libskale/httpserveroverride.cpp
+++ b/libskale/httpserveroverride.cpp
@@ -1546,7 +1546,7 @@ const double SkaleServerOverride::g_lfDefaultExecutionDurationMaxForPerformanceW
     1.0;  // in seconds, default 1 second
 
 SkaleServerOverride::SkaleServerOverride(
-    dev::eth::ChainParams& chainParams, dev::eth::Interface* pEth, const opts_t& opts )
+    std::shared_ptr< const dev::eth::ChainParams > chainParams, dev::eth::Interface* pEth, const opts_t& opts )
     : AbstractServerConnector(), chainParams_( chainParams ), pEth_( pEth ), opts_( opts ) {
     // proxygen-related init
     skutils::http_pg::init_logging( "skaled" );
@@ -1585,11 +1585,8 @@ dev::eth::Interface* SkaleServerOverride::ethereum() const {
     return pEth_;
 }
 
-dev::eth::ChainParams& SkaleServerOverride::chainParams() {
-    return chainParams_;
-}
 const dev::eth::ChainParams& SkaleServerOverride::chainParams() const {
-    return chainParams_;
+    return *chainParams_;
 }
 
 std::unique_ptr< dev::Logger > SkaleServerOverride::getLoggerFromMethodTraceVerbosity(

--- a/libskale/httpserveroverride.cpp
+++ b/libskale/httpserveroverride.cpp
@@ -1587,6 +1587,7 @@ dev::eth::Interface* SkaleServerOverride::ethereum() const {
 }
 
 const dev::eth::ChainParams& SkaleServerOverride::chainParams() const {
+    CHECK_EXPRESSION( chainParams_ );
     return *chainParams_;
 }
 

--- a/libskale/httpserveroverride.cpp
+++ b/libskale/httpserveroverride.cpp
@@ -1546,7 +1546,8 @@ const double SkaleServerOverride::g_lfDefaultExecutionDurationMaxForPerformanceW
     1.0;  // in seconds, default 1 second
 
 SkaleServerOverride::SkaleServerOverride(
-    std::shared_ptr< const dev::eth::ChainParams > chainParams, dev::eth::Interface* pEth, const opts_t& opts )
+    std::shared_ptr< const dev::eth::ChainParams > chainParams, dev::eth::Interface* pEth,
+    const opts_t& opts )
     : AbstractServerConnector(), chainParams_( chainParams ), pEth_( pEth ), opts_( opts ) {
     // proxygen-related init
     skutils::http_pg::init_logging( "skaled" );

--- a/libskale/httpserveroverride.h
+++ b/libskale/httpserveroverride.h
@@ -318,7 +318,7 @@ class SkaleServerOverride : public jsonrpc::AbstractServerConnector,
                             public SkaleStatsSubscriptionManager,
                             public dev::rpc::SkaleStatsProviderImpl {
     std::atomic_size_t nTaskNumberCall_ = 0;
-    dev::eth::ChainParams& chainParams_;
+    std::shared_ptr< const dev::eth::ChainParams > chainParams_;
     mutable dev::eth::Interface* pEth_;
 
 public:
@@ -444,7 +444,7 @@ public:
     opts_t opts_;
 
     SkaleServerOverride(
-        dev::eth::ChainParams& chainParams, dev::eth::Interface* pEth, const opts_t& opts );
+        std::shared_ptr< const dev::eth::ChainParams > chainParams, dev::eth::Interface* pEth, const opts_t& opts );
     ~SkaleServerOverride() override;
 
     dev::eth::Interface* ethereum() const;

--- a/libskale/httpserveroverride.h
+++ b/libskale/httpserveroverride.h
@@ -443,8 +443,8 @@ public:
     };
     opts_t opts_;
 
-    SkaleServerOverride(
-        std::shared_ptr< const dev::eth::ChainParams > chainParams, dev::eth::Interface* pEth, const opts_t& opts );
+    SkaleServerOverride( std::shared_ptr< const dev::eth::ChainParams > chainParams,
+        dev::eth::Interface* pEth, const opts_t& opts );
     ~SkaleServerOverride() override;
 
     dev::eth::Interface* ethereum() const;

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -87,7 +87,7 @@ string Debug::debug_getConfig() {
 }
 
 string Debug::debug_getSchainName() {
-    return m_eth.chainParams().sChain.name;
+    return m_eth.chainParams().getSchainName();
 }
 
 uint64_t Debug::debug_getSnapshotCalculationTime() {

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -123,7 +123,7 @@ Json::Value Debug::debug_getFutureTransactions() {
 
 Json::Value Debug::debug_getPatchTimestamps() {
     Json::Value jsonResponse;
-    ChainParams chainParams = m_eth.chainParams();
+    const ChainParams& chainParams = m_eth.chainParams();
 
     size_t numberOfPatches = static_cast< size_t >( SchainPatchEnum::PatchesCount );
     for ( size_t patch = 0; patch < numberOfPatches; patch++ ) {

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -858,7 +858,7 @@ Json::Value Eth::eth_getFilterLogs( string const& _filterId ) {
     } catch ( const TooBigResponse& ) {
         BOOST_THROW_EXCEPTION( JsonRpcException( Errors::ERROR_RPC_INVALID_PARAMS,
             "Log response size exceeded. Maximum allowed number of requested blocks is " +
-                to_string( this->client()->chainParams().getLogsBlocksLimit ) ) );
+                to_string( this->client()->chainParams().getLogsBlocksLimit() ) ) );
     } catch ( ... ) {
         BOOST_THROW_EXCEPTION( JsonRpcException( Errors::ERROR_RPC_INVALID_PARAMS ) );
     }
@@ -886,7 +886,7 @@ Json::Value Eth::eth_getLogs( Json::Value const& _json ) {
     } catch ( const TooBigResponse& ) {
         BOOST_THROW_EXCEPTION( JsonRpcException( Errors::ERROR_RPC_INVALID_PARAMS,
             "Log response size exceeded. Maximum allowed number of requested blocks is " +
-                to_string( this->client()->chainParams().getLogsBlocksLimit ) ) );
+                to_string( this->client()->chainParams().getLogsBlocksLimit() ) ) );
     } catch ( const JsonRpcException& ) {
         throw;
     } catch ( ... ) {

--- a/libweb3jsonrpc/Net.cpp
+++ b/libweb3jsonrpc/Net.cpp
@@ -30,16 +30,16 @@
 using namespace dev;
 using namespace dev::rpc;
 
-Net::Net( const dev::eth::ChainParams& _chainParams ) : m_chainParams( _chainParams ) {}
+Net::Net( std::shared_ptr< const dev::eth::ChainParams > _chainParams ) : m_chainParams( _chainParams ) {}
 
 // TODO Ask here real values from consensus/broadcast
 
 std::string Net::net_version() {
-    return toString( m_chainParams.chainID );
+    return toString( m_chainParams->getChainId() );
 }
 
 std::string Net::net_peerCount() {
-    return toJS( m_chainParams.sChain.nodes.size() - 1 );
+    return toJS( m_chainParams->getNodesCount() - 1 );
 }
 
 bool Net::net_listening() {

--- a/libweb3jsonrpc/Net.cpp
+++ b/libweb3jsonrpc/Net.cpp
@@ -30,7 +30,8 @@
 using namespace dev;
 using namespace dev::rpc;
 
-Net::Net( std::shared_ptr< const dev::eth::ChainParams > _chainParams ) : m_chainParams( _chainParams ) {}
+Net::Net( std::shared_ptr< const dev::eth::ChainParams > _chainParams )
+    : m_chainParams( _chainParams ) {}
 
 // TODO Ask here real values from consensus/broadcast
 

--- a/libweb3jsonrpc/Net.h
+++ b/libweb3jsonrpc/Net.h
@@ -35,7 +35,7 @@ namespace rpc {
 
 class Net : public NetFace {
 public:
-    Net( const dev::eth::ChainParams& );
+    Net( std::shared_ptr< const dev::eth::ChainParams > );
     virtual RPCModules implementedModules() const override {
         return RPCModules{ RPCModule{ "net", "1.0" } };
     }
@@ -44,7 +44,7 @@ public:
     virtual bool net_listening() override;
 
 private:
-    const dev::eth::ChainParams m_chainParams;
+    std::shared_ptr< const dev::eth::ChainParams > m_chainParams;
 };
 
 }  // namespace rpc

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -169,7 +169,7 @@ nlohmann::json Skale::impl_skale_getSnapshot( const nlohmann::json& joRequest, C
             "snapshot info request received too early, no snapshot available yet, please try later "
             "or request earlier block number";
         joResponse["timeValid"] =
-            currentSnapshotTime + m_client.chainParams().sChain.snapshotDownloadTimeout;
+            currentSnapshotTime + m_client.chainParams().getSnapshotDownloadTimeout();
         return joResponse;
     }
 
@@ -184,7 +184,7 @@ nlohmann::json Skale::impl_skale_getSnapshot( const nlohmann::json& joRequest, C
     if ( m_shared_space && !m_shared_space->try_lock() ) {
         joResponse["error"] = "snapshot serialization space is occupied, please try again later";
         joResponse["timeValid"] =
-            time( NULL ) + m_client.chainParams().sChain.snapshotDownloadTimeout;
+            time( NULL ) + m_client.chainParams().getSnapshotDownloadTimeout();
         return joResponse;
     }
 
@@ -207,12 +207,12 @@ nlohmann::json Skale::impl_skale_getSnapshot( const nlohmann::json& joRequest, C
          !snapshotDownloadFragmentMonitorThread->joinable() ) {
         snapshotDownloadFragmentMonitorThread.reset( new std::thread( [this]() {
             while ( ( time( NULL ) - lastSnapshotDownloadFragmentTime <
-                            m_client.chainParams().sChain.snapshotDownloadInactiveTimeout ||
+                            m_client.chainParams().getSnapshotDownloadInactiveTimeout() ||
                         time( NULL ) - currentSnapshotTime <
-                            m_client.chainParams().sChain.snapshotDownloadInactiveTimeout ) &&
+                            m_client.chainParams().getSnapshotDownloadInactiveTimeout() ) &&
                     ( time( NULL ) - currentSnapshotTime <
-                            m_client.chainParams().sChain.snapshotDownloadTimeout ||
-                        m_client.chainParams().nodeInfo.archiveMode ) ) {
+                            m_client.chainParams().getSnapshotDownloadTimeout() ||
+                        m_client.chainParams().isArchiveModeEnabled() ) ) {
                 if ( threadExitRequested )
                     break;
                 sleep( SNAPSHOT_DOWNLOAD_MONITOR_THREAD_SLEEP_MS );
@@ -387,16 +387,8 @@ Json::Value Skale::skale_getSnapshotSignature( unsigned blockNumber ) {
 
             obj["keyShareName"] = chainParams.getKeyShareName();
             obj["messageHash"] = snapshotHash.hex();
-            obj["n"] = chainParams.sChain.nodes.size();
-            obj["t"] = chainParams.sChain.t;
-
-            auto it =
-                std::find_if( chainParams.sChain.nodes.begin(), chainParams.sChain.nodes.end(),
-                    [&chainParams]( const dev::eth::sChainNode& schain_node ) {
-                        return schain_node.id == chainParams.getSelfNodeId();
-                    } );
-            assert( it != chainParams.sChain.nodes.end() );
-            dev::eth::sChainNode schain_node = *it;
+            obj["n"] = chainParams.getNodesCount();
+            obj["t"] = chainParams.getThresholdCount();
 
             joCall["params"] = obj;
 

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -358,8 +358,8 @@ std::string Skale::skale_getLatestSnapshotBlockNumber() {
 
 Json::Value Skale::skale_getSnapshotSignature( unsigned blockNumber ) {
     const dev::eth::ChainParams& chainParams = this->m_client.chainParams();
-    if ( !chainParams.isSyncNode() && ( chainParams.getKeyShareName().empty() ||
-                                               chainParams.getSgxServerUrl().empty() ) )
+    if ( !chainParams.isSyncNode() &&
+         ( chainParams.getKeyShareName().empty() || chainParams.getSgxServerUrl().empty() ) )
         throw jsonrpc::JsonRpcException( "Snapshot signing is not enabled" );
 
     if ( blockNumber != 0 && blockNumber != this->m_client.getLatestSnapshotBlockNumer() ) {

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -530,7 +530,7 @@ Json::Value Skale::skale_getDBUsage() {
 #ifndef MIRAGE
 std::string Skale::oracle_submitRequest( std::string& request ) {
     try {
-        if ( m_client.chainParams().nodeInfo.syncNode )
+        if ( m_client.chainParams().isSyncNode() )
             throw std::runtime_error( "Oracle is disabled on this instance" );
         std::string receipt;
         std::string errorMessage;
@@ -551,7 +551,7 @@ std::string Skale::oracle_submitRequest( std::string& request ) {
 
 std::string Skale::oracle_checkResult( std::string& receipt ) {
     try {
-        if ( m_client.chainParams().nodeInfo.syncNode )
+        if ( m_client.chainParams().isSyncNode() )
             throw std::runtime_error( "Oracle is disabled on this instance" );
         std::string result;
         // this function is guaranteed not to throw exceptions

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -357,9 +357,9 @@ std::string Skale::skale_getLatestSnapshotBlockNumber() {
 }
 
 Json::Value Skale::skale_getSnapshotSignature( unsigned blockNumber ) {
-    dev::eth::ChainParams chainParams = this->m_client.chainParams();
-    if ( !chainParams.nodeInfo.syncNode && ( chainParams.nodeInfo.keyShareName.empty() ||
-                                               chainParams.nodeInfo.sgxServerUrl.empty() ) )
+    const dev::eth::ChainParams& chainParams = this->m_client.chainParams();
+    if ( !chainParams.isSyncNode() && ( chainParams.getKeyShareName().empty() ||
+                                               chainParams.getSgxServerUrl().empty() ) )
         throw jsonrpc::JsonRpcException( "Snapshot signing is not enabled" );
 
     if ( blockNumber != 0 && blockNumber != this->m_client.getLatestSnapshotBlockNumer() ) {
@@ -374,8 +374,8 @@ Json::Value Skale::skale_getSnapshotSignature( unsigned blockNumber ) {
                 "Requested hash of block " + to_string( blockNumber ) + " is absent" );
 
         nlohmann::json joSignature = nlohmann::json::object();
-        if ( !chainParams.nodeInfo.syncNode ) {
-            std::string sgxServerURL = chainParams.nodeInfo.sgxServerUrl;
+        if ( !chainParams.isSyncNode() ) {
+            std::string sgxServerURL = chainParams.getSgxServerUrl();
             skutils::url u( sgxServerURL );
 
             nlohmann::json joCall = nlohmann::json::object();
@@ -385,15 +385,15 @@ Json::Value Skale::skale_getSnapshotSignature( unsigned blockNumber ) {
                 joCall["type"] = "BLSSignReq";
             nlohmann::json obj = nlohmann::json::object();
 
-            obj["keyShareName"] = chainParams.nodeInfo.keyShareName;
+            obj["keyShareName"] = chainParams.getKeyShareName();
             obj["messageHash"] = snapshotHash.hex();
             obj["n"] = chainParams.sChain.nodes.size();
             obj["t"] = chainParams.sChain.t;
 
             auto it =
                 std::find_if( chainParams.sChain.nodes.begin(), chainParams.sChain.nodes.end(),
-                    [chainParams]( const dev::eth::sChainNode& schain_node ) {
-                        return schain_node.id == chainParams.nodeInfo.id;
+                    [&chainParams]( const dev::eth::sChainNode& schain_node ) {
+                        return schain_node.id == chainParams.getSelfNodeId();
                     } );
             assert( it != chainParams.sChain.nodes.end() );
             dev::eth::sChainNode schain_node = *it;

--- a/libweb3jsonrpc/SkaleStats.cpp
+++ b/libweb3jsonrpc/SkaleStats.cpp
@@ -63,8 +63,8 @@ namespace dev {
 namespace rpc {
 
 SkaleStats::SkaleStats(
-    const std::string& configPath, eth::Interface& _eth, const dev::eth::ChainParams& chainParams )
-    : skutils::json_config_file_accessor( configPath ), chainParams_( chainParams ), m_eth( _eth ) {
+    const std::string& configPath, eth::Interface& _eth )
+    : skutils::json_config_file_accessor( configPath ), m_eth( _eth ) {
     initStatsCounters();
     nThisNodeIndex_ = findThisNodeIndex();
     //

--- a/libweb3jsonrpc/SkaleStats.cpp
+++ b/libweb3jsonrpc/SkaleStats.cpp
@@ -62,8 +62,7 @@ namespace dev {
 
 namespace rpc {
 
-SkaleStats::SkaleStats(
-    const std::string& configPath, eth::Interface& _eth )
+SkaleStats::SkaleStats( const std::string& configPath, eth::Interface& _eth )
     : skutils::json_config_file_accessor( configPath ), m_eth( _eth ) {
     initStatsCounters();
     nThisNodeIndex_ = findThisNodeIndex();

--- a/libweb3jsonrpc/SkaleStats.h
+++ b/libweb3jsonrpc/SkaleStats.h
@@ -102,13 +102,10 @@ class SkaleStats : public dev::rpc::SkaleStatsFace,
     int nThisNodeIndex_ = -1;  // 1-based "schainIndex"
     int findThisNodeIndex();
 
-    const dev::eth::ChainParams& chainParams_;
-
 public:
     bool isExposeAllDebugInfo_ = false;
 
-    SkaleStats( const std::string& configPath, eth::Interface& _eth,
-        const dev::eth::ChainParams& chainParams );
+    SkaleStats( const std::string& configPath, eth::Interface& _eth );
 
     virtual RPCModules implementedModules() const override {
         return RPCModules{ RPCModule{ "skaleStats", "1.0" } };

--- a/skale-vm/main.cpp
+++ b/skale-vm/main.cpp
@@ -52,7 +52,7 @@ unsigned const c_lineWidth = 160;
 
 int64_t maxBlockGasLimit() {
     static int64_t limit =
-        ChainParams( genesisInfo( Network::MainNetwork ) ).maxGasLimit.convert_to< int64_t >();
+        ChainParams( genesisInfo( Network::MainNetwork ) ).getMaxGasLimit().convert_to< int64_t >();
     return limit;
 }
 
@@ -290,7 +290,7 @@ int main( int argc, char** argv ) {
     LastBlockHashes lastBlockHashes;
 
     EnvInfo const envInfo( blockHeader, lastBlockHashes, 0 /*_committedBlockTimestamp*/,
-        0 /* gasUsed */, chainParams.chainID );
+        0 /* gasUsed */, chainParams.getChainId() );
     EVMSchedule evmSchedule = chainParams.makeEvmSchedule( 0, envInfo.number() );
 
 

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -623,7 +623,7 @@ int main( int argc, char** argv ) {
         bool bEnabledAPIs_performanceTracker = false;
 
         string strJsonAdminSessionKey;
-        std::shared_ptr< ChainParams > chainParams;
+        std::shared_ptr< ChainParams > chainParams = std::make_shared< ChainParams >();
         string privateChain;
 
         bool upnp = true;

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -311,7 +311,7 @@ void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >
             }
 
             fs::rename( db_path,
-                db_path.parent_path() / ( prefix + chainParams.nodeInfo.id.str() + ".db" ) );
+                db_path.parent_path() / ( prefix + chainParams.getSelfNodeId().str() + ".db" ) );
         }
         //// HACK END ////
 
@@ -326,9 +326,9 @@ void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >
 std::array< std::string, 4 > getBLSPublicKeyToVerifySnapshot( const ChainParams& chainParams ) {
     std::array< std::string, 4 > arrayCommonPublicKey;
     bool isRotationtrigger = true;
-    if ( chainParams.sChain.nodeGroups.size() > 1 ) {
+    if ( chainParams.getNodeGroups().size() > 1 ) {
         if ( ( uint64_t ) time( NULL ) >=
-             chainParams.sChain.nodeGroups[chainParams.sChain.nodeGroups.size() - 2].finishTs ) {
+             chainParams.getNodeGroupByIndex(chainParams.getNodeGroups().size() - 2).finishTs ) {
             isRotationtrigger = false;
         }
     } else {
@@ -336,9 +336,9 @@ std::array< std::string, 4 > getBLSPublicKeyToVerifySnapshot( const ChainParams&
     }
     if ( isRotationtrigger ) {
         arrayCommonPublicKey =
-            chainParams.sChain.nodeGroups[chainParams.sChain.nodeGroups.size() - 2].blsPublicKey;
+            chainParams.getNodeGroupByIndex(chainParams.getNodeGroups().size() - 2).blsPublicKey;
     } else {
-        arrayCommonPublicKey = chainParams.sChain.nodeGroups.back().blsPublicKey;
+        arrayCommonPublicKey = chainParams.getNodeGroupByIndex( chainParams.getNodeGroups().size() - 1 ).blsPublicKey;
     }
 
     return arrayCommonPublicKey;
@@ -527,15 +527,15 @@ void downloadAndProccessSnapshot( std::shared_ptr< SnapshotManager >& snapshotMa
         successfullDownload = downloadSnapshotFromUrl( snapshotManager, chainParams,
             arrayCommonPublicKey, urlToDownloadSnapshotFrom, isRegularSnapshot, true );
     else {
-        for ( size_t idx = 0; idx < chainParams.sChain.nodes.size() && !successfullDownload; ++idx )
+        for ( size_t idx = 0; idx < chainParams.getNodesCount() && !successfullDownload; ++idx )
             try {
-                if ( chainParams.nodeInfo.id == chainParams.sChain.nodes.at( idx ).id )
+                if ( chainParams.getSelfNodeId() == chainParams.getNodeByIndex( idx ).id )
                     continue;
 
                 std::string nodeUrl =
                     std::string( "http://" ) +
-                    std::string( chainParams.sChain.nodes.at( idx ).ip ) + std::string( ":" ) +
-                    ( chainParams.sChain.nodes.at( idx ).port + 3 ).convert_to< std::string >();
+                    std::string( chainParams.getNodeByIndex( idx ).ip ) + std::string( ":" ) +
+                    ( chainParams.getNodeByIndex( idx ).port + 3 ).convert_to< std::string >();
 
                 successfullDownload = downloadSnapshotFromUrl( snapshotManager, chainParams,
                     arrayCommonPublicKey, nodeUrl, isRegularSnapshot );
@@ -1574,7 +1574,7 @@ int main( int argc, char** argv ) {
             u.fragment( "" );
             u.set_query();
             strURL = u.str();
-            chainParams->nodeInfo.sgxServerUrl = strURL;
+            chainParams->setSgxServerUrl( strURL );
         }
 
         std::shared_ptr< StatusAndControl > statusAndControl =

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -621,13 +621,8 @@ int main( int argc, char** argv ) {
         bool bEnabledAPIs_debug = false;
         bool bEnabledAPIs_performanceTracker = false;
 
-        const std::list< std::pair< std::string, std::string > >& listIfaceInfos4 =
-            get_machine_ip_addresses_4();  // IPv4
-        const std::list< std::pair< std::string, std::string > >& listIfaceInfos6 =
-            get_machine_ip_addresses_6();  // IPv6
-
         string strJsonAdminSessionKey;
-        ChainParams chainParams;
+        std::shared_ptr< ChainParams > chainParams;
         string privateChain;
 
         bool upnp = true;
@@ -1086,7 +1081,7 @@ int main( int argc, char** argv ) {
             strJsonAdminSessionKey = vm["admin"].as< string >();
 
         if ( vm.count( "skale" ) ) {
-            chainParams = ChainParams( genesisInfo( eth::Network::Skale ) );
+            chainParams.reset( new ChainParams( genesisInfo( eth::Network::Skale ) ) );
             chainConfigIsSet = true;
         }
 
@@ -1099,14 +1094,14 @@ int main( int argc, char** argv ) {
                 configJSON = contentsString( configPath.string() );
                 if ( configJSON.empty() )
                     throw std::runtime_error( "Config file probably not found" );
-                chainParams = chainParams.loadConfig( configJSON, configPath );
+                chainParams->loadConfig( configJSON, configPath );
                 chainConfigIsSet = true;
                 // TODO avoid double-parse
                 joConfig = nlohmann::json::parse( configJSON );
                 chainConfigParsed = true;
                 dev::eth::g_configAccesssor.reset(
                     new skutils::json_config_file_accessor( configPath.string() ) );
-                dev::db::DBFactory::setReopenPeriodMs( chainParams.sChain.levelDBReopenIntervalMs );
+                dev::db::DBFactory::setReopenPeriodMs( chainParams->getLevelDbReopenIntervalMs() );
             } catch ( const char* str ) {
                 LOG( loggerError ) << "Error: " << str << ": " << configPath;
                 return EX_USAGE;
@@ -1148,7 +1143,7 @@ int main( int argc, char** argv ) {
 
         if ( !chainConfigIsSet )
             // default to skale if not already set with `--config`
-            chainParams = ChainParams( genesisInfo( eth::Network::Skale ) );
+            chainParams.reset( new ChainParams( genesisInfo( eth::Network::Skale ) ) );
 
         if ( chainConfigParsed ) {
             try {
@@ -1579,7 +1574,7 @@ int main( int argc, char** argv ) {
             u.fragment( "" );
             u.set_query();
             strURL = u.str();
-            chainParams.nodeInfo.sgxServerUrl = strURL;
+            chainParams->nodeInfo.sgxServerUrl = strURL;
         }
 
         std::shared_ptr< StatusAndControl > statusAndControl =
@@ -1616,10 +1611,10 @@ int main( int argc, char** argv ) {
                               << urlToDownloadSnapshotFrom;
         }
 
-        if ( chainParams.sChain.snapshotIntervalSec > 0 || downloadSnapshotFlag ) {
-            std::vector< std::string > coreVolumes = { BlockChain::getChainDirName( chainParams ),
-                "filestorage", "prices_" + chainParams.nodeInfo.id.str() + ".db",
-                "blocks_" + chainParams.nodeInfo.id.str() + ".db" };
+        if ( chainParams->getSnapshotIntervalSec() > 0 || downloadSnapshotFlag ) {
+            std::vector< std::string > coreVolumes = { BlockChain::getChainDirName( *chainParams ),
+                "filestorage", "prices_" + chainParams->getSelfNodeId().str() + ".db",
+                "blocks_" + chainParams->getSelfNodeId().str() + ".db" };
             snapshotManager.reset( new SnapshotManager(
                 chainParams, getDataDir(), sharedSpace ? sharedSpace->getPath() : "" ) );
         }
@@ -1635,7 +1630,7 @@ int main( int argc, char** argv ) {
 
             try {
                 downloadAndProccessSnapshot(
-                    snapshotManager, chainParams, urlToDownloadSnapshotFrom, true );
+                    snapshotManager, *chainParams, urlToDownloadSnapshotFrom, true );
 
                 // if we dont have 0 snapshot yet
                 try {
@@ -1644,14 +1639,14 @@ int main( int argc, char** argv ) {
                     // sleep before send skale_getSnapshot again - will receive error
                     LOG( loggerInfo )
                         << std::string( "Will sleep for " )
-                        << chainParams.sChain.snapshotDownloadInactiveTimeout +
+                        << chainParams->getSnapshotDownloadInactiveTimeout() +
                                dev::rpc::Skale::snapshotDownloadFragmentMonitorThreadTimeout()
                         << std::string( " seconds before downloading 0 snapshot" );
-                    sleep( chainParams.sChain.snapshotDownloadInactiveTimeout +
+                    sleep( chainParams->getSnapshotDownloadInactiveTimeout() +
                            dev::rpc::Skale::snapshotDownloadFragmentMonitorThreadTimeout() );
 
                     downloadAndProccessSnapshot(
-                        snapshotManager, chainParams, urlToDownloadSnapshotFrom, false );
+                        snapshotManager, *chainParams, urlToDownloadSnapshotFrom, false );
                 }
 
             } catch ( std::exception& ) {
@@ -1662,10 +1657,10 @@ int main( int argc, char** argv ) {
         }  // if --download-snapshot
 
         // download 0 snapshot if needed
-        if ( chainParams.nodeInfo.syncNode ) {
+        if ( chainParams->isSyncNode() ) {
             auto bc = BlockChain( chainParams, getDataDir() );
             if ( bc.number() == 0 ) {
-                if ( chainParams.nodeInfo.syncFromCatchup && !downloadSnapshotFlag ) {
+                if ( chainParams->isSyncFromCatchupEnabled() && !downloadSnapshotFlag ) {
                     statusAndControl->setExitState( StatusAndControl::StartAgain, true );
                     statusAndControl->setExitState( StatusAndControl::StartFromSnapshot, true );
                     statusAndControl->setSubsystemRunning(
@@ -1673,7 +1668,7 @@ int main( int argc, char** argv ) {
 
                     try {
                         downloadAndProccessSnapshot(
-                            snapshotManager, chainParams, urlToDownloadSnapshotFrom, false );
+                            snapshotManager, *chainParams, urlToDownloadSnapshotFrom, false );
                         snapshotManager->restoreSnapshot( 0 );
                     } catch ( SnapshotManager::SnapshotAbsent& ) {
                         LOG( loggerWarning ) << "Snapshot for 0 block is not found";
@@ -1688,7 +1683,7 @@ int main( int argc, char** argv ) {
         statusAndControl->setExitState( StatusAndControl::StartFromSnapshot, false );
 
         // it was needed for snapshot downloading
-        if ( chainParams.sChain.snapshotIntervalSec <= 0 ) {
+        if ( chainParams->getSnapshotIntervalSec() <= 0 ) {
             snapshotManager = nullptr;
         }
 
@@ -1775,21 +1770,21 @@ int main( int argc, char** argv ) {
             Ethash::init();
             NoProof::init();
 
-            if ( chainParams.sealEngineName == Ethash::name() ) {
-                g_client.reset( new eth::EthashClient( chainParams, ( int ) chainParams.networkID,
+            if ( chainParams->getSealEngineName() == Ethash::name() ) {
+                g_client.reset( new eth::EthashClient( chainParams, chainParams->getNetworkId(),
                     shared_ptr< GasPricer >(), snapshotManager, instanceMonitor, getDataDir(),
                     withExisting,
                     TransactionQueue::Limits{ c_transactionQueueSize, c_futureTransactionQueueSize,
                         c_transactionQueueSizeBytes, c_futureTransactionQueueSizeBytes } ) );
-            } else if ( chainParams.sealEngineName == NoProof::name() ) {
-                g_client.reset( new eth::Client( chainParams, ( int ) chainParams.networkID,
+            } else if ( chainParams->getSealEngineName() == NoProof::name() ) {
+                g_client.reset( new eth::Client( chainParams, chainParams->getNetworkId(),
                     shared_ptr< GasPricer >(), snapshotManager, instanceMonitor, getDataDir(),
                     withExisting,
                     TransactionQueue::Limits{ c_transactionQueueSize, c_futureTransactionQueueSize,
                         c_transactionQueueSizeBytes, c_futureTransactionQueueSizeBytes } ) );
             } else
                 BOOST_THROW_EXCEPTION( ChainParamsInvalid() << errinfo_comment(
-                                           "Unknown seal engine: " + chainParams.sealEngineName ) );
+                                           "Unknown seal engine: " + chainParams->getSealEngineName() ) );
 
             g_client->dbRotationPeriod(
                 ( ( clock_t )( clockDbRotationPeriodInSeconds ) ) * CLOCKS_PER_SEC );
@@ -1802,14 +1797,14 @@ int main( int argc, char** argv ) {
                 else
                     return "";
             } );
-            g_client->setAuthor( chainParams.sChain.blockAuthor );
+            g_client->setAuthor( chainParams->getBlockAuthor() );
 
             DefaultConsensusFactory cons_fact( *g_client );
             setenv( "DATA_DIR", getDataDir().c_str(), 0 );
 
             std::shared_ptr< SkaleHost > skaleHost = std::make_shared< SkaleHost >( *g_client,
                 &cons_fact, instanceMonitor, skutils::json_config_file_accessor::g_strImaMainNetURL,
-                !chainParams.nodeInfo.syncNode );
+                !chainParams->isSyncNode() );
             dev::eth::g_skaleHost = skaleHost;
 
             // XXX nested lambdas and strlen hacks..
@@ -1943,14 +1938,14 @@ int main( int argc, char** argv ) {
                     allowedDestinations.insert( _t.to );
                 return r == "yes" || r == "always";
             };
-        if ( chainParams.nodeInfo.ip.empty() ) {
+        if ( chainParams->getSelfNodeIp().empty() ) {
             LOG( loggerWarning ) << "IPv4"
                                  << " bind address is not set, will not start RPC on this protocol";
             nExplicitPortHTTP4std = nExplicitPortHTTPS4std = nExplicitPortHTTP4nfo =
                 nExplicitPortHTTPS4nfo = nExplicitPortWS4std = nExplicitPortWSS4std =
                     nExplicitPortWS4nfo = nExplicitPortWSS4nfo = -1;
         }
-        if ( chainParams.nodeInfo.ip6.empty() ) {
+        if ( chainParams->getSelfNodeIpV6().empty() ) {
             LOG( loggerWarning )
                 << "IPv6 bind address is not set, will not start RPC on this protocol";
             nExplicitPortHTTP6std = nExplicitPortHTTPS6std = nExplicitPortHTTP6nfo =
@@ -1998,7 +1993,7 @@ int main( int argc, char** argv ) {
             auto pEthFace = new rpc::Eth( configPath.string(), *g_client, *accountHolder.get() );
             auto pSkaleFace = new rpc::Skale( *g_client, sharedSpace );
             auto pSkaleStatsFace =
-                new rpc::SkaleStats( configPath.string(), *g_client, chainParams );
+                new rpc::SkaleStats( configPath.string(), *g_client );
             pSkaleStatsFace->isExposeAllDebugInfo_ = isExposeAllDebugInfo;
             auto pPersonalFace = bEnabledAPIs_personal ?
                                      new rpc::Personal( keyManager, *accountHolder, *g_client ) :
@@ -2380,43 +2375,43 @@ int main( int argc, char** argv ) {
                 inject_rapidjson_handlers( serverOpts, pEthFace );
                 serverOpts.fn_binary_snapshot_download_ = fn_binary_snapshot_download;
                 serverOpts.netOpts_.bindOptsStandard_.cntServers_ = cntServersStd;
-                serverOpts.netOpts_.bindOptsStandard_.strAddrHTTP4_ = chainParams.nodeInfo.ip;
+                serverOpts.netOpts_.bindOptsStandard_.strAddrHTTP4_ = chainParams->getSelfNodeIp();
                 serverOpts.netOpts_.bindOptsStandard_.nBasePortHTTP4_ = nExplicitPortHTTP4std;
-                serverOpts.netOpts_.bindOptsStandard_.strAddrHTTP6_ = chainParams.nodeInfo.ip6;
+                serverOpts.netOpts_.bindOptsStandard_.strAddrHTTP6_ = chainParams->getSelfNodeIpV6();
                 serverOpts.netOpts_.bindOptsStandard_.nBasePortHTTP6_ = nExplicitPortHTTP6std;
-                serverOpts.netOpts_.bindOptsStandard_.strAddrHTTPS4_ = chainParams.nodeInfo.ip;
+                serverOpts.netOpts_.bindOptsStandard_.strAddrHTTPS4_ = chainParams->getSelfNodeIp();
                 serverOpts.netOpts_.bindOptsStandard_.nBasePortHTTPS4_ = nExplicitPortHTTPS4std;
-                serverOpts.netOpts_.bindOptsStandard_.strAddrHTTPS6_ = chainParams.nodeInfo.ip6;
+                serverOpts.netOpts_.bindOptsStandard_.strAddrHTTPS6_ = chainParams->getSelfNodeIpV6();
                 serverOpts.netOpts_.bindOptsStandard_.nBasePortHTTPS6_ = nExplicitPortHTTPS6std;
-                serverOpts.netOpts_.bindOptsStandard_.strAddrWS4_ = chainParams.nodeInfo.ip;
+                serverOpts.netOpts_.bindOptsStandard_.strAddrWS4_ = chainParams->getSelfNodeIp();
                 serverOpts.netOpts_.bindOptsStandard_.nBasePortWS4_ = nExplicitPortWS4std;
-                serverOpts.netOpts_.bindOptsStandard_.strAddrWS6_ = chainParams.nodeInfo.ip6;
+                serverOpts.netOpts_.bindOptsStandard_.strAddrWS6_ = chainParams->getSelfNodeIpV6();
                 serverOpts.netOpts_.bindOptsStandard_.nBasePortWS6_ = nExplicitPortWS6std;
-                serverOpts.netOpts_.bindOptsStandard_.strAddrWSS4_ = chainParams.nodeInfo.ip;
+                serverOpts.netOpts_.bindOptsStandard_.strAddrWSS4_ = chainParams->getSelfNodeIp();
                 serverOpts.netOpts_.bindOptsStandard_.nBasePortWSS4_ = nExplicitPortWSS4std;
-                serverOpts.netOpts_.bindOptsStandard_.strAddrWSS6_ = chainParams.nodeInfo.ip6;
+                serverOpts.netOpts_.bindOptsStandard_.strAddrWSS6_ = chainParams->getSelfNodeIpV6();
                 serverOpts.netOpts_.bindOptsStandard_.nBasePortWSS6_ = nExplicitPortWSS6std;
 
                 serverOpts.netOpts_.bindOptsInformational_.cntServers_ = cntServersNfo;
-                serverOpts.netOpts_.bindOptsInformational_.strAddrHTTP4_ = chainParams.nodeInfo.ip;
+                serverOpts.netOpts_.bindOptsInformational_.strAddrHTTP4_ = chainParams->getSelfNodeIp();
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortHTTP4_ = nExplicitPortHTTP4nfo;
-                serverOpts.netOpts_.bindOptsInformational_.strAddrHTTP6_ = chainParams.nodeInfo.ip6;
+                serverOpts.netOpts_.bindOptsInformational_.strAddrHTTP6_ = chainParams->getSelfNodeIpV6();
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortHTTP6_ = nExplicitPortHTTP6nfo;
-                serverOpts.netOpts_.bindOptsInformational_.strAddrHTTPS4_ = chainParams.nodeInfo.ip;
+                serverOpts.netOpts_.bindOptsInformational_.strAddrHTTPS4_ = chainParams->getSelfNodeIp();
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortHTTPS4_ =
                     nExplicitPortHTTPS4nfo;
                 serverOpts.netOpts_.bindOptsInformational_.strAddrHTTPS6_ =
-                    chainParams.nodeInfo.ip6;
+                    chainParams->getSelfNodeIpV6();
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortHTTPS6_ =
                     nExplicitPortHTTPS6nfo;
 
-                serverOpts.netOpts_.bindOptsInformational_.strAddrWS4_ = chainParams.nodeInfo.ip;
+                serverOpts.netOpts_.bindOptsInformational_.strAddrWS4_ = chainParams->getSelfNodeIp();
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortWS4_ = nExplicitPortWS4nfo;
-                serverOpts.netOpts_.bindOptsInformational_.strAddrWS6_ = chainParams.nodeInfo.ip6;
+                serverOpts.netOpts_.bindOptsInformational_.strAddrWS6_ = chainParams->getSelfNodeIpV6();
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortWS6_ = nExplicitPortWS6nfo;
-                serverOpts.netOpts_.bindOptsInformational_.strAddrWSS4_ = chainParams.nodeInfo.ip;
+                serverOpts.netOpts_.bindOptsInformational_.strAddrWSS4_ = chainParams->getSelfNodeIp();
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortWSS4_ = nExplicitPortWSS4nfo;
-                serverOpts.netOpts_.bindOptsInformational_.strAddrWSS6_ = chainParams.nodeInfo.ip6;
+                serverOpts.netOpts_.bindOptsInformational_.strAddrWSS6_ = chainParams->getSelfNodeIpV6();
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortWSS6_ = nExplicitPortWSS6nfo;
 
                 serverOpts.netOpts_.strPathSslKey_ = strPathSslKey;
@@ -2804,7 +2799,7 @@ int main( int argc, char** argv ) {
 
         LOG( loggerError ) << localeconv()->decimal_point;
 
-        std::string basename = "profile" + chainParams.nodeInfo.id.str();
+        std::string basename = "profile" + chainParams->getSelfNodeId().str();
         MicroProfileDumpFileImmediately(
             ( basename + ".html" ).c_str(), ( basename + ".csv" ).c_str(), nullptr );
         MicroProfileShutdown();

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -328,7 +328,7 @@ std::array< std::string, 4 > getBLSPublicKeyToVerifySnapshot( const ChainParams&
     bool isRotationtrigger = true;
     if ( chainParams.getNodeGroups().size() > 1 ) {
         if ( ( uint64_t ) time( NULL ) >=
-             chainParams.getNodeGroupByIndex(chainParams.getNodeGroups().size() - 2).finishTs ) {
+             chainParams.getNodeGroupByIndex( chainParams.getNodeGroups().size() - 2 ).finishTs ) {
             isRotationtrigger = false;
         }
     } else {
@@ -336,9 +336,10 @@ std::array< std::string, 4 > getBLSPublicKeyToVerifySnapshot( const ChainParams&
     }
     if ( isRotationtrigger ) {
         arrayCommonPublicKey =
-            chainParams.getNodeGroupByIndex(chainParams.getNodeGroups().size() - 2).blsPublicKey;
+            chainParams.getNodeGroupByIndex( chainParams.getNodeGroups().size() - 2 ).blsPublicKey;
     } else {
-        arrayCommonPublicKey = chainParams.getNodeGroupByIndex( chainParams.getNodeGroups().size() - 1 ).blsPublicKey;
+        arrayCommonPublicKey =
+            chainParams.getNodeGroupByIndex( chainParams.getNodeGroups().size() - 1 ).blsPublicKey;
     }
 
     return arrayCommonPublicKey;
@@ -533,8 +534,8 @@ void downloadAndProccessSnapshot( std::shared_ptr< SnapshotManager >& snapshotMa
                     continue;
 
                 std::string nodeUrl =
-                    std::string( "http://" ) +
-                    std::string( chainParams.getNodeByIndex( idx ).ip ) + std::string( ":" ) +
+                    std::string( "http://" ) + std::string( chainParams.getNodeByIndex( idx ).ip ) +
+                    std::string( ":" ) +
                     ( chainParams.getNodeByIndex( idx ).port + 3 ).convert_to< std::string >();
 
                 successfullDownload = downloadSnapshotFromUrl( snapshotManager, chainParams,
@@ -1783,8 +1784,9 @@ int main( int argc, char** argv ) {
                     TransactionQueue::Limits{ c_transactionQueueSize, c_futureTransactionQueueSize,
                         c_transactionQueueSizeBytes, c_futureTransactionQueueSizeBytes } ) );
             } else
-                BOOST_THROW_EXCEPTION( ChainParamsInvalid() << errinfo_comment(
-                                           "Unknown seal engine: " + chainParams->getSealEngineName() ) );
+                BOOST_THROW_EXCEPTION(
+                    ChainParamsInvalid() << errinfo_comment(
+                        "Unknown seal engine: " + chainParams->getSealEngineName() ) );
 
             g_client->dbRotationPeriod(
                 ( ( clock_t )( clockDbRotationPeriodInSeconds ) ) * CLOCKS_PER_SEC );
@@ -1992,8 +1994,7 @@ int main( int argc, char** argv ) {
             auto pWeb3Face = new rpc::Web3( clientVersion() );
             auto pEthFace = new rpc::Eth( configPath.string(), *g_client, *accountHolder.get() );
             auto pSkaleFace = new rpc::Skale( *g_client, sharedSpace );
-            auto pSkaleStatsFace =
-                new rpc::SkaleStats( configPath.string(), *g_client );
+            auto pSkaleStatsFace = new rpc::SkaleStats( configPath.string(), *g_client );
             pSkaleStatsFace->isExposeAllDebugInfo_ = isExposeAllDebugInfo;
             auto pPersonalFace = bEnabledAPIs_personal ?
                                      new rpc::Personal( keyManager, *accountHolder, *g_client ) :
@@ -2377,11 +2378,13 @@ int main( int argc, char** argv ) {
                 serverOpts.netOpts_.bindOptsStandard_.cntServers_ = cntServersStd;
                 serverOpts.netOpts_.bindOptsStandard_.strAddrHTTP4_ = chainParams->getSelfNodeIp();
                 serverOpts.netOpts_.bindOptsStandard_.nBasePortHTTP4_ = nExplicitPortHTTP4std;
-                serverOpts.netOpts_.bindOptsStandard_.strAddrHTTP6_ = chainParams->getSelfNodeIpV6();
+                serverOpts.netOpts_.bindOptsStandard_.strAddrHTTP6_ =
+                    chainParams->getSelfNodeIpV6();
                 serverOpts.netOpts_.bindOptsStandard_.nBasePortHTTP6_ = nExplicitPortHTTP6std;
                 serverOpts.netOpts_.bindOptsStandard_.strAddrHTTPS4_ = chainParams->getSelfNodeIp();
                 serverOpts.netOpts_.bindOptsStandard_.nBasePortHTTPS4_ = nExplicitPortHTTPS4std;
-                serverOpts.netOpts_.bindOptsStandard_.strAddrHTTPS6_ = chainParams->getSelfNodeIpV6();
+                serverOpts.netOpts_.bindOptsStandard_.strAddrHTTPS6_ =
+                    chainParams->getSelfNodeIpV6();
                 serverOpts.netOpts_.bindOptsStandard_.nBasePortHTTPS6_ = nExplicitPortHTTPS6std;
                 serverOpts.netOpts_.bindOptsStandard_.strAddrWS4_ = chainParams->getSelfNodeIp();
                 serverOpts.netOpts_.bindOptsStandard_.nBasePortWS4_ = nExplicitPortWS4std;
@@ -2393,11 +2396,14 @@ int main( int argc, char** argv ) {
                 serverOpts.netOpts_.bindOptsStandard_.nBasePortWSS6_ = nExplicitPortWSS6std;
 
                 serverOpts.netOpts_.bindOptsInformational_.cntServers_ = cntServersNfo;
-                serverOpts.netOpts_.bindOptsInformational_.strAddrHTTP4_ = chainParams->getSelfNodeIp();
+                serverOpts.netOpts_.bindOptsInformational_.strAddrHTTP4_ =
+                    chainParams->getSelfNodeIp();
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortHTTP4_ = nExplicitPortHTTP4nfo;
-                serverOpts.netOpts_.bindOptsInformational_.strAddrHTTP6_ = chainParams->getSelfNodeIpV6();
+                serverOpts.netOpts_.bindOptsInformational_.strAddrHTTP6_ =
+                    chainParams->getSelfNodeIpV6();
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortHTTP6_ = nExplicitPortHTTP6nfo;
-                serverOpts.netOpts_.bindOptsInformational_.strAddrHTTPS4_ = chainParams->getSelfNodeIp();
+                serverOpts.netOpts_.bindOptsInformational_.strAddrHTTPS4_ =
+                    chainParams->getSelfNodeIp();
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortHTTPS4_ =
                     nExplicitPortHTTPS4nfo;
                 serverOpts.netOpts_.bindOptsInformational_.strAddrHTTPS6_ =
@@ -2405,13 +2411,17 @@ int main( int argc, char** argv ) {
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortHTTPS6_ =
                     nExplicitPortHTTPS6nfo;
 
-                serverOpts.netOpts_.bindOptsInformational_.strAddrWS4_ = chainParams->getSelfNodeIp();
+                serverOpts.netOpts_.bindOptsInformational_.strAddrWS4_ =
+                    chainParams->getSelfNodeIp();
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortWS4_ = nExplicitPortWS4nfo;
-                serverOpts.netOpts_.bindOptsInformational_.strAddrWS6_ = chainParams->getSelfNodeIpV6();
+                serverOpts.netOpts_.bindOptsInformational_.strAddrWS6_ =
+                    chainParams->getSelfNodeIpV6();
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortWS6_ = nExplicitPortWS6nfo;
-                serverOpts.netOpts_.bindOptsInformational_.strAddrWSS4_ = chainParams->getSelfNodeIp();
+                serverOpts.netOpts_.bindOptsInformational_.strAddrWSS4_ =
+                    chainParams->getSelfNodeIp();
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortWSS4_ = nExplicitPortWSS4nfo;
-                serverOpts.netOpts_.bindOptsInformational_.strAddrWSS6_ = chainParams->getSelfNodeIpV6();
+                serverOpts.netOpts_.bindOptsInformational_.strAddrWSS6_ =
+                    chainParams->getSelfNodeIpV6();
                 serverOpts.netOpts_.bindOptsInformational_.nBasePortWSS6_ = nExplicitPortWSS6nfo;
 
                 serverOpts.netOpts_.strPathSslKey_ = strPathSslKey;

--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -90,7 +90,7 @@ json_spirit::mObject FillTransactionTest( json_spirit::mObject const& _o ) {
         unique_ptr< SealEngineFace > se( params.createSealEngine() );
 
         // Test networks has forkblocks set to 0 if rules are enabled
-        bool onExperimental = ( bh.number() >= params.constantinopleForkBlock );
+        bool onExperimental = ( bh.number() >= params.getConstantinopleForkBlock() );
 
         out[test::netIdToString( network )] = mObject();
         mObject expectSection = getExpectSection( expectObj, network );
@@ -154,7 +154,7 @@ void TestTransactionTest( json_spirit::mObject const& _o ) {
         BOOST_REQUIRE( _o.at( networkname ).type() == json_spirit::obj_type );
         ChainParams params( genesisInfo( network ) );
         unique_ptr< SealEngineFace > se( params.createSealEngine() );
-        bool onExperimental = ( bh.number() >= params.experimentalForkBlock );
+        bool onExperimental = ( bh.number() >= params.getExperimentalForkBlock() );
         mObject obj = _o.at( networkname ).get_obj();
         try {
             bytes stream = importByteArray( _o.at( "rlp" ).get_str() );

--- a/test/tools/libtesteth/BlockChainHelper.cpp
+++ b/test/tools/libtesteth/BlockChainHelper.cpp
@@ -360,7 +360,7 @@ void TestBlock::verify( TestBlockChain const& _bc ) const {
         _bc.getInterface().sealEngine()->verify(
             CheckNothingNew, m_blockHeader, BlockHeader(), &m_bytes );
     } catch ( Exception const& _e ) {
-        u256 const& daoHardfork = _bc.getInterface().sealEngine()->chainParams().daoHardforkBlock;
+        u256 const& daoHardfork = _bc.getInterface().sealEngine()->chainParams().getDaoHardforkBlock();
         if ( ( m_blockHeader.number() >= daoHardfork &&
                  m_blockHeader.number() <= daoHardfork + 9 ) ||
              m_blockHeader.number() == 0 ) {

--- a/test/tools/libtesteth/BlockChainHelper.cpp
+++ b/test/tools/libtesteth/BlockChainHelper.cpp
@@ -460,14 +460,14 @@ TestBlockChain::TestBlockChain( TestBlock const& _genesisBlock ) {
 
 void TestBlockChain::reset( TestBlock const& _genesisBlock ) {
     m_tempDirBlockchain.reset( new TransientDirectory );
-    ChainParams p = ChainParams( genesisInfo( TestBlockChain::s_sealEngineNetwork ),
-        _genesisBlock.bytes(), _genesisBlock.accountMap() );
+    m_chainParams.reset( new ChainParams( genesisInfo( TestBlockChain::s_sealEngineNetwork ),
+        _genesisBlock.bytes(), _genesisBlock.accountMap() ) );
 
     m_blockChain.reset(
-        new BlockChain( p, m_tempDirBlockchain.get()->path(), true, WithExisting::Kill ) );
+        new BlockChain( m_chainParams, m_tempDirBlockchain.get()->path(), true, WithExisting::Kill ) );
     if ( !m_blockChain->isKnown( BlockHeader::headerHashFromBlock( _genesisBlock.bytes() ) ) ) {
         cdebug << "Not known:" << BlockHeader::headerHashFromBlock( _genesisBlock.bytes() )
-               << BlockHeader( p.genesisBlock() ).hash();
+               << BlockHeader( m_chainParams->genesisBlock() ).hash();
         cdebug << "Genesis block not known!";
         cdebug << "This should never happen.";
         assert( false );

--- a/test/tools/libtesteth/BlockChainHelper.h
+++ b/test/tools/libtesteth/BlockChainHelper.h
@@ -152,6 +152,7 @@ public:
     static eth::Network s_sealEngineNetwork;
 
 private:
+    std::shared_ptr< ChainParams > m_chainParams;
     std::unique_ptr< BlockChain > m_blockChain;
     TestBlock m_genesisBlock;
     TestBlock m_lastBlock;

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -50,7 +50,7 @@ vector< h256 > lastHashes( u256 _currentBlockNumber ) {
 
 int mainnetChainID() {
     static auto const c_mainnetChainID =
-        ChainParams( genesisInfo( eth::Network::MainNetworkTest ) ).chainID;
+        ChainParams( genesisInfo( eth::Network::MainNetworkTest ) ).getChainId();
     return c_mainnetChainID;
 }
 }  // namespace
@@ -260,7 +260,7 @@ std::tuple< State, ImportTest::ExecOutput, skale::ChangeLog > ImportTest::execut
     try {
         unique_ptr< SealEngineFace > se(
             ChainParams( genesisInfo( _sealEngineNetwork ) ).createSealEngine() );
-        removeEmptyAccounts = m_envInfo->number() >= se->chainParams().EIP158ForkBlock;
+        removeEmptyAccounts = m_envInfo->number() >= se->chainParams().getEIP158ForkBlock();
         if ( Options::get().jsontrace ) {
             StandardTrace st;
             st.setShowMnemonics();

--- a/test/tools/libtestutils/BlockChainLoader.cpp
+++ b/test/tools/libtestutils/BlockChainLoader.cpp
@@ -37,9 +37,9 @@ BlockChainLoader::BlockChainLoader( Json::Value const& _json, eth::Network _seal
     bytes genesisBlock = fromHex( _json["genesisRLP"].asString() );
 
     Json::FastWriter a;
-    m_bc.reset( new BlockChain( ChainParams( genesisInfo( _sealEngineNetwork ), genesisBlock,
-                                    jsonToAccountMap( a.write( _json["pre"] ) ) ),
-        m_dir.path(), false, WithExisting::Kill ) );
+    m_chainParams.reset( new ChainParams( genesisInfo( _sealEngineNetwork ), genesisBlock,
+                                          jsonToAccountMap( a.write( _json["pre"] ) ) ) );
+    m_bc.reset( new BlockChain( m_chainParams, m_dir.path(), false, WithExisting::Kill ) );
 
     // load pre state
     m_block = m_bc->genesisBlock( m_dir.path(), m_bc->genesisHash() );

--- a/test/tools/libtestutils/BlockChainLoader.h
+++ b/test/tools/libtestutils/BlockChainLoader.h
@@ -45,6 +45,7 @@ public:
 
 private:
     TransientDirectory m_dir;
+    std::shared_ptr< dev::eth::ChainParams > m_chainParams;
     std::unique_ptr< eth::BlockChain > m_bc;
     eth::Block m_block;
 };

--- a/test/unittests/libethashseal/EthashTest.cpp
+++ b/test/unittests/libethashseal/EthashTest.cpp
@@ -40,8 +40,8 @@ BOOST_FIXTURE_TEST_SUITE( EthashTests, TestOutputHelperFixture )
 BOOST_AUTO_TEST_CASE( calculateDifficultyByzantiumWithoutUncles,
     *boost::unit_test::precondition( dev::test::run_not_express ) ) {
     ChainOperationParams params;
-    params.homesteadForkBlock = 0;
-    params.byzantiumForkBlock = u256( 0x1000 );
+    params.setHomesteadForkBlock( 0 );
+    params.setByzantiumForkBlock( u256( 0x1000 ) );
 
     Ethash ethash;
     ethash.setChainParams( params );
@@ -63,8 +63,8 @@ BOOST_AUTO_TEST_CASE( calculateDifficultyByzantiumWithoutUncles,
 BOOST_AUTO_TEST_CASE( calculateDifficultyByzantiumWithUncles,
     *boost::unit_test::precondition( dev::test::run_not_express ) ) {
     ChainOperationParams params;
-    params.homesteadForkBlock = 0;
-    params.byzantiumForkBlock = u256( 0x1000 );
+    params.setHomesteadForkBlock( 0 );
+    params.setByzantiumForkBlock( u256( 0x1000 ) );
 
     Ethash ethash;
     ethash.setChainParams( params );
@@ -88,8 +88,8 @@ BOOST_AUTO_TEST_CASE( calculateDifficultyByzantiumWithUncles,
 BOOST_AUTO_TEST_CASE( calculateDifficultyByzantiumMaxAdjustment,
     *boost::unit_test::precondition( dev::test::run_not_express ) ) {
     ChainOperationParams params;
-    params.homesteadForkBlock = 0;
-    params.byzantiumForkBlock = u256( 0x1000 );
+    params.setHomesteadForkBlock( 0 );
+    params.setByzantiumForkBlock( u256( 0x1000 ) );
 
     Ethash ethash;
     ethash.setChainParams( params );

--- a/test/unittests/libethcore/SealEngineTest.cpp
+++ b/test/unittests/libethcore/SealEngineTest.cpp
@@ -34,7 +34,7 @@ namespace {
 class UnsignedTransactionFixture : public TestOutputHelperFixture {
 public:
     UnsignedTransactionFixture() {
-        params.experimentalForkBlock = u256( 0x1000 );
+        params.setExperimentalForkBlock( u256( 0x1000 ) );
 
         ethash.setChainParams( params );
 

--- a/test/unittests/libethereum/BlockChain.cpp
+++ b/test/unittests/libethereum/BlockChain.cpp
@@ -54,8 +54,8 @@ BOOST_AUTO_TEST_CASE( output ) {
 BOOST_AUTO_TEST_CASE( opendb ) {
     TestBlock genesis = TestBlockChain::defaultGenesisBlock();
     TransientDirectory tempDirBlockchain;
-    ChainParams p(
-        genesisInfo( eth::Network::TransitionnetTest ), genesis.bytes(), genesis.accountMap() );
+    std::shared_ptr< ChainParams > p( new ChainParams(
+        genesisInfo( eth::Network::TransitionnetTest ), genesis.bytes(), genesis.accountMap() ) );
     BlockChain bc( p, tempDirBlockchain.path(), false, WithExisting::Kill );
     auto is_critical = []( std::exception const& _e ) {
         return string( _e.what() ).find( "DatabaseAlreadyOpen" ) != string::npos;

--- a/test/unittests/libethereum/ClientTest.cpp
+++ b/test/unittests/libethereum/ClientTest.cpp
@@ -257,7 +257,7 @@ public:
 
         gainRoot();
 
-        std::shared_ptr< ChainParams > chainParams;
+        std::shared_ptr< ChainParams > chainParams = std::make_shared< ChainParams >();
 
         Json::Value ret;
         Json::Reader().parse( _config, ret );

--- a/test/unittests/libethereum/ClientTest.cpp
+++ b/test/unittests/libethereum/ClientTest.cpp
@@ -257,7 +257,7 @@ public:
 
         gainRoot();
 
-        std::shared_ptr< ChainParams > chainParams = std::make_shared< ChainParams >();
+        chainParams = std::make_shared< ChainParams >();
 
         Json::Value ret;
         Json::Reader().parse( _config, ret );
@@ -336,6 +336,7 @@ public:
     }
 
 private:
+    std::shared_ptr< ChainParams > chainParams;
     std::unique_ptr< dev::eth::Client > m_ethereum;
     TransientDirectory m_tmpDir;
     dev::KeyPair coinbase{KeyPair::create()};

--- a/test/unittests/libethereum/ClientTest.cpp
+++ b/test/unittests/libethereum/ClientTest.cpp
@@ -108,7 +108,7 @@ class TestClientFixture : public TestOutputHelperFixture {
 public:
     TestClientFixture( const std::string& _config = "" ) try {
 
-        ChainParams chainParams;
+        std::shared_ptr< ChainParams > chainParams;
         if ( _config != "" ) {
             Json::Value ret;
             Json::Reader().parse( _config, ret );
@@ -117,15 +117,15 @@ public:
     #endif
             Json::FastWriter fastWriter;
             std::string config = fastWriter.write( ret );
-            chainParams = chainParams.loadConfig( config );
+            chainParams->loadConfig( config );
         }
         else {
-            chainParams.nodeInfo.port = chainParams.nodeInfo.port6 = rand_port;
-            chainParams.sChain.nodes[0].port = chainParams.sChain.nodes[0].port6 = rand_port;
+            chainParams->nodeInfo.port = chainParams->nodeInfo.port6 = rand_port;
+            chainParams->sChain.nodes[0].port = chainParams->sChain.nodes[0].port6 = rand_port;
         }
 
-        chainParams.sealEngineName = NoProof::name();
-        chainParams.allowFutureBlocks = true;
+        chainParams->sealEngineName = NoProof::name();
+        chainParams->allowFutureBlocks = true;
 
         string listenIP = "127.0.0.1";
         unsigned short listenPort = 30303;
@@ -143,7 +143,7 @@ public:
         auto monitor = make_shared< InstanceMonitor >("test");
 
         setenv("DATA_DIR", m_tmpDir.path().c_str(), 1);
-        m_ethereum.reset( new eth::ClientTest( chainParams, ( int ) chainParams.networkID,
+        m_ethereum.reset( new eth::ClientTest( chainParams, ( int ) chainParams->getNetworkId(),
             shared_ptr< GasPricer >(), NULL, monitor, m_tmpDir.path(), WithExisting::Kill ) );
 
         //        m_ethereum.reset(
@@ -257,7 +257,7 @@ public:
 
         gainRoot();
 
-        ChainParams chainParams;
+        std::shared_ptr< ChainParams > chainParams;
 
         Json::Value ret;
         Json::Reader().parse( _config, ret );
@@ -266,7 +266,7 @@ public:
 #endif
         Json::FastWriter fastWriter;
         std::string config = fastWriter.write( ret );
-        chainParams = chainParams.loadConfig( config );
+        chainParams->loadConfig( config );
 
         auto nodesState = contents( m_tmpDir.path() / fs::path( "network.rlp" ) );
 
@@ -288,7 +288,7 @@ public:
         auto monitor = make_shared< InstanceMonitor >("test");
 
         setenv("DATA_DIR", m_tmpDir.path().c_str(), 1);
-        m_ethereum.reset( new eth::ClientTest( chainParams, ( int ) chainParams.networkID,
+        m_ethereum.reset( new eth::ClientTest( chainParams, ( int ) chainParams->getNetworkId(),
             shared_ptr< GasPricer >(), mgr, monitor, m_tmpDir.path(), WithExisting::Kill ) );
 
         //        m_ethereum.reset(

--- a/test/unittests/libethereum/ClientTest.cpp
+++ b/test/unittests/libethereum/ClientTest.cpp
@@ -108,7 +108,7 @@ class TestClientFixture : public TestOutputHelperFixture {
 public:
     TestClientFixture( const std::string& _config = "" ) try {
 
-        std::shared_ptr< ChainParams > chainParams;
+        std::shared_ptr< ChainParams > chainParams = std::make_shared< ChainParams >();
         if ( _config != "" ) {
             Json::Value ret;
             Json::Reader().parse( _config, ret );

--- a/test/unittests/libethereum/GasPricer.cpp
+++ b/test/unittests/libethereum/GasPricer.cpp
@@ -66,7 +66,8 @@ BOOST_AUTO_TEST_CASE( trivialGasPricer ) {
     BOOST_CHECK_EQUAL( gp->ask( Block( Block::Null ) ), DefaultGasPrice );
     BOOST_CHECK_EQUAL( gp->bid(), DefaultGasPrice );
 
-    gp->update( BlockChain( eth::ChainParams(), TransientDirectory().path(), false, WithExisting::Kill ) );
+    std::shared_ptr< eth::ChainParams > chainParams( new eth::ChainParams() );
+    gp->update( BlockChain( chainParams, TransientDirectory().path(), false, WithExisting::Kill ) );
     BOOST_CHECK_EQUAL( gp->ask( Block( Block::Null ) ), DefaultGasPrice );
     BOOST_CHECK_EQUAL( gp->bid(), DefaultGasPrice );
 }

--- a/test/unittests/libethereum/PrecompiledTest.cpp
+++ b/test/unittests/libethereum/PrecompiledTest.cpp
@@ -1703,10 +1703,10 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
     Json::FastWriter fastWriter;
     std::string config = fastWriter.write( ret );
 
-    ChainParams chainParams;
-    chainParams = chainParams.loadConfig( config );
-    chainParams.sealEngineName = NoProof::name();
-    chainParams.allowFutureBlocks = true;
+    std::shared_ptr< ChainParams > chainParams;
+    chainParams->loadConfig( config );
+    chainParams->sealEngineName = NoProof::name();
+    chainParams->allowFutureBlocks = true;
 
     dev::eth::g_configAccesssor.reset( new skutils::json_config_file_accessor( "../../test/unittests/libethereum/PrecompiledConfig.json" ) );
 
@@ -1714,7 +1714,7 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
     dev::TransientDirectory m_tmpDir;
     auto monitor = make_shared< InstanceMonitor >("test");
     setenv("DATA_DIR", m_tmpDir.path().c_str(), 1);
-    client.reset( new eth::ClientTest( chainParams, ( int ) chainParams.networkID,
+    client.reset( new eth::ClientTest( chainParams, ( int ) chainParams->getNetworkId(),
         shared_ptr< GasPricer >(), nullptr, monitor, m_tmpDir.path(), dev::WithExisting::Kill ) );
 
     client->setAuthor( Address("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF") );

--- a/test/unittests/libethereum/PrecompiledTest.cpp
+++ b/test/unittests/libethereum/PrecompiledTest.cpp
@@ -1705,8 +1705,10 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
 
     std::shared_ptr< ChainParams > chainParams;
     chainParams->loadConfig( config );
-    chainParams->sealEngineName = NoProof::name();
-    chainParams->allowFutureBlocks = true;
+//    chainParams->sealEngineName = NoProof::name();
+//    chainParams->allowFutureBlocks = true;
+    size_t _port = ( srand( time( nullptr ) ), 1024 + rand() % 64000 );
+    chainParams->fillDefaultTestsParameters( _port );
 
     dev::eth::g_configAccesssor.reset( new skutils::json_config_file_accessor( "../../test/unittests/libethereum/PrecompiledConfig.json" ) );
 

--- a/test/unittests/libethereum/PrecompiledTest.cpp
+++ b/test/unittests/libethereum/PrecompiledTest.cpp
@@ -1703,10 +1703,8 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
     Json::FastWriter fastWriter;
     std::string config = fastWriter.write( ret );
 
-    std::shared_ptr< ChainParams > chainParams;
+    std::shared_ptr< ChainParams > chainParams = std::make_shared< ChainParams >();
     chainParams->loadConfig( config );
-//    chainParams->sealEngineName = NoProof::name();
-//    chainParams->allowFutureBlocks = true;
     size_t _port = ( srand( time( nullptr ) ), 1024 + rand() % 64000 );
     chainParams->fillDefaultTestsParameters( _port );
 

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -135,7 +135,7 @@ struct SkaleHostFixture : public TestOutputHelperFixture {
                           std::map< std::string, std::string >() ) {
         dev::p2p::NetworkPreferences nprefs;
 
-        std::shared_ptr< ChainParams > chainParams = std::make_shared< ChainParams >();
+        chainParams = std::make_shared< ChainParams >();
         chainParams->sealEngineName = NoProof::name();
         chainParams->allowFutureBlocks = true;
         chainParams->difficulty = chainParams->getMinimumDifficulty();
@@ -206,6 +206,7 @@ struct SkaleHostFixture : public TestOutputHelperFixture {
     TransactionQueue* tq;
 
     TransientDirectory tempDir;  // ! should exist before client!
+    std::shared_ptr< ChainParams > chainParams;
     unique_ptr< Client > client;
 
     dev::KeyPair coinbase{ KeyPair::create() };

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -135,29 +135,29 @@ struct SkaleHostFixture : public TestOutputHelperFixture {
                           std::map< std::string, std::string >() ) {
         dev::p2p::NetworkPreferences nprefs;
 
-        ChainParams chainParams;
-        chainParams.sealEngineName = NoProof::name();
-        chainParams.allowFutureBlocks = true;
-        chainParams.difficulty = chainParams.minimumDifficulty;
-        chainParams.gasLimit = chainParams.maxGasLimit;
-        chainParams.istanbulForkBlock = 0;
+        std::shared_ptr< ChainParams > chainParams;
+        chainParams->sealEngineName = NoProof::name();
+        chainParams->allowFutureBlocks = true;
+        chainParams->difficulty = chainParams->minimumDifficulty;
+        chainParams->gasLimit = chainParams->maxGasLimit;
+        chainParams->istanbulForkBlock = 0;
         // add random extra data to randomize genesis hash and get random DB path,
         // so that tests can be run in parallel
         // TODO: better make it use ethemeral in-memory databases
-        chainParams.extraData = h256::random().asBytes();
-        chainParams.sChain.nodeGroups = { { {}, uint64_t( -1 ), { "0", "0", "1", "0" } } };
-        chainParams.nodeInfo.port = chainParams.nodeInfo.port6 = rand_port;
-        chainParams.nodeInfo.testSignatures = true;
-        chainParams.sChain.nodes[0].port = chainParams.sChain.nodes[0].port6 = rand_port;
+        chainParams->extraData = h256::random().asBytes();
+        chainParams->sChain.nodeGroups = { { {}, uint64_t( -1 ), { "0", "0", "1", "0" } } };
+        chainParams->nodeInfo.port = chainParams->nodeInfo.port6 = rand_port;
+        chainParams->nodeInfo.testSignatures = true;
+        chainParams->sChain.nodes[0].port = chainParams->sChain.nodes[0].port6 = rand_port;
 
         // not 0-timestamp genesis - to test patch
-        chainParams.timestamp = std::time( NULL ) - 5;
+        chainParams->timestamp = std::time( NULL ) - 5;
 
         if ( params.count( "multiTransactionMode" ) && stoi( params.at( "multiTransactionMode" ) ) )
-            chainParams.sChain.multiTransactionMode = true;
+            chainParams->sChain.multiTransactionMode = true;
         if ( params.count( "skipInvalidTransactionsPatchTimestamp" ) &&
              stoi( params.at( "skipInvalidTransactionsPatchTimestamp" ) ) )
-            chainParams.sChain._patchTimestamps[static_cast< size_t >(
+            chainParams->sChain._patchTimestamps[static_cast< size_t >(
                 SchainPatchEnum::SkipInvalidTransactionsPatch )] =
                 stoi( params.at( "skipInvalidTransactionsPatchTimestamp" ) );
 
@@ -169,7 +169,7 @@ struct SkaleHostFixture : public TestOutputHelperFixture {
 
         setenv( "DATA_DIR", tempDir.path().c_str(), 1 );
         client = make_unique< Client >(
-            chainParams, chainParams.networkID, gasPricer, nullptr, monitor, tempDir.path() );
+            chainParams, chainParams->getNetworkId(), gasPricer, nullptr, monitor, tempDir.path() );
         this->tq = client->debugGetTransactionQueue();
         client->setAuthor( coinbase.address() );
 

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -135,11 +135,11 @@ struct SkaleHostFixture : public TestOutputHelperFixture {
                           std::map< std::string, std::string >() ) {
         dev::p2p::NetworkPreferences nprefs;
 
-        std::shared_ptr< ChainParams > chainParams;
+        std::shared_ptr< ChainParams > chainParams = std::make_shared< ChainParams >();
         chainParams->sealEngineName = NoProof::name();
         chainParams->allowFutureBlocks = true;
-        chainParams->difficulty = chainParams->minimumDifficulty;
-        chainParams->gasLimit = chainParams->maxGasLimit;
+        chainParams->difficulty = chainParams->getMinimumDifficulty();
+        chainParams->gasLimit = chainParams->getMaxGasLimit();
         chainParams->istanbulForkBlock = 0;
         // add random extra data to randomize genesis hash and get random DB path,
         // so that tests can be run in parallel
@@ -894,7 +894,7 @@ BOOST_DATA_TEST_CASE(
     // 2 txn
     json["value"] = jsToDecimal( toJS( 9000 * dev::eth::szabo ) );
     json["nonce"] = 1;
-    json["gas"] = jsToDecimal( toJS( client->chainParams().gasLimit - 21000 + 1 ) );
+    json["gas"] = jsToDecimal( toJS( client->chainParams().getGasLimit() - 21000 + 1 ) );
 
     Transaction tx2 = fixture.tx_from_json( json );
 
@@ -943,7 +943,7 @@ BOOST_AUTO_TEST_CASE( gasLimitInBlockProposal ) {
 
     auto wr_state = client->state().createStateCopyAndClearCaches();
     wr_state.addBalance(
-        fixture.account2.address(), client->chainParams().gasLimit * 1000 + dev::eth::ether );
+        fixture.account2.address(), client->chainParams().getGasLimit() * 1000 + dev::eth::ether );
     wr_state.commit();
     wr_state.getOriginalDb()->createBlockSnap(2);
 
@@ -959,7 +959,7 @@ BOOST_AUTO_TEST_CASE( gasLimitInBlockProposal ) {
 
     // 2 txn
     json["from"] = toJS( account2.address() );
-    json["gas"] = jsToDecimal( toJS( client->chainParams().gasLimit - 21000 + 1 ) );
+    json["gas"] = jsToDecimal( toJS( client->chainParams().getGasLimit() - 21000 + 1 ) );
 
     Transaction tx2 = fixture.tx_from_json( json );
 

--- a/test/unittests/libevm/VMTest.cpp
+++ b/test/unittests/libevm/VMTest.cpp
@@ -175,7 +175,7 @@ public:
     State state = State(0).createStateCopyAndClearCaches();
     std::unique_ptr< SealEngineFace > se{
         ChainParams( genesisInfo( Network::ConstantinopleTest ) ).createSealEngine()};
-    EnvInfo envInfo{blockHeader, lastBlockHashes, 1, 0, se->chainParams().chainID};
+    EnvInfo envInfo{blockHeader, lastBlockHashes, 1, 0, se->chainParams().getChainId()};
 
     u256 value = 0;
     u256 gasPrice = 1;
@@ -336,7 +336,7 @@ public:
     State state{0};
     std::unique_ptr< SealEngineFace > se{
         ChainParams( genesisInfo( Network::ConstantinopleTest ) ).createSealEngine()};
-    EnvInfo envInfo{blockHeader, lastBlockHashes, 1, 0, se->chainParams().chainID};
+    EnvInfo envInfo{blockHeader, lastBlockHashes, 1, 0, se->chainParams().getChainId()};
 
     u256 value = 0;
     u256 gasPrice = 1;
@@ -446,7 +446,7 @@ public:
     State state = State( 0, dev::TransientDirectory().path(), dev::h256() ).createStateCopyAndClearCaches();
     std::unique_ptr< SealEngineFace > se{
         ChainParams( genesisInfo( Network::ConstantinopleTest ) ).createSealEngine()};
-    EnvInfo envInfo{blockHeader, lastBlockHashes, 1, 0, se->chainParams().chainID};
+    EnvInfo envInfo{blockHeader, lastBlockHashes, 1, 0, se->chainParams().getChainId()};
 
     u256 value = 0;
     u256 gasPrice = 1;
@@ -517,7 +517,7 @@ public:
     State state{0};
     std::unique_ptr< SealEngineFace > se{
         ChainParams( genesisInfo( Network::IstanbulTest ) ).createSealEngine()};
-    EnvInfo envInfo{blockHeader, lastBlockHashes, 1, 0, se->chainParams().chainID};
+    EnvInfo envInfo{blockHeader, lastBlockHashes, 1, 0, se->chainParams().getChainId()};
 
     u256 value = 0;
     u256 gasPrice = 1;
@@ -624,7 +624,7 @@ public:
     State state{0};
     std::unique_ptr< SealEngineFace > se{
         ChainParams( genesisInfo( Network::IstanbulTest ) ).createSealEngine()};
-    EnvInfo envInfo{blockHeader, lastBlockHashes, 1, 0, se->chainParams().chainID};
+    EnvInfo envInfo{blockHeader, lastBlockHashes, 1, 0, se->chainParams().getChainId()};
 
     u256 value = 0;
     u256 gasPrice = 1;
@@ -658,7 +658,7 @@ public:
         SchainPatch::init(cp);
 
         se.reset(cp.createSealEngine());
-        envInfo = std::make_unique<EnvInfo> ( blockHeader, lastBlockHashes, 1, 0, cp.chainID );
+        envInfo = std::make_unique<EnvInfo> ( blockHeader, lastBlockHashes, 1, 0, cp.getChainId() );
 
         state.addBalance( address, 1 * ether );
     }

--- a/test/unittests/libskale/HashSnapshot.cpp
+++ b/test/unittests/libskale/HashSnapshot.cpp
@@ -264,23 +264,23 @@ struct SnapshotHashingFixture : public TestOutputHelperFixture, public FixtureCo
 
         gainRoot();
 
-        ChainParams chainParams;
+        std::shared_ptr< ChainParams > chainParams;
         dev::p2p::NetworkPreferences nprefs;
-        chainParams.sealEngineName = NoProof::name();
-        chainParams.allowFutureBlocks = true;
-        chainParams.difficulty = chainParams.minimumDifficulty;
-        chainParams.gasLimit = chainParams.maxGasLimit;
-        chainParams.byzantiumForkBlock = 0;
-        chainParams.externalGasDifficulty = 1;
+        chainParams->sealEngineName = NoProof::name();
+        chainParams->allowFutureBlocks = true;
+        chainParams->difficulty = chainParams->minimumDifficulty;
+        chainParams->gasLimit = chainParams->maxGasLimit;
+        chainParams->byzantiumForkBlock = 0;
+        chainParams->externalGasDifficulty = 1;
 #ifndef MIRAGE
         chainParams.sChain.contractStorageLimit = 0x1122334455667788UL;
 #endif
         // add random extra data to randomize genesis hash and get random DB path,
         // so that tests can be run in parallel
         // TODO: better make it use ethemeral in-memory databases
-        chainParams.extraData = h256::random().asBytes();
+        chainParams->extraData = h256::random().asBytes();
 
-        chainParams.sChain.emptyBlockIntervalMs = 1000;
+        chainParams->sChain.emptyBlockIntervalMs = 1000;
 
         //        web3.reset( new WebThreeDirect(
         //            "eth tests", tempDir.path(), "", chainParams, WithExisting::Kill, {"eth"},
@@ -328,7 +328,7 @@ struct SnapshotHashingFixture : public TestOutputHelperFixture, public FixtureCo
         auto monitor = make_shared< InstanceMonitor >( "test" );
 
         setenv( "DATA_DIR", BTRFS_DIR_PATH.c_str(), 1 );
-        client.reset( new eth::ClientTest( chainParams, ( int ) chainParams.networkID,
+        client.reset( new eth::ClientTest( chainParams, ( int ) chainParams->getNetworkId(),
             shared_ptr< GasPricer >(), NULL, monitor, boost::filesystem::path( BTRFS_DIR_PATH ),
             WithExisting::Kill ) );
 

--- a/test/unittests/libskale/HashSnapshot.cpp
+++ b/test/unittests/libskale/HashSnapshot.cpp
@@ -141,6 +141,72 @@ public:
         this->hashAgent_->signatures_[idx] = libff::alt_bn128_G1::random_element();
     }
 
+    static std::shared_ptr< ChainParams > makeChainParamsForTest( const std::string& _testName ) {
+        std::shared_ptr< ChainParams > chainParams = std::make_shared< ChainParams >();
+        if ( _testName == "PositiveTest" ) {
+            chainParams->sChain.t = 3;
+            chainParams->sChain.nodes.resize( 4 );
+            for ( size_t i = 0; i < chainParams->sChain.nodes.size(); ++i ) {
+                chainParams->sChain.nodes[i].id = i;
+            }
+            chainParams->nodeInfo.id = 3;
+
+            return chainParams;
+        }
+
+        if ( _testName == "WrongHash" ) {
+            chainParams->sChain.t = 5;
+            chainParams->sChain.nodes.resize( 7 );
+            for ( size_t i = 0; i < chainParams->sChain.nodes.size(); ++i ) {
+                chainParams->sChain.nodes[i].id = i;
+            }
+            chainParams->nodeInfo.id = 6;
+
+            return chainParams;
+        }
+
+        if ( _testName == "NotEnoughVotes" ) {
+            chainParams->sChain.t = 3;
+            chainParams->sChain.nodes.resize( 4 );
+            for ( size_t i = 0; i < chainParams->sChain.nodes.size(); ++i ) {
+                chainParams->sChain.nodes[i].id = i;
+            }
+            chainParams->nodeInfo.id = 3;
+
+            return chainParams;
+        }
+
+        if ( _testName == "WrongSignature" ) {
+            chainParams->sChain.t = 3;
+            chainParams->sChain.nodes.resize( 4 );
+            for ( size_t i = 0; i < chainParams->sChain.nodes.size(); ++i ) {
+                chainParams->sChain.nodes[i].id = i;
+            }
+            chainParams->nodeInfo.id = 3;
+
+            return chainParams;
+        }
+
+        if ( _testName == "noSnapshotMajority" ) {
+            chainParams->sChain.t = 3;
+            chainParams->sChain.nodes.resize( 4 );
+            for ( size_t i = 0; i < chainParams->sChain.nodes.size(); ++i ) {
+                chainParams->sChain.nodes[i].id = i;
+            }
+            chainParams->nodeInfo.id = 3;
+
+            chainParams->sChain.nodes[0].ip = "123.45.68.89";
+            chainParams->sChain.nodes[1].ip = "123.45.87.89";
+            chainParams->sChain.nodes[2].ip = "123.45.77.89";
+
+            chainParams->sChain.nodes[3].ip = "123.45.67.89";
+
+            return chainParams;
+        }
+
+        return chainParams;
+    }
+
     libff::alt_bn128_Fr secret_as_is;
 
     std::shared_ptr< SnapshotHashAgent > hashAgent_;
@@ -148,6 +214,8 @@ public:
     bool isSnapshotMajorityRequired = false;
 
     std::vector< libff::alt_bn128_Fr > blsPrivateKeys_;
+
+    enum testNames { PositiveTest, WrongHash, NotEnoughVotes, WrongSignature, noSnapshotMajority };
 };
 }  // namespace test
 }  // namespace dev
@@ -264,12 +332,12 @@ struct SnapshotHashingFixture : public TestOutputHelperFixture, public FixtureCo
 
         gainRoot();
 
-        std::shared_ptr< ChainParams > chainParams;
+        std::shared_ptr< ChainParams > chainParams = std::make_shared< ChainParams >();
         dev::p2p::NetworkPreferences nprefs;
         chainParams->sealEngineName = NoProof::name();
         chainParams->allowFutureBlocks = true;
-        chainParams->difficulty = chainParams->minimumDifficulty;
-        chainParams->gasLimit = chainParams->maxGasLimit;
+        chainParams->difficulty = chainParams->getMinimumDifficulty();
+        chainParams->gasLimit = chainParams->getMaxGasLimit();
         chainParams->byzantiumForkBlock = 0;
         chainParams->externalGasDifficulty = 1;
 #ifndef MIRAGE
@@ -422,16 +490,10 @@ BOOST_AUTO_TEST_SUITE( SnapshotSigningTestSuite )
 
 BOOST_AUTO_TEST_CASE( PositiveTest ) {
     libff::init_alt_bn128_params();
-    ChainParams chainParams;
-    chainParams.sChain.t = 3;
-    chainParams.sChain.nodes.resize( 4 );
-    for ( size_t i = 0; i < chainParams.sChain.nodes.size(); ++i ) {
-        chainParams.sChain.nodes[i].id = i;
-    }
-    chainParams.nodeInfo.id = 3;
-    SnapshotHashAgentTest test_agent( chainParams, "" );
+    std::shared_ptr< ChainParams > chainParams = SnapshotHashAgentTest::makeChainParamsForTest( "PositiveTest" );
+    SnapshotHashAgentTest test_agent( *chainParams, "" );
     dev::h256 hash = dev::h256::random();
-    std::vector< dev::h256 > snapshot_hashes( chainParams.sChain.nodes.size(), hash );
+    std::vector< dev::h256 > snapshot_hashes( chainParams->getNodesCount(), hash );
     test_agent.fillData( snapshot_hashes );
     BOOST_REQUIRE( test_agent.verifyAllData() == 3 );
     auto res = test_agent.getNodesToDownloadSnapshotFrom();
@@ -447,16 +509,10 @@ BOOST_AUTO_TEST_CASE( PositiveTest ) {
 
 BOOST_AUTO_TEST_CASE( WrongHash ) {
     libff::init_alt_bn128_params();
-    ChainParams chainParams;
-    chainParams.sChain.t = 5;
-    chainParams.sChain.nodes.resize( 7 );
-    for ( size_t i = 0; i < chainParams.sChain.nodes.size(); ++i ) {
-        chainParams.sChain.nodes[i].id = i;
-    }
-    chainParams.nodeInfo.id = 6;
-    SnapshotHashAgentTest test_agent( chainParams, "" );
+    std::shared_ptr< ChainParams > chainParams = SnapshotHashAgentTest::makeChainParamsForTest( "WrongHash" );
+    SnapshotHashAgentTest test_agent( *chainParams, "" );
     dev::h256 hash = dev::h256::random();  // `correct` hash
-    std::vector< dev::h256 > snapshot_hashes( chainParams.sChain.nodes.size(), hash );
+    std::vector< dev::h256 > snapshot_hashes( chainParams->getNodesCount(), hash );
     snapshot_hashes[4] = dev::h256::random();  // hash is different from `correct` hash
     test_agent.fillData( snapshot_hashes );
     BOOST_REQUIRE( test_agent.verifyAllData() == 6 );
@@ -467,16 +523,10 @@ BOOST_AUTO_TEST_CASE( WrongHash ) {
 
 BOOST_AUTO_TEST_CASE( NotEnoughVotes ) {
     libff::init_alt_bn128_params();
-    ChainParams chainParams;
-    chainParams.sChain.t = 3;
-    chainParams.sChain.nodes.resize( 4 );
-    for ( size_t i = 0; i < chainParams.sChain.nodes.size(); ++i ) {
-        chainParams.sChain.nodes[i].id = i;
-    }
-    chainParams.nodeInfo.id = 3;
-    SnapshotHashAgentTest test_agent( chainParams, "" );
+    std::shared_ptr< ChainParams > chainParams = SnapshotHashAgentTest::makeChainParamsForTest( "NotEnoughVotes" );
+    SnapshotHashAgentTest test_agent( *chainParams, "" );
     dev::h256 hash = dev::h256::random();
-    std::vector< dev::h256 > snapshot_hashes( chainParams.sChain.nodes.size(), hash );
+    std::vector< dev::h256 > snapshot_hashes( chainParams->getNodesCount(), hash );
     snapshot_hashes[2] = dev::h256::random();
     test_agent.fillData( snapshot_hashes );
     BOOST_REQUIRE( test_agent.verifyAllData() == 3 );
@@ -485,16 +535,10 @@ BOOST_AUTO_TEST_CASE( NotEnoughVotes ) {
 
 BOOST_AUTO_TEST_CASE( WrongSignature ) {
     libff::init_alt_bn128_params();
-    ChainParams chainParams;
-    chainParams.sChain.t = 3;
-    chainParams.sChain.nodes.resize( 4 );
-    for ( size_t i = 0; i < chainParams.sChain.nodes.size(); ++i ) {
-        chainParams.sChain.nodes[i].id = i;
-    }
-    chainParams.nodeInfo.id = 3;
-    SnapshotHashAgentTest test_agent( chainParams, "" );
+    std::shared_ptr< ChainParams > chainParams = SnapshotHashAgentTest::makeChainParamsForTest( "WrongSignature" );
+    SnapshotHashAgentTest test_agent( *chainParams, "" );
     dev::h256 hash = dev::h256::random();
-    std::vector< dev::h256 > snapshot_hashes( chainParams.sChain.nodes.size(), hash );
+    std::vector< dev::h256 > snapshot_hashes( chainParams->getNodesCount(), hash );
     test_agent.fillData( snapshot_hashes );
     test_agent.spoilSignature( 0 );
     BOOST_REQUIRE( test_agent.verifyAllData() == 2 );
@@ -502,24 +546,12 @@ BOOST_AUTO_TEST_CASE( WrongSignature ) {
 
 BOOST_AUTO_TEST_CASE( noSnapshotMajority ) {
     libff::init_alt_bn128_params();
-    ChainParams chainParams;
-    chainParams.sChain.t = 3;
-    chainParams.sChain.nodes.resize( 4 );
-    for ( size_t i = 0; i < chainParams.sChain.nodes.size(); ++i ) {
-        chainParams.sChain.nodes[i].id = i;
-    }
-    chainParams.nodeInfo.id = 3;
+    std::shared_ptr< ChainParams > chainParams = SnapshotHashAgentTest::makeChainParamsForTest( "noSnapshotMajority" );
+    std::string url = chainParams->getNodeByIndex( 3 ).ip + std::string( ":1234" );
 
-    chainParams.sChain.nodes[0].ip = "123.45.68.89";
-    chainParams.sChain.nodes[1].ip = "123.45.87.89";
-    chainParams.sChain.nodes[2].ip = "123.45.77.89";
-
-    chainParams.sChain.nodes[3].ip = "123.45.67.89";
-    std::string url = chainParams.sChain.nodes[3].ip + std::string( ":1234" );
-
-    SnapshotHashAgentTest test_agent( chainParams, url );
+    SnapshotHashAgentTest test_agent( *chainParams, url );
     dev::h256 hash = dev::h256::random();
-    std::vector< dev::h256 > snapshot_hashes( chainParams.sChain.nodes.size(), hash );
+    std::vector< dev::h256 > snapshot_hashes( chainParams->getNodesCount(), hash );
     snapshot_hashes[2] = dev::h256::random();
     test_agent.fillData( snapshot_hashes );
 

--- a/test/unittests/libskale/HashSnapshot.cpp
+++ b/test/unittests/libskale/HashSnapshot.cpp
@@ -341,7 +341,7 @@ struct SnapshotHashingFixture : public TestOutputHelperFixture, public FixtureCo
         chainParams->byzantiumForkBlock = 0;
         chainParams->externalGasDifficulty = 1;
 #ifndef MIRAGE
-        chainParams.sChain.contractStorageLimit = 0x1122334455667788UL;
+        chainParams->sChain.contractStorageLimit = 0x1122334455667788UL;
 #endif
         // add random extra data to randomize genesis hash and get random DB path,
         // so that tests can be run in parallel

--- a/test/unittests/libskale/SnapshotManager.cpp
+++ b/test/unittests/libskale/SnapshotManager.cpp
@@ -160,7 +160,8 @@ BOOST_AUTO_TEST_SUITE( BtrfsTestSuite,
 BOOST_FIXTURE_TEST_CASE( SimplePositiveTest, BtrfsFixture,
     
     *boost::unit_test::precondition( dev::test::run_not_express ) ) {
-    SnapshotManager mgr( dev::eth::ChainParams{}, fs::path( BTRFS_DIR_PATH ) );
+    std::shared_ptr< dev::eth::ChainParams > chainParams( new dev::eth::ChainParams{} );
+    SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) );
 
     std::string chainDirName = dev::eth::BlockChain::getChainDirName( dev::eth::ChainParams() );
 
@@ -233,14 +234,16 @@ BOOST_FIXTURE_TEST_CASE( SimplePositiveTest, BtrfsFixture,
 
 BOOST_FIXTURE_TEST_CASE( NoBtrfsTest, NoBtrfsFixture,
     *boost::unit_test::precondition( dev::test::run_not_express ) ) {
-    BOOST_REQUIRE_THROW( SnapshotManager mgr( dev::eth::ChainParams{}, fs::path( BTRFS_DIR_PATH ) ),
+    std::shared_ptr< dev::eth::ChainParams > chainParams( new dev::eth::ChainParams{} );
+    BOOST_REQUIRE_THROW( SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) ),
         SnapshotManager::CannotPerformBtrfsOperation );
 }
 
 BOOST_FIXTURE_TEST_CASE( BadPathTest, BtrfsFixture,
     *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+    std::shared_ptr< dev::eth::ChainParams > chainParams( new dev::eth::ChainParams() );
     BOOST_REQUIRE_EXCEPTION(
-        SnapshotManager mgr( dev::eth::ChainParams(), fs::path( BTRFS_DIR_PATH ) / "_invalid" ),
+        SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) / "_invalid" ),
         SnapshotManager::InvalidPath, [this]( const SnapshotManager::InvalidPath& ex ) -> bool {
             return ex.path == fs::path( BTRFS_DIR_PATH ) / "_invalid";
         } );
@@ -271,17 +274,18 @@ BOOST_FIXTURE_TEST_CASE( InaccessiblePathTest, BtrfsFixture,
 
     dropRoot();
 
-    BOOST_REQUIRE_EXCEPTION( SnapshotManager mgr( dev::eth::ChainParams(), fs::path( BTRFS_DIR_PATH ) / "_no_w" ),
+    std::shared_ptr< dev::eth::ChainParams > chainParams( new dev::eth::ChainParams() );
+    BOOST_REQUIRE_EXCEPTION( SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) / "_no_w" ),
         SnapshotManager::CannotCreate, [this]( const SnapshotManager::CannotCreate& ex ) -> bool {
             return ex.path == fs::path( BTRFS_DIR_PATH ) / "_no_w" / "snapshots";
         } );
 
-    BOOST_REQUIRE_EXCEPTION( SnapshotManager mgr( dev::eth::ChainParams(), fs::path( BTRFS_DIR_PATH ) / "_no_x" ),
+    BOOST_REQUIRE_EXCEPTION( SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) / "_no_x" ),
         SnapshotManager::CannotCreate, [this]( const SnapshotManager::CannotCreate& ex ) -> bool {
             return ex.path == fs::path( BTRFS_DIR_PATH ) / "_no_x" / "snapshots";
         } );
 
-    BOOST_REQUIRE_EXCEPTION( SnapshotManager mgr( dev::eth::ChainParams(), fs::path( BTRFS_DIR_PATH ) / "_no_r" ),
+    BOOST_REQUIRE_EXCEPTION( SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) / "_no_r" ),
         SnapshotManager::CannotCreate, [this]( const SnapshotManager::CannotCreate& ex ) -> bool {
             return ex.path == fs::path( BTRFS_DIR_PATH ) / "_no_x" / "snapshots";
         } );
@@ -289,7 +293,8 @@ BOOST_FIXTURE_TEST_CASE( InaccessiblePathTest, BtrfsFixture,
 
 BOOST_FIXTURE_TEST_CASE( SnapshotTest, BtrfsFixture,
     *boost::unit_test::precondition( dev::test::run_not_express ) ) {
-    SnapshotManager mgr( dev::eth::ChainParams{}, fs::path( BTRFS_DIR_PATH ) );
+    std::shared_ptr< dev::eth::ChainParams > chainParams( new dev::eth::ChainParams{} );
+    SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) );
 
     BOOST_REQUIRE_NO_THROW( mgr.doSnapshot( 2 ) );
     BOOST_REQUIRE_THROW( mgr.doSnapshot( 2 ), SnapshotManager::SnapshotPresent );
@@ -318,7 +323,8 @@ BOOST_FIXTURE_TEST_CASE( SnapshotTest, BtrfsFixture,
 
 BOOST_FIXTURE_TEST_CASE( RestoreTest, BtrfsFixture,
     *boost::unit_test::precondition( dev::test::run_not_express ) ) {
-    SnapshotManager mgr( dev::eth::ChainParams{}, fs::path( BTRFS_DIR_PATH ) );
+    std::shared_ptr< dev::eth::ChainParams > chainParams( new dev::eth::ChainParams{} );
+    SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) );
 
     BOOST_REQUIRE_THROW( mgr.restoreSnapshot( 2 ), SnapshotManager::SnapshotAbsent );
 
@@ -334,7 +340,8 @@ BOOST_FIXTURE_TEST_CASE( RestoreTest, BtrfsFixture,
 
 BOOST_FIXTURE_TEST_CASE( DiffTest, BtrfsFixture,
     *boost::unit_test::precondition( dev::test::run_not_express ) ) {
-    SnapshotManager mgr( dev::eth::ChainParams{}, fs::path( BTRFS_DIR_PATH ) );
+    std::shared_ptr< dev::eth::ChainParams > chainParams( new dev::eth::ChainParams{} );
+    SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) );
     mgr.doSnapshot( 2 );
     fs::create_directory( fs::path( BTRFS_DIR_PATH ) / "filestorage" / "dir" );
     mgr.doSnapshot( 4 );
@@ -367,7 +374,8 @@ BOOST_FIXTURE_TEST_CASE( DiffTest, BtrfsFixture,
 
 BOOST_FIXTURE_TEST_CASE( ImportTest, BtrfsFixture,
     *boost::unit_test::precondition( dev::test::run_not_express ) ) {
-    SnapshotManager mgr( dev::eth::ChainParams{}, fs::path( BTRFS_DIR_PATH ) );
+    std::shared_ptr< dev::eth::ChainParams > chainParams( new dev::eth::ChainParams{} );
+    SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) );
 
     BOOST_REQUIRE_THROW( mgr.importDiff( 8 ), SnapshotManager::InvalidPath );
 
@@ -406,7 +414,8 @@ BOOST_FIXTURE_TEST_CASE( ImportTest, BtrfsFixture,
 BOOST_FIXTURE_TEST_CASE( SnapshotRotationTest, BtrfsFixture,
     
     *boost::unit_test::precondition( dev::test::run_not_express ) ) {
-    SnapshotManager mgr( dev::eth::ChainParams{}, fs::path( BTRFS_DIR_PATH ) );
+    std::shared_ptr< dev::eth::ChainParams > chainParams( new dev::eth::ChainParams{} );
+    SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) );
 
     BOOST_REQUIRE_NO_THROW( mgr.doSnapshot( 1 ) );
     sleep( 1 );
@@ -427,7 +436,8 @@ BOOST_FIXTURE_TEST_CASE( SnapshotRotationTest, BtrfsFixture,
 BOOST_FIXTURE_TEST_CASE( DiffRotationTest, BtrfsFixture,
     
     *boost::unit_test::precondition( dev::test::run_not_express ) ) {
-    SnapshotManager mgr( dev::eth::ChainParams{}, fs::path( BTRFS_DIR_PATH ) );
+    std::shared_ptr< dev::eth::ChainParams > chainParams( new dev::eth::ChainParams{} );
+    SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) );
 
     fs::path diff12 = mgr.getDiffPath( 2 );
     {
@@ -457,7 +467,8 @@ BOOST_FIXTURE_TEST_CASE( DiffRotationTest, BtrfsFixture,
 BOOST_FIXTURE_TEST_CASE( RemoveSnapshotTest, BtrfsFixture,
     
     *boost::unit_test::precondition( dev::test::run_not_express ) ) {
-    SnapshotManager mgr( dev::eth::ChainParams{}, fs::path( BTRFS_DIR_PATH ) );
+    std::shared_ptr< dev::eth::ChainParams > chainParams( new dev::eth::ChainParams{} );
+    SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) );
 
     mgr.doSnapshot( 1 );
     mgr.doSnapshot( 2 );
@@ -475,7 +486,8 @@ BOOST_FIXTURE_TEST_CASE( RemoveSnapshotTest, BtrfsFixture,
 BOOST_FIXTURE_TEST_CASE( CleanupTest, BtrfsFixture,
 
     *boost::unit_test::precondition( dev::test::run_not_express ) ) {
-    SnapshotManager mgr( dev::eth::ChainParams{}, fs::path( BTRFS_DIR_PATH ) );
+    std::shared_ptr< dev::eth::ChainParams > chainParams( new dev::eth::ChainParams{} );
+    SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) );
 
     mgr.doSnapshot( 1 );
     mgr.doSnapshot( 2 );
@@ -497,8 +509,8 @@ BOOST_FIXTURE_TEST_CASE( CleanupTest, BtrfsFixture,
 #ifdef HISTORIC_STATE
 BOOST_FIXTURE_TEST_CASE( ArchiveNodeTest, BtrfsFixture,
                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {
-    auto chainParams = dev::eth::ChainParams();
-    chainParams.nodeInfo.archiveMode = true;
+    std::shared_ptr< dev::eth::ChainParams > chainParams( new dev::eth::ChainParams() );
+    chainParams->nodeInfo.archiveMode = true;
     SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) );
 
     std::string chainDirName = dev::eth::BlockChain::getChainDirName( dev::eth::ChainParams() );

--- a/test/unittests/libskale/SnapshotManager.cpp
+++ b/test/unittests/libskale/SnapshotManager.cpp
@@ -510,7 +510,7 @@ BOOST_FIXTURE_TEST_CASE( CleanupTest, BtrfsFixture,
 BOOST_FIXTURE_TEST_CASE( ArchiveNodeTest, BtrfsFixture,
                          *boost::unit_test::precondition( dev::test::run_not_express ) ) {
     std::shared_ptr< dev::eth::ChainParams > chainParams( new dev::eth::ChainParams() );
-    chainParams->nodeInfo.archiveMode = true;
+    chainParams->setArchiveMode();
     SnapshotManager mgr( chainParams, fs::path( BTRFS_DIR_PATH ) );
 
     std::string chainDirName = dev::eth::BlockChain::getChainDirName( dev::eth::ChainParams() );

--- a/test/unittests/libweb3jsonrpc/Client.cpp
+++ b/test/unittests/libweb3jsonrpc/Client.cpp
@@ -66,13 +66,13 @@ BOOST_AUTO_TEST_CASE( Personal ) {
 
     // 'allowFutureBlocks = true' is required to mine multiple blocks,
     // otherwise mining will hang after the first block
-    ChainParams chainParams;
-    chainParams.sealEngineName = NoProof::name();
-    chainParams.allowFutureBlocks = true;
-    chainParams.difficulty = chainParams.minimumDifficulty;
-    chainParams.gasLimit = chainParams.maxGasLimit;
-    chainParams.nodeInfo.port = chainParams.nodeInfo.port6 = rand_port;
-    chainParams.sChain.nodes[0].port = chainParams.sChain.nodes[0].port6 = rand_port;
+    std::shared_ptr< ChainParams > chainParams;
+    chainParams->sealEngineName = NoProof::name();
+    chainParams->allowFutureBlocks = true;
+    chainParams->difficulty = chainParams->minimumDifficulty;
+    chainParams->gasLimit = chainParams->maxGasLimit;
+    chainParams->nodeInfo.port = chainParams->nodeInfo.port6 = rand_port;
+    chainParams->sChain.nodes[0].port = chainParams->sChain.nodes[0].port6 = rand_port;
 
     //    dev::WebThreeDirect web3( WebThreeDirect::composeClientVersion( "eth" ), getDataDir(),
     //    string(),
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE( Personal ) {
     auto monitor = make_shared< InstanceMonitor >("test");
 
     setenv("DATA_DIR", getDataDir().c_str(), 1);
-    Client client( chainParams, ( int ) chainParams.networkID, shared_ptr< GasPricer >(), NULL, monitor,
+    Client client( chainParams, ( int ) chainParams->getNetworkId(), shared_ptr< GasPricer >(), NULL, monitor,
         getDataDir(), WithExisting::Kill, TransactionQueue::Limits{100000, 1024} );
 
     client.injectSkaleHost();

--- a/test/unittests/libweb3jsonrpc/Client.cpp
+++ b/test/unittests/libweb3jsonrpc/Client.cpp
@@ -66,13 +66,8 @@ BOOST_AUTO_TEST_CASE( Personal ) {
 
     // 'allowFutureBlocks = true' is required to mine multiple blocks,
     // otherwise mining will hang after the first block
-    std::shared_ptr< ChainParams > chainParams;
-    chainParams->sealEngineName = NoProof::name();
-    chainParams->allowFutureBlocks = true;
-    chainParams->difficulty = chainParams->minimumDifficulty;
-    chainParams->gasLimit = chainParams->maxGasLimit;
-    chainParams->nodeInfo.port = chainParams->nodeInfo.port6 = rand_port;
-    chainParams->sChain.nodes[0].port = chainParams->sChain.nodes[0].port6 = rand_port;
+    std::shared_ptr< ChainParams > chainParams = std::make_shared< ChainParams >();
+    chainParams->fillDefaultTestsParameters( rand_port );
 
     //    dev::WebThreeDirect web3( WebThreeDirect::composeClientVersion( "eth" ), getDataDir(),
     //    string(),

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -267,7 +267,7 @@ private:
 struct JsonRpcFixture : public TestOutputHelperFixture {
     // chain params needs to be a field of JsonRPCFixture
     // since references to it are passed to the server
-    ChainParams chainParams;
+    std::shared_ptr< ChainParams > chainParams;
 
 
     JsonRpcFixture( const std::string& _config = "", bool _owner = true,
@@ -295,7 +295,7 @@ struct JsonRpcFixture : public TestOutputHelperFixture {
 #endif
                 Json::FastWriter fastWriter;
                 std::string output = fastWriter.write( ret );
-                chainParams = chainParams.loadConfig( output );
+                chainParams->loadConfig( output );
             } else {
                 Json::Value ret;
                 Json::Reader().parse( _config, ret );
@@ -305,7 +305,7 @@ struct JsonRpcFixture : public TestOutputHelperFixture {
 #endif
                 Json::FastWriter fastWriter;
                 std::string output = fastWriter.write( ret );
-                chainParams = chainParams.loadConfig( output );
+                chainParams->loadConfig( output );
                 // insecure schain owner(originator) private key
                 // address is 0x5C4e11842E8be09264dc1976943571d7Af6d00F9
                 coinbase = dev::KeyPair( dev::Secret(
@@ -315,22 +315,22 @@ struct JsonRpcFixture : public TestOutputHelperFixture {
                     "0x23ABDBD3C61B5330AF61EBE8BEF582F4E5CC08E554053A718BDCE7813B9DC1FC" ) );
             }
         } else {
-            chainParams.sealEngineName = NoProof::name();
-            chainParams.allowFutureBlocks = true;
-            chainParams.difficulty = chainParams.minimumDifficulty;
-            chainParams.gasLimit = chainParams.maxGasLimit;
-            chainParams.byzantiumForkBlock = 0;
-            chainParams.EIP158ForkBlock = 0;
-            chainParams.constantinopleForkBlock = 0;
-            chainParams.istanbulForkBlock = 0;
-            chainParams.externalGasDifficulty = 1;
+            chainParams->sealEngineName = NoProof::name();
+            chainParams->allowFutureBlocks = true;
+            chainParams->difficulty = chainParams->minimumDifficulty;
+            chainParams->gasLimit = chainParams->maxGasLimit;
+            chainParams->byzantiumForkBlock = 0;
+            chainParams->EIP158ForkBlock = 0;
+            chainParams->constantinopleForkBlock = 0;
+            chainParams->istanbulForkBlock = 0;
+            chainParams->externalGasDifficulty = 1;
 #ifndef MIRAGE
             chainParams.sChain.contractStorageLimit = 128;
 #endif
             // 615 + 1430 is experimentally-derived block size + average extras size
-            chainParams.sChain.dbStorageLimit = 320.5 * ( 615 + 1430 );
+            chainParams->sChain.dbStorageLimit = 320.5 * ( 615 + 1430 );
 #ifdef MIRAGE
-            chainParams.sChain.nodes[0].owner = jsToAddress( "0x0E7d7F1D34a502bD609542576941C3FCc087c588" );
+            chainParams->sChain.nodes[0].owner = jsToAddress( "0x0E7d7F1D34a502bD609542576941C3FCc087c588" );
 #endif
 #ifndef MIRAGE
             chainParams.sChain
@@ -347,32 +347,32 @@ struct JsonRpcFixture : public TestOutputHelperFixture {
                 ._patchTimestamps[static_cast< size_t >( SchainPatchEnum::PushZeroPatch )] =
                 push0PatchActivationTimestamp;
 #endif
-            chainParams.sChain.emptyBlockIntervalMs = _emptyBlockIntervalMs;
+            chainParams->sChain.emptyBlockIntervalMs = _emptyBlockIntervalMs;
             // add random extra data to randomize genesis hash and get random DB path,
             // so that tests can be run in parallel
             // TODO: better make it use ethemeral in-memory databases
-            chainParams.extraData = h256::random().asBytes();
-            chainParams.nodeInfo.port = chainParams.nodeInfo.port6 = rand_port;
-            chainParams.sChain.nodes[0].port = chainParams.sChain.nodes[0].port6 = rand_port;
-            chainParams.skaleDisableChainIdCheck = true;
+            chainParams->extraData = h256::random().asBytes();
+            chainParams->nodeInfo.port = chainParams->nodeInfo.port6 = rand_port;
+            chainParams->sChain.nodes[0].port = chainParams->sChain.nodes[0].port6 = rand_port;
+            chainParams->skaleDisableChainIdCheck = true;
 
             if ( params.count( "getLogsBlocksLimit" ) && stoi( params.at( "getLogsBlocksLimit" ) ) )
-                chainParams.getLogsBlocksLimit = stoi( params.at( "getLogsBlocksLimit" ) );
+                chainParams->getLogsBlocksLimit = stoi( params.at( "getLogsBlocksLimit" ) );
         }
-        chainParams.sChain.multiTransactionMode = _mtmEnabled;
-        chainParams.nodeInfo.syncNode = _isSyncNode;
+        chainParams->sChain.multiTransactionMode = _mtmEnabled;
+        chainParams->nodeInfo.syncNode = _isSyncNode;
 
         auto monitor = make_shared< InstanceMonitor >( "test" );
 
 
         setenv( "DATA_DIR", tempDir.path().c_str(), 1 );
-        client.reset( new eth::ClientTest( chainParams, ( int ) chainParams.networkID,
+        client.reset( new eth::ClientTest( chainParams, ( int ) chainParams->getNetworkId(),
             shared_ptr< GasPricer >(), NULL, monitor, tempDir.path(), WithExisting::Kill ) );
 
         if ( !_generation2 )
             client->setAuthor( coinbase.address() );
         else
-            client->setAuthor( chainParams.sChain.blockAuthor );
+            client->setAuthor( chainParams->getBlockAuthor() );
 
         // wait for 1st block - because it's always empty
         std::promise< void > blockPromise;
@@ -417,7 +417,7 @@ struct JsonRpcFixture : public TestOutputHelperFixture {
         inject_rapidjson_handlers( serverOpts, ethFace );
 
         serverOpts.netOpts_.bindOptsStandard_.cntServers_ = 1;
-        serverOpts.netOpts_.bindOptsStandard_.strAddrHTTP4_ = chainParams.nodeInfo.ip;
+        serverOpts.netOpts_.bindOptsStandard_.strAddrHTTP4_ = chainParams->getSelfNodeIp();
         // random port
         // +3 because rand() seems to be called effectively simultaneously here and in "static"
         // section - thus giving same port for consensus
@@ -430,7 +430,7 @@ struct JsonRpcFixture : public TestOutputHelperFixture {
         sleep( 1 );
 
         httpClient = new jsonrpc::HttpClient(
-            "http://" + chainParams.nodeInfo.ip + ":" +
+            "http://" + chainParams->getSelfNodeIp() + ":" +
             std::to_string( serverOpts.netOpts_.bindOptsStandard_.nBasePortHTTP4_ ) );
         httpClient->SetTimeout( 1000000000 );
 

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -325,7 +325,7 @@ struct JsonRpcFixture : public TestOutputHelperFixture {
             chainParams->istanbulForkBlock = 0;
             chainParams->externalGasDifficulty = 1;
 #ifndef MIRAGE
-            chainParams.sChain.contractStorageLimit = 128;
+            chainParams->sChain.contractStorageLimit = 128;
 #endif
             // 615 + 1430 is experimentally-derived block size + average extras size
             chainParams->sChain.dbStorageLimit = 320.5 * ( 615 + 1430 );
@@ -333,17 +333,17 @@ struct JsonRpcFixture : public TestOutputHelperFixture {
             chainParams->sChain.nodes[0].owner = jsToAddress( "0x0E7d7F1D34a502bD609542576941C3FCc087c588" );
 #endif
 #ifndef MIRAGE
-            chainParams.sChain
+            chainParams->sChain
                 ._patchTimestamps[static_cast< size_t >( SchainPatchEnum::ContractStoragePatch )] =
                 1;
-            chainParams.sChain._patchTimestamps[static_cast< size_t >(
+            chainParams->sChain._patchTimestamps[static_cast< size_t >(
                 SchainPatchEnum::StorageDestructionPatch )] = 1;
             powPatchActivationTimestamp = time( nullptr ) + 60;
-            chainParams.sChain
+            chainParams->sChain
                 ._patchTimestamps[static_cast< size_t >( SchainPatchEnum::CorrectForkInPowPatch )] =
                 powPatchActivationTimestamp;
             push0PatchActivationTimestamp = time( nullptr ) + 10;
-            chainParams.sChain
+            chainParams->sChain
                 ._patchTimestamps[static_cast< size_t >( SchainPatchEnum::PushZeroPatch )] =
                 push0PatchActivationTimestamp;
 #endif

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -267,7 +267,7 @@ private:
 struct JsonRpcFixture : public TestOutputHelperFixture {
     // chain params needs to be a field of JsonRPCFixture
     // since references to it are passed to the server
-    std::shared_ptr< ChainParams > chainParams;
+    std::shared_ptr< ChainParams > chainParams = std::make_shared< ChainParams >();
 
 
     JsonRpcFixture( const std::string& _config = "", bool _owner = true,
@@ -317,8 +317,8 @@ struct JsonRpcFixture : public TestOutputHelperFixture {
         } else {
             chainParams->sealEngineName = NoProof::name();
             chainParams->allowFutureBlocks = true;
-            chainParams->difficulty = chainParams->minimumDifficulty;
-            chainParams->gasLimit = chainParams->maxGasLimit;
+            chainParams->difficulty = chainParams->getMinimumDifficulty();
+            chainParams->gasLimit = chainParams->getMaxGasLimit();
             chainParams->byzantiumForkBlock = 0;
             chainParams->EIP158ForkBlock = 0;
             chainParams->constantinopleForkBlock = 0;
@@ -357,7 +357,7 @@ struct JsonRpcFixture : public TestOutputHelperFixture {
             chainParams->skaleDisableChainIdCheck = true;
 
             if ( params.count( "getLogsBlocksLimit" ) && stoi( params.at( "getLogsBlocksLimit" ) ) )
-                chainParams->getLogsBlocksLimit = stoi( params.at( "getLogsBlocksLimit" ) );
+                chainParams->logsBlocksLimit = stoi( params.at( "getLogsBlocksLimit" ) );
         }
         chainParams->sChain.multiTransactionMode = _mtmEnabled;
         chainParams->nodeInfo.syncNode = _isSyncNode;

--- a/test/unittests/mapreduce_consensus/ConsensusEngine.cpp
+++ b/test/unittests/mapreduce_consensus/ConsensusEngine.cpp
@@ -199,6 +199,7 @@ protected:
     TransientDirectory m_tempDir;
 
 protected:  // remote peer
+    std::shared_ptr< ChainParams > chainParams;
     unique_ptr< Client > client;
     unique_ptr< ModularServer<> > rpcServer;
     unique_ptr< WebThreeStubClient > rpcClient;
@@ -209,7 +210,7 @@ protected:  // remote peer
 public:
     ConsensusExtFaceFixture() {
 
-        std::shared_ptr< ChainParams > chainParams;
+        chainParams = std::make_shared< ChainParams >();
         chainParams->sealEngineName = NoProof::name();
         chainParams->allowFutureBlocks = true;
         chainParams->difficulty = chainParams->getMinimumDifficulty();

--- a/test/unittests/mapreduce_consensus/ConsensusEngine.cpp
+++ b/test/unittests/mapreduce_consensus/ConsensusEngine.cpp
@@ -104,8 +104,8 @@ public:
         ChainParams chainParams;
         chainParams.sealEngineName = NoProof::name();
         chainParams.allowFutureBlocks = true;
-        chainParams.difficulty = chainParams.minimumDifficulty;
-        chainParams.gasLimit = chainParams.maxGasLimit;
+        chainParams.difficulty = chainParams.getMinimumDifficulty();
+        chainParams.gasLimit = chainParams.getMaxGasLimit();
         chainParams.extraData = h256::random().asBytes();
         chainParams.nodeInfo.port = chainParams.nodeInfo.port6 = rand_port;
         chainParams.sChain.nodes[0].port = chainParams.sChain.nodes[0].port6 = rand_port;
@@ -212,8 +212,8 @@ public:
         std::shared_ptr< ChainParams > chainParams;
         chainParams->sealEngineName = NoProof::name();
         chainParams->allowFutureBlocks = true;
-        chainParams->difficulty = chainParams->minimumDifficulty;
-        chainParams->gasLimit = chainParams->maxGasLimit;
+        chainParams->difficulty = chainParams->getMinimumDifficulty();
+        chainParams->gasLimit = chainParams->getMaxGasLimit();
         chainParams->extraData = h256::random().asBytes();
         chainParams->nodeInfo.port = chainParams->nodeInfo.port6 = rand_port;
         chainParams->sChain.nodes[0].port = chainParams->sChain.nodes[0].port6 = rand_port;

--- a/test/unittests/mapreduce_consensus/ConsensusEngine.cpp
+++ b/test/unittests/mapreduce_consensus/ConsensusEngine.cpp
@@ -209,14 +209,14 @@ protected:  // remote peer
 public:
     ConsensusExtFaceFixture() {
 
-        ChainParams chainParams;
-        chainParams.sealEngineName = NoProof::name();
-        chainParams.allowFutureBlocks = true;
-        chainParams.difficulty = chainParams.minimumDifficulty;
-        chainParams.gasLimit = chainParams.maxGasLimit;
-        chainParams.extraData = h256::random().asBytes();
-        chainParams.nodeInfo.port = chainParams.nodeInfo.port6 = rand_port;
-        chainParams.sChain.nodes[0].port = chainParams.sChain.nodes[0].port6 = rand_port;
+        std::shared_ptr< ChainParams > chainParams;
+        chainParams->sealEngineName = NoProof::name();
+        chainParams->allowFutureBlocks = true;
+        chainParams->difficulty = chainParams->minimumDifficulty;
+        chainParams->gasLimit = chainParams->maxGasLimit;
+        chainParams->extraData = h256::random().asBytes();
+        chainParams->nodeInfo.port = chainParams->nodeInfo.port6 = rand_port;
+        chainParams->sChain.nodes[0].port = chainParams->sChain.nodes[0].port6 = rand_port;
 
 
 #ifdef MIRAGE
@@ -224,14 +224,14 @@ public:
 #else
         sChainNode node2{u256( 2 ), "127.0.0.12", u256( 11111 ), "::1", u256( 11111 ), u256( 1 ), "0xfa", {"0", "1", "0", "1"}};
 #endif
-        chainParams.sChain.nodes.push_back( node2 );
+        chainParams->sChain.nodes.push_back( node2 );
         //////////////////////////////////////////////
 
 
         m_consensus.reset( new ConsensusEngine(
-            *this, 0, BlockHeader( chainParams.genesisBlock() ).timestamp(), 0 ,
+            *this, 0, BlockHeader( chainParams->genesisBlock() ).timestamp(), 0 ,
             std::map<std::string, std::uint64_t>()));
-        m_consensus->parseFullConfigAndCreateNode( chainParams.getOriginalJson(), "" );
+        m_consensus->parseFullConfigAndCreateNode( chainParams->getOriginalJson(), "" );
 
         m_consensusThread = std::thread( [this]() {
             m_consensus->startAll();
@@ -239,10 +239,10 @@ public:
         } );
 
         //////////////////////////////////////////////
-        chainParams.nodeInfo.ip = "127.0.0.12";
-        chainParams.nodeInfo.id = 2;
-        chainParams.nodeInfo.name = "Node2";
-        chainParams.resetJson();
+        chainParams->nodeInfo.ip = "127.0.0.12";
+        chainParams->nodeInfo.id = 2;
+        chainParams->nodeInfo.name = "Node2";
+        chainParams->resetJson();
 
         //        web3.reset( new WebThreeDirect(
         //            "eth tests", "", "", chainParams, WithExisting::Kill, {"eth"}, true ) );
@@ -251,7 +251,7 @@ public:
 
         setenv("DATA_DIR", m_tempDir.path().c_str(), 1);
         client.reset(
-            new eth::Client( chainParams, ( int ) chainParams.networkID, shared_ptr< GasPricer >(),
+            new eth::Client( chainParams, ( int ) chainParams->getNetworkId(), shared_ptr< GasPricer >(),
                 NULL, monitor, m_tempDir.path().c_str(), WithExisting::Kill, TransactionQueue::Limits{100000, 1024} ) );
 
         client->injectSkaleHost();


### PR DESCRIPTION
fixes #1845 

**these changes are applied to both current and future network**

1. make `ChainParams` object non-copyable
2. make all `ChainParams` and `ChainOperationParams` sensitive data fields private and add const getter methods to access them
3. the original `ChainParams` object is created as a `shared_ptr` in `skaled/main.cpp`
4. all c++ objects that hold `ChainParams` object hold it as `shared_ptr<const ChainParams>` to guarantee that the underlying object will not be changed

this approach guarantees that all c++ objects refer to the same `ChainParams` object at runtime which will be helpful later

tests:
- unit tests pass
- build and run skaled with `-fsanitize=thread` option or run it with `valgrind --tool=helgrind` and send `eth_call`, `eth_chainId`, `eth_estimateGas` and `eth_sendRawTransaction` requests from different threads. the sanitizer output shows no issues related to the new `ChainParams` design