### PR TITLE
Pre-FAIR config support for FAIR build

### DIFF
--- a/libethereum/Account.cpp
+++ b/libethereum/Account.cpp
@@ -117,7 +117,6 @@ PrecompiledContract createPrecompiledContract( js::mObject const& _precompiled )
         cwarn << "Couldn't create a precompiled contract account. Missing a pricer called:" << n;
         throw;
     } catch ( ExecutorNotFound const& ) {
-        // Oh dear - missing a plugin?
         cwarn << "Couldn't create a precompiled contract account. Missing an executor called:" << n;
         throw;
     }
@@ -212,11 +211,18 @@ AccountMap dev::eth::jsonToAccountMap( std::string const& _json, u256 const& _de
                  shouldNotExists )  // defined only shouldNotExists field
                 ret[a] = Account( 0, 0 );
         }
-
-        if ( o_precompiled && accountMaskJson.count( c_precompiled ) ) {
-            js::mObject p = accountMaskJson.at( c_precompiled ).get_obj();
-            o_precompiled->insert( make_pair( a, createPrecompiledContract( p ) ) );
+#ifdef MIRAGE
+        try {
+#endif
+            if ( o_precompiled && accountMaskJson.count( c_precompiled ) ) {
+                js::mObject p = accountMaskJson.at( c_precompiled ).get_obj();
+                o_precompiled->insert( make_pair( a, createPrecompiledContract( p ) ) );
+            }
+#ifdef MIRAGE
+        } catch ( ExecutorNotFound const& ) {
+            cwarn << "Precompiled contract skipped due to missing executor";
         }
+#endif
     }
 
     return ret;

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -410,7 +410,11 @@ void ChainParams::processSkaleConfigItems( json_spirit::mObject& obj ) {
         sChainNode node{};
         node.id = nodeConfObj.at( "nodeID" ).get_uint64();
 #ifdef MIRAGE
-        node.owner = jsToAddress( nodeConfObj.at( "owner" ).get_str() );
+        try {
+            node.owner = jsToAddress( nodeConfObj.at( "owner" ).get_str() );
+        } catch ( ... ) {
+            node.owner = ZeroAddress;
+        }
 #endif
         node.ip = nodeConfObj.at( "ip" ).get_str();
         node.port = nodeConfObj.at( "basePort" ).get_uint64();

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -405,7 +405,11 @@ void ChainParams::processSkaleConfigItems( json_spirit::mObject& obj ) {
         s.nodeGroups = nodeGroups;
     }
 
-    auto parseNodeDetails = [testSignatures]( const auto& jsonNodeObj ) -> sChainNode {
+    auto parseNodeDetails = [
+#ifdef MIRAGE
+                                this,
+#endif
+                                testSignatures]( const auto& jsonNodeObj ) -> sChainNode {
         auto nodeConfObj = jsonNodeObj.get_obj();
         sChainNode node{};
         node.id = nodeConfObj.at( "nodeID" ).get_uint64();
@@ -413,6 +417,8 @@ void ChainParams::processSkaleConfigItems( json_spirit::mObject& obj ) {
         try {
             node.owner = jsToAddress( nodeConfObj.at( "owner" ).get_str() );
         } catch ( ... ) {
+            LOG( m_loggerWarning )
+                << "Node " << node.id << ": owner is not set, using zero address as fallback";
             node.owner = ZeroAddress;
         }
 #endif

--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -235,6 +235,7 @@ private:
     mutable std::shared_mutex m_mutex;
 
     Logger m_loggerInfo{ createLogger( VerbosityInfo, "ChainParams" ) };
+    Logger m_loggerWarning{ createLogger( VerbosityWarning, "ChainParams" ) };
 #endif
     Logger m_loggerDebug{ createLogger( VerbosityDebug, "ChainParams" ) };
 };

--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -270,9 +270,7 @@ void validateConfigJson( js::mObject const& _obj ) {
             { "snapshotDownloadInactiveTimeout",
                 { { js::int_type }, JsonFieldPresence::Optional } },
             { "rotateAfterBlock", { { js::int_type }, JsonFieldPresence::Optional } },
-#ifndef MIRAGE
             { "contractStorageLimit", { { js::int_type }, JsonFieldPresence::Optional } },
-#endif
             { "dbStorageLimit", { { js::int_type }, JsonFieldPresence::Optional } },
 #ifdef MIRAGE
             { "nodes", { { js::obj_type, js::array_type }, JsonFieldPresence::Required } },

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -563,7 +563,7 @@ void SnapshotManager::addLastPriceToHash( unsigned _blockNumber, secp256k1_sha25
 
 #ifndef MIRAGE
 void SnapshotManager::proceedRegularFile(
-    const boost::filesystem::path& path, secp256k1_sha256_t* ctx, bool is_checking ) const {
+    const boost::filesystem::path& path, secp256k1_sha256_t* ctx, bool isChecking ) const {
     if ( path.extension() == "._hash" ) {
         return;
     }
@@ -571,7 +571,7 @@ void SnapshotManager::proceedRegularFile(
     std::string relativePath = path.string().substr( path.string().find( "filestorage" ) );
 
     std::string fileHashPathStr = path.string() + "._hash";
-    if ( !is_checking ) {
+    if ( !isChecking ) {
         dev::h256 fileHash;
         if ( !boost::filesystem::exists( fileHashPathStr ) ) {
             // file has not been downloaded fully
@@ -640,7 +640,7 @@ void SnapshotManager::proceedDirectory(
 }
 
 void SnapshotManager::proceedFileStorageDirectory( const boost::filesystem::path& _fileSystemDir,
-    secp256k1_sha256_t* ctx, bool is_checking ) const {
+    secp256k1_sha256_t* ctx, bool isChecking ) const {
     boost::filesystem::recursive_directory_iterator directory_it( _fileSystemDir ), end;
 
     std::vector< boost::filesystem::path > contents;
@@ -655,7 +655,7 @@ void SnapshotManager::proceedFileStorageDirectory( const boost::filesystem::path
 
     for ( auto& content : contents ) {
         if ( boost::filesystem::is_regular_file( content ) ) {
-            proceedRegularFile( content, ctx, is_checking );
+            proceedRegularFile( content, ctx, isChecking );
         } else {
             proceedDirectory( content, ctx );
         }
@@ -664,20 +664,20 @@ void SnapshotManager::proceedFileStorageDirectory( const boost::filesystem::path
 
 
 void SnapshotManager::computeFileStorageHash( const boost::filesystem::path& _fileSystemDir,
-    secp256k1_sha256_t* ctx, bool is_checking ) const {
+    secp256k1_sha256_t* ctx, bool isChecking ) const {
     if ( !boost::filesystem::exists( _fileSystemDir ) ) {
         throw std::logic_error( "filestorage btrfs subvolume was corrupted - " +
                                 _fileSystemDir.string() + " doesn't exist" );
     }
 
-    this->proceedFileStorageDirectory( _fileSystemDir, ctx, is_checking );
+    this->proceedFileStorageDirectory( _fileSystemDir, ctx, isChecking );
 }
 #endif
 
 void SnapshotManager::computeAllVolumesHash( unsigned _blockNumber, secp256k1_sha256_t* ctx
 #ifndef MIRAGE
     ,
-    bool is_checking
+    bool isChecking
 #endif
 ) const {
     assert( allVolumes.size() != 0 );
@@ -716,7 +716,7 @@ void SnapshotManager::computeAllVolumesHash( unsigned _blockNumber, secp256k1_sh
 #ifndef MIRAGE
     // filestorage
     this->computeFileStorageHash(
-        this->snapshotsDir / std::to_string( _blockNumber ) / "filestorage", ctx, is_checking );
+        this->snapshotsDir / std::to_string( _blockNumber ) / "filestorage", ctx, isChecking );
 #endif
     // if have prices and blocks
     if ( _blockNumber && allVolumes.size() > 3 ) {
@@ -772,7 +772,7 @@ void SnapshotManager::computeAllVolumesHash( unsigned _blockNumber, secp256k1_sh
 void SnapshotManager::computeSnapshotHash( unsigned _blockNumber
 #ifndef MIRAGE
     ,
-    bool is_checking
+    bool isChecking
 #endif
 ) {
     if ( this->isSnapshotHashPresent( _blockNumber ) ) {
@@ -809,7 +809,7 @@ void SnapshotManager::computeSnapshotHash( unsigned _blockNumber
     this->computeAllVolumesHash( _blockNumber, &ctx
 #ifndef MIRAGE
         ,
-        is_checking
+        isChecking
 #endif
     );
 

--- a/libskale/SnapshotManager.cpp
+++ b/libskale/SnapshotManager.cpp
@@ -674,8 +674,12 @@ void SnapshotManager::computeFileStorageHash( const boost::filesystem::path& _fi
 }
 #endif
 
-void SnapshotManager::computeAllVolumesHash(
-    unsigned _blockNumber, secp256k1_sha256_t* ctx, bool is_checking ) const {
+void SnapshotManager::computeAllVolumesHash( unsigned _blockNumber, secp256k1_sha256_t* ctx
+#ifndef MIRAGE
+    ,
+    bool is_checking
+#endif
+) const {
     assert( allVolumes.size() != 0 );
 
     // TODO XXX Remove volumes structure knowledge from here!!
@@ -765,7 +769,12 @@ void SnapshotManager::computeAllVolumesHash(
     //     }
 }
 
-void SnapshotManager::computeSnapshotHash( unsigned _blockNumber, bool is_checking ) {
+void SnapshotManager::computeSnapshotHash( unsigned _blockNumber
+#ifndef MIRAGE
+    ,
+    bool is_checking
+#endif
+) {
     if ( this->isSnapshotHashPresent( _blockNumber ) ) {
         return;
     }
@@ -797,7 +806,12 @@ void SnapshotManager::computeSnapshotHash( unsigned _blockNumber, bool is_checki
             batched_io::test_crash_before_commit( "SnapshotManager::doSnapshot" );
     }
 
-    this->computeAllVolumesHash( _blockNumber, &ctx, is_checking );
+    this->computeAllVolumesHash( _blockNumber, &ctx
+#ifndef MIRAGE
+        ,
+        is_checking
+#endif
+    );
 
     for ( const auto& volume : volumes ) {
         int res = btrfs.subvolume.property_set(

--- a/libskale/SnapshotManager.h
+++ b/libskale/SnapshotManager.h
@@ -172,7 +172,7 @@ public:
     void computeSnapshotHash( unsigned _blockNumber
 #ifndef MIRAGE
         ,
-        bool is_checking = false
+        bool isChecking = false
 #endif
     );
 
@@ -199,17 +199,17 @@ private:
 
 #ifndef MIRAGE
     void computeFileStorageHash( const boost::filesystem::path& _fileSystemDir,
-        secp256k1_sha256_t* ctx, bool is_checking ) const;
+        secp256k1_sha256_t* ctx, bool isChecking ) const;
     void proceedFileStorageDirectory( const boost::filesystem::path& _fileSystemDir,
-        secp256k1_sha256_t* ctx, bool is_checking ) const;
+        secp256k1_sha256_t* ctx, bool isChecking ) const;
     void proceedRegularFile(
-        const boost::filesystem::path& path, secp256k1_sha256_t* ctx, bool is_checking ) const;
+        const boost::filesystem::path& path, secp256k1_sha256_t* ctx, bool isChecking ) const;
     void proceedDirectory( const boost::filesystem::path& path, secp256k1_sha256_t* ctx ) const;
 #endif
     void computeAllVolumesHash( unsigned _blockNumber, secp256k1_sha256_t* ctx
 #ifndef MIRAGE
         ,
-        bool is_checking
+        bool isChecking
 #endif
     ) const;
     void computeDatabaseHash(

--- a/libskale/SnapshotManager.h
+++ b/libskale/SnapshotManager.h
@@ -169,7 +169,12 @@ public:
     dev::h256 getSnapshotHash( unsigned _blockNumber ) const;
     std::pair< int, int > getLatestSnapshots() const;
     bool isSnapshotHashPresent( unsigned _blockNumber ) const;
-    void computeSnapshotHash( unsigned _blockNumber, bool is_checking = false );
+    void computeSnapshotHash( unsigned _blockNumber
+#ifndef MIRAGE
+        ,
+        bool is_checking = false
+#endif
+    );
 
     uint64_t getBlockTimestamp( unsigned _blockNumber ) const;
 
@@ -201,8 +206,12 @@ private:
         const boost::filesystem::path& path, secp256k1_sha256_t* ctx, bool is_checking ) const;
     void proceedDirectory( const boost::filesystem::path& path, secp256k1_sha256_t* ctx ) const;
 #endif
-    void computeAllVolumesHash(
-        unsigned _blockNumber, secp256k1_sha256_t* ctx, bool is_checking ) const;
+    void computeAllVolumesHash( unsigned _blockNumber, secp256k1_sha256_t* ctx
+#ifndef MIRAGE
+        ,
+        bool is_checking
+#endif
+    ) const;
     void computeDatabaseHash(
         const boost::filesystem::path& _dbDir, secp256k1_sha256_t* ctx ) const;
     void addLastPriceToHash( unsigned _blockNumber, secp256k1_sha256_t* ctx ) const;

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -439,7 +439,12 @@ bool tryDownloadSnapshot( std::shared_ptr< SnapshotManager >& snapshotManager,
             downloadSnapshot( blockNumber, snapshotManager, urlToDownloadSnapshot, chainParams );
 
             try {
-                snapshotManager->computeSnapshotHash( blockNumber, true );
+                snapshotManager->computeSnapshotHash( blockNumber
+#ifndef MIRAGE
+                    ,
+                    true
+#endif
+                );
             } catch ( const std::exception& ) {
                 std::throw_with_nested( std::runtime_error(
                     std::string( "FATAL:" ) +

--- a/test/unittests/libskale/HashSnapshot.cpp
+++ b/test/unittests/libskale/HashSnapshot.cpp
@@ -634,7 +634,11 @@ BOOST_FIXTURE_TEST_CASE( SnapshotHashingTest, SnapshotHashingFixture,
 
     mgr->doSnapshot( 3 );
 
+#ifndef MIRAGE    
     mgr->computeSnapshotHash( 3, true );
+#else
+    mgr->computeSnapshotHash( 3 );
+#endif
 
     BOOST_REQUIRE( mgr->isSnapshotHashPresent( 3 ) );
 


### PR DESCRIPTION
## Description

- Added ability to run FAIR build with both FAIR and pre-FAIR configs
- Removed compilation warnings for FAIR build

## Tests

- Verified on local machine using `test/historicstate/configs/test_3_of_16.json` (pre-FAIR config)
- Verified on local machine using a FAIR config
