### PR TITLE
Handle dencun opcodes for FAIR

### DIFF
--- a/libethereum/Transaction.cpp
+++ b/libethereum/Transaction.cpp
@@ -74,6 +74,10 @@ TransactionException dev::eth::toTransactionException( Exception const& _e ) {
         return TransactionException::StackUnderflow;
     if ( !!dynamic_cast< InvalidContractDeployer const* >( &_e ) )
         return TransactionException::InvalidContractDeployer;
+#ifdef MIRAGE
+    if ( !!dynamic_cast< UnsupportedDencunOpcode const* >( &_e ) )
+        return TransactionException::UnsupportedDencunOpcode;
+#endif
     return TransactionException::Unknown;
 }
 
@@ -136,6 +140,11 @@ std::ostream& dev::eth::operator<<( std::ostream& _out, TransactionException con
     case TransactionException::WouldNotBeInBlock:
         _out << "WouldNotBeInBlock";
         break;
+#ifdef MIRAGE
+    case TransactionException::UnsupportedDencunOpcode:
+        _out << "UnsupportedDencunOpcode";
+        break;
+#endif
     default:
         _out << "Unknown";
         break;

--- a/libethereum/Transaction.h
+++ b/libethereum/Transaction.h
@@ -59,6 +59,10 @@ enum class TransactionException {
     ,
     InvalidBITEAESData
 #endif
+#ifdef MIRAGE
+    ,
+    UnsupportedDencunOpcode
+#endif
 };
 
 enum class CodeDeposit { None = 0, Failed, Success };

--- a/libevm/Instruction.cpp
+++ b/libevm/Instruction.cpp
@@ -87,7 +87,7 @@ static const std::map<Instruction,  InstructionInfo> c_instructionInfo =
     { Instruction::GAS,          { "GAS",                 0,    1,  Tier::Base } },
     { Instruction::JUMPDEST,     { "JUMPDEST",            0,    0,  Tier::Special } },
 #ifdef MIRAGE
-    { Instruction::TLOAD,        { "TLOAD",               0,    1,  Tier::Special } },
+    { Instruction::TLOAD,        { "TLOAD",               1,    1,  Tier::Special } },
     { Instruction::TSTORE,       { "TSTORE",              2,    0,  Tier::Special } },
     { Instruction::MCOPY,        { "MCOPY",               3,    0,  Tier::VeryLow } },
 #endif

--- a/libevm/Instruction.cpp
+++ b/libevm/Instruction.cpp
@@ -86,6 +86,11 @@ static const std::map<Instruction,  InstructionInfo> c_instructionInfo =
     { Instruction::MSIZE,        { "MSIZE",               0,    1,  Tier::Base } },
     { Instruction::GAS,          { "GAS",                 0,    1,  Tier::Base } },
     { Instruction::JUMPDEST,     { "JUMPDEST",            0,    0,  Tier::Special } },
+#ifdef MIRAGE
+    { Instruction::TLOAD,        { "TLOAD",               0,    1,  Tier::Special } },
+    { Instruction::TSTORE,       { "TSTORE",              2,    0,  Tier::Special } },
+    { Instruction::MCOPY,        { "MCOPY",               3,    0,  Tier::VeryLow } },
+#endif
     // As per EIP-3855 PUSH0 instruction tire is base (2 gas units)
     // As all other PUSH instructions, it removes zero elements from stack and
     // pushes 1 element to stack

--- a/libevm/Instruction.h
+++ b/libevm/Instruction.h
@@ -93,7 +93,11 @@ enum class Instruction : uint8_t {
     MSIZE,       ///< get the size of active memory
     GAS,         ///< get the amount of available gas
     JUMPDEST,    ///< set a potential jump destination
-
+#ifdef MIRAGE
+    TLOAD = 0x5c,  // EIP-1153
+	TSTORE = 0x5d, // EIP-1153
+	MCOPY = 0x5e,  // EIP-5656
+#endif
     PUSH0 = 0x5f,  // EIP-3855
     PUSH1 = 0x60,  ///< place 1 byte item on stack
     PUSH2,         ///< place 2 byte item on stack

--- a/libevm/Instruction.h
+++ b/libevm/Instruction.h
@@ -94,9 +94,9 @@ enum class Instruction : uint8_t {
     GAS,         ///< get the amount of available gas
     JUMPDEST,    ///< set a potential jump destination
 #ifdef MIRAGE
-    TLOAD = 0x5c,  // EIP-1153
-	TSTORE = 0x5d, // EIP-1153
-	MCOPY = 0x5e,  // EIP-5656
+    TLOAD = 0x5c,   // EIP-1153
+    TSTORE = 0x5d,  // EIP-1153
+    MCOPY = 0x5e,   // EIP-5656
 #endif
     PUSH0 = 0x5f,  // EIP-3855
     PUSH1 = 0x60,  ///< place 1 byte item on stack

--- a/libevm/LegacyVM.cpp
+++ b/libevm/LegacyVM.cpp
@@ -797,22 +797,14 @@ void LegacyVM::interpretCases() {
             throwUnsupportedDencunOpcode();
         }
         CONTINUE
+#endif
 
-        CASE( JUMPTO ) CASE( JUMPIF ) CASE( JUMPV ) CASE( JUMPSUB ) CASE( JUMPSUBV )
-            CASE( RETURNSUB ) CASE( GETLOCAL ) CASE( PUTLOCAL ) {
-            ON_OP();
-            throwBadInstruction();
-        }
-        CONTINUE
-#else
         CASE( JUMPTO ) CASE( JUMPIF ) CASE( JUMPV ) CASE( JUMPSUB ) CASE( JUMPSUBV )
             CASE( RETURNSUB ) CASE( BEGINSUB ) CASE( BEGINDATA ) CASE( GETLOCAL ) CASE( PUTLOCAL ) {
             ON_OP();
             throwBadInstruction();
         }
         CONTINUE
-#endif
-
 #endif
 
 #if EIP_616

--- a/libevm/LegacyVM.cpp
+++ b/libevm/LegacyVM.cpp
@@ -787,6 +787,24 @@ void LegacyVM::interpretCases() {
         }
         NEXT
 #else
+
+
+#ifdef MIRAGE
+        CASE( TLOAD ) 
+        CASE( TSTORE ) 
+        CASE( MCOPY ) {
+            ON_OP();
+            throwUnsupportedDencunOpcode();
+        }
+        CONTINUE
+
+        CASE( JUMPTO ) CASE( JUMPIF ) CASE( JUMPV ) CASE( JUMPSUB ) CASE( JUMPSUBV )
+            CASE( RETURNSUB ) CASE( GETLOCAL ) CASE( PUTLOCAL ) {
+            ON_OP();
+            throwBadInstruction();
+        }
+        CONTINUE
+#else
         CASE( JUMPTO ) CASE( JUMPIF ) CASE( JUMPV ) CASE( JUMPSUB ) CASE( JUMPSUBV )
             CASE( RETURNSUB ) CASE( BEGINSUB ) CASE( BEGINDATA ) CASE( GETLOCAL ) CASE( PUTLOCAL ) {
             ON_OP();
@@ -795,14 +813,6 @@ void LegacyVM::interpretCases() {
         CONTINUE
 #endif
 
-#ifdef MIRAGE
-        CASE( TLOAD ) 
-        CASE( TSTORE ) 
-        CASE( MCOPY ) {
-            ON_OP();
-            throwBadInstruction();
-        }
-        CONTINUE
 #endif
 
 #if EIP_616

--- a/libevm/LegacyVM.cpp
+++ b/libevm/LegacyVM.cpp
@@ -799,8 +799,10 @@ void LegacyVM::interpretCases() {
 
         CASE( JUMPTO )
         CASE( JUMPIF )
-        CASE( JUMPV ) CASE( JUMPSUB ) CASE( JUMPSUBV ) CASE( RETURNSUB ) CASE( BEGINSUB )
-            CASE( BEGINDATA ) CASE( GETLOCAL ) CASE( PUTLOCAL ) {
+        CASE( JUMPV )
+        CASE( JUMPSUB )
+        CASE( JUMPSUBV )
+        CASE( RETURNSUB ) CASE( BEGINSUB ) CASE( BEGINDATA ) CASE( GETLOCAL ) CASE( PUTLOCAL ) {
             ON_OP();
             throwBadInstruction();
         }

--- a/libevm/LegacyVM.cpp
+++ b/libevm/LegacyVM.cpp
@@ -798,8 +798,9 @@ void LegacyVM::interpretCases() {
 #endif
 
         CASE( JUMPTO )
-        CASE( JUMPIF ) CASE( JUMPV ) CASE( JUMPSUB ) CASE( JUMPSUBV ) CASE( RETURNSUB )
-            CASE( BEGINSUB ) CASE( BEGINDATA ) CASE( GETLOCAL ) CASE( PUTLOCAL ) {
+        CASE( JUMPIF )
+        CASE( JUMPV ) CASE( JUMPSUB ) CASE( JUMPSUBV ) CASE( RETURNSUB ) CASE( BEGINSUB )
+            CASE( BEGINDATA ) CASE( GETLOCAL ) CASE( PUTLOCAL ) {
             ON_OP();
             throwBadInstruction();
         }

--- a/libevm/LegacyVM.cpp
+++ b/libevm/LegacyVM.cpp
@@ -795,6 +795,16 @@ void LegacyVM::interpretCases() {
         CONTINUE
 #endif
 
+#ifdef MIRAGE
+        CASE( TLOAD ) 
+        CASE( TSTORE ) 
+        CASE( MCOPY ) {
+            ON_OP();
+            throwBadInstruction();
+        }
+        CONTINUE
+#endif
+
 #if EIP_616
 
         CASE( XADD ) {

--- a/libevm/LegacyVM.cpp
+++ b/libevm/LegacyVM.cpp
@@ -790,17 +790,16 @@ void LegacyVM::interpretCases() {
 
 
 #ifdef MIRAGE
-        CASE( TLOAD ) 
-        CASE( TSTORE ) 
-        CASE( MCOPY ) {
+        CASE( TLOAD ) CASE( TSTORE ) CASE( MCOPY ) {
             ON_OP();
             throwUnsupportedDencunOpcode();
         }
         CONTINUE
 #endif
 
-        CASE( JUMPTO ) CASE( JUMPIF ) CASE( JUMPV ) CASE( JUMPSUB ) CASE( JUMPSUBV )
-            CASE( RETURNSUB ) CASE( BEGINSUB ) CASE( BEGINDATA ) CASE( GETLOCAL ) CASE( PUTLOCAL ) {
+        CASE( JUMPTO )
+        CASE( JUMPIF ) CASE( JUMPV ) CASE( JUMPSUB ) CASE( JUMPSUBV ) CASE( RETURNSUB )
+            CASE( BEGINSUB ) CASE( BEGINDATA ) CASE( GETLOCAL ) CASE( PUTLOCAL ) {
             ON_OP();
             throwBadInstruction();
         }

--- a/libevm/LegacyVM.h
+++ b/libevm/LegacyVM.h
@@ -149,6 +149,10 @@ private:
     void throwBufferOverrun( bigint const& _enfOfAccess );
     void throwStorageOverflow( const std::string& _addr );
 
+#ifdef MIRAGE
+    void throwUnsupportedDencunOpcode();
+#endif
+
     std::vector< uint64_t > m_beginSubs;
     std::vector< uint64_t > m_jumpDests;
     int64_t verifyJumpDest( u256 const& _dest, bool _throw = true );

--- a/libevm/LegacyVMCalls.cpp
+++ b/libevm/LegacyVMCalls.cpp
@@ -57,8 +57,7 @@ void LegacyVM::throwDisallowedStateChange() {
 }
 
 #ifdef MIRAGE
-void LegacyVM::throwUnsupportedDencunOpcode()
-{
+void LegacyVM::throwUnsupportedDencunOpcode() {
     BOOST_THROW_EXCEPTION( UnsupportedDencunOpcode() );
 }
 #endif

--- a/libevm/LegacyVMCalls.cpp
+++ b/libevm/LegacyVMCalls.cpp
@@ -56,6 +56,13 @@ void LegacyVM::throwDisallowedStateChange() {
     BOOST_THROW_EXCEPTION( DisallowedStateChange() );
 }
 
+#ifdef MIRAGE
+void LegacyVM::throwUnsupportedDencunOpcode()
+{
+    BOOST_THROW_EXCEPTION( UnsupportedDencunOpcode() );
+}
+#endif
+
 // throwBadStack is called from fetchInstruction() -> adjustStack()
 // its the only exception that can happen before ON_OP() log is done for an opcode case in VM.cpp
 // so the call to m_onFail is needed here

--- a/libevm/LegacyVMConfig.h
+++ b/libevm/LegacyVMConfig.h
@@ -161,6 +161,18 @@ namespace eth {
 //
 #elif EVM_JUMP_DISPATCH
 
+#ifndef MIRAGE
+#define OPCODES_5C_5E      \
+    &&BEGINDATA,           \
+    &&BEGINSUB,            \
+    &&INVALID,
+#else
+#define OPCODES_5C_5E      \
+    &&TLOAD,               \
+    &&TSTORE,              \
+    &&MCOPY,
+#endif
+
 #define INIT_CASES                              \
                                                 \
     static const void* const jumpTable[256] = { \
@@ -256,9 +268,7 @@ namespace eth {
         &&MSIZE,                                \
         &&GAS,                                  \
         &&JUMPDEST,                             \
-        &&BEGINDATA,                            \
-        &&BEGINSUB,                             \
-        &&INVALID,                              \
+        OPCODES_5C_5E                           \
         &&PUSH0, /* EIP-3855  */                \
         &&PUSH1, /* 60, */                      \
         &&PUSH2,                                \

--- a/libevm/LegacyVMConfig.h
+++ b/libevm/LegacyVMConfig.h
@@ -162,15 +162,9 @@ namespace eth {
 #elif EVM_JUMP_DISPATCH
 
 #ifndef MIRAGE
-#define OPCODES_5C_5E      \
-    &&BEGINDATA,           \
-    &&BEGINSUB,            \
-    &&INVALID,
+#define OPCODES_5C_5E &&BEGINDATA, &&BEGINSUB, &&INVALID,
 #else
-#define OPCODES_5C_5E      \
-    &&TLOAD,               \
-    &&TSTORE,              \
-    &&MCOPY,
+#define OPCODES_5C_5E &&TLOAD, &&TSTORE, &&MCOPY,
 #endif
 
 #define INIT_CASES                              \
@@ -268,9 +262,8 @@ namespace eth {
         &&MSIZE,                                \
         &&GAS,                                  \
         &&JUMPDEST,                             \
-        OPCODES_5C_5E                           \
-        &&PUSH0, /* EIP-3855  */                \
-        &&PUSH1, /* 60, */                      \
+        OPCODES_5C_5E && PUSH0, /* EIP-3855  */ \
+        &&PUSH1,                /* 60, */       \
         &&PUSH2,                                \
         &&PUSH3,                                \
         &&PUSH4,                                \

--- a/libevm/VMFace.h
+++ b/libevm/VMFace.h
@@ -39,6 +39,10 @@ ETH_SIMPLE_EXCEPTION_VM( BufferOverrun );
 ETH_SIMPLE_EXCEPTION_VM( StorageOverflow );
 ETH_SIMPLE_EXCEPTION_VM( InvalidContractDeployer );
 
+#ifdef MIRAGE
+ETH_SIMPLE_EXCEPTION_VM( UnsupportedDencunOpcode );
+#endif
+
 /// Reports VM internal error. This is not based on VMException because it must be handled
 /// differently than defined consensus exceptions.
 struct InternalVMError : Exception {};

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -1155,6 +1155,14 @@ std::pair< ExecutionResult, TransactionReceipt > State::execute( EnvInfo const& 
     }
 #endif
 
+#ifdef MIRAGE
+    if (res.excepted == dev::eth::TransactionException::UnsupportedDencunOpcode ) {
+        strRevertReason = "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= Shanghai";
+        std::string strOut = "Error message from State::execute(): " + strRevertReason;
+        LOG( m_loggerDebug ) << strOut;
+    }
+#endif
+
     bool removeEmptyAccounts = false;
     switch ( _p ) {
     case Permanence::Reverted:

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -1156,8 +1156,10 @@ std::pair< ExecutionResult, TransactionReceipt > State::execute( EnvInfo const& 
 #endif
 
 #ifdef MIRAGE
-    if (res.excepted == dev::eth::TransactionException::UnsupportedDencunOpcode ) {
-        strRevertReason = "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= Shanghai";
+    if ( res.excepted == dev::eth::TransactionException::UnsupportedDencunOpcode ) {
+        strRevertReason =
+            "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= "
+            "Shanghai";
         std::string strOut = "Error message from State::execute(): " + strRevertReason;
         LOG( m_loggerDebug ) << strOut;
     }

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -493,6 +493,19 @@ string Eth::eth_call( TransactionSkeleton& t, string const&
         throw std::logic_error( strRevertReason );
     }
 
+#ifdef MIRAGE
+    if ( er.excepted == dev::eth::TransactionException::UnsupportedDencunOpcode ) {
+        strRevertReason = "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= Shanghai";
+
+        if ( !er.output.empty() ) {
+            Json::Value output = toJS( er.output );
+            BOOST_THROW_EXCEPTION(
+                JsonRpcException( REVERT_RPC_ERROR_CODE, strRevertReason, output ) );
+        }
+
+        throw std::logic_error( strRevertReason );
+    }
+#endif
 
     string callResult = toJS( er.output );
 
@@ -523,6 +536,21 @@ string Eth::eth_estimateGas( Json::Value const& _json ) {
 
             throw std::logic_error( strRevertReason );
         }
+
+#ifdef MIRAGE
+        if ( result.second.excepted == dev::eth::TransactionException::UnsupportedDencunOpcode ) {
+            strRevertReason = "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= Shanghai";
+
+            if ( !result.second.output.empty() ) {
+                Json::Value output = toJS( result.second.output );
+                BOOST_THROW_EXCEPTION(
+                    JsonRpcException( REVERT_RPC_ERROR_CODE, strRevertReason, output ) );
+            }
+
+            throw std::logic_error( strRevertReason );
+        }
+#endif
+
         return toJS( result.first );
     } catch ( std::logic_error& error ) {
         throw error;

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -505,8 +505,7 @@ string Eth::eth_call( TransactionSkeleton& t, string const&
                 JsonRpcException( REVERT_RPC_ERROR_CODE, strRevertReason, output ) );
         }
 
-        BOOST_THROW_EXCEPTION(
-            JsonRpcException( REVERT_RPC_ERROR_CODE, strRevertReason ) );
+        BOOST_THROW_EXCEPTION( JsonRpcException( REVERT_RPC_ERROR_CODE, strRevertReason ) );
     }
 #endif
 
@@ -552,8 +551,7 @@ string Eth::eth_estimateGas( Json::Value const& _json ) {
                     JsonRpcException( REVERT_RPC_ERROR_CODE, strRevertReason, output ) );
             }
 
-            BOOST_THROW_EXCEPTION(
-                JsonRpcException( REVERT_RPC_ERROR_CODE, strRevertReason ) );
+            BOOST_THROW_EXCEPTION( JsonRpcException( REVERT_RPC_ERROR_CODE, strRevertReason ) );
         }
 #endif
 

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -495,7 +495,9 @@ string Eth::eth_call( TransactionSkeleton& t, string const&
 
 #ifdef MIRAGE
     if ( er.excepted == dev::eth::TransactionException::UnsupportedDencunOpcode ) {
-        strRevertReason = "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= Shanghai";
+        strRevertReason =
+            "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= "
+            "Shanghai";
 
         if ( !er.output.empty() ) {
             Json::Value output = toJS( er.output );
@@ -539,7 +541,9 @@ string Eth::eth_estimateGas( Json::Value const& _json ) {
 
 #ifdef MIRAGE
         if ( result.second.excepted == dev::eth::TransactionException::UnsupportedDencunOpcode ) {
-            strRevertReason = "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= Shanghai";
+            strRevertReason =
+                "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= "
+                "Shanghai";
 
             if ( !result.second.output.empty() ) {
                 Json::Value output = toJS( result.second.output );

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -505,7 +505,8 @@ string Eth::eth_call( TransactionSkeleton& t, string const&
                 JsonRpcException( REVERT_RPC_ERROR_CODE, strRevertReason, output ) );
         }
 
-        throw std::logic_error( strRevertReason );
+        BOOST_THROW_EXCEPTION(
+            JsonRpcException( REVERT_RPC_ERROR_CODE, strRevertReason ) );
     }
 #endif
 

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -551,7 +551,8 @@ string Eth::eth_estimateGas( Json::Value const& _json ) {
                     JsonRpcException( REVERT_RPC_ERROR_CODE, strRevertReason, output ) );
             }
 
-            throw std::logic_error( strRevertReason );
+            BOOST_THROW_EXCEPTION(
+                JsonRpcException( REVERT_RPC_ERROR_CODE, strRevertReason ) );
         }
 #endif
 

--- a/test/unittests/libethereum/Transaction.cpp
+++ b/test/unittests/libethereum/Transaction.cpp
@@ -414,6 +414,13 @@ BOOST_AUTO_TEST_CASE( transactionExceptionOutput ) {
         "Error output TransactionException::InvalidContractDeployer" );
     buffer.str( std::string() );
 
+#ifdef MIRAGE 
+    buffer << TransactionException::UnsupportedDencunOpcode;
+    BOOST_CHECK_MESSAGE( buffer.str() == "UnsupportedDencunOpcode",
+        "Error output TransactionException::UnsupportedDencunOpcode" );
+    buffer.str( std::string() );
+#endif
+
     buffer << TransactionException( -1 );
     BOOST_CHECK_MESSAGE(
         buffer.str() == "Unknown", "Error output TransactionException::StackUnderflow" );

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -5063,6 +5063,35 @@ BOOST_AUTO_TEST_CASE( getBLSPublicKey ) {
     BOOST_REQUIRE_EQUAL( blsPublicKey["BLSPublicKey2"], "3371162264373897025322009434717052197952692496405149486989861571246537813591" );
     BOOST_REQUIRE_EQUAL( blsPublicKey["BLSPublicKey3"], "13678625751515504401110635369790787716744686498431213713911601759809559919693" );
 }
+
+BOOST_AUTO_TEST_CASE( dencunOpcodesInConstructor ) {
+    JsonRpcFixture fixture( c_BITEConfigString, false, false, true );
+
+    // contract TLoadInConstructor {
+
+    //     constructor(uint256 _input) {
+    //         assembly {
+    //             let val := tload(0x0)
+    //             sstore(0x0, val)
+    //         }
+    //     }
+    // }
+
+    string compiled = "6080604052348015600e575f5ffd5b505f5c805f555060ac8060205f395ff3fe6080604052348015600e575f5ffd5b50600436106026575f3560e01c80636d619daa14602a575b5f5ffd5b60306044565b604051603b9190605f565b60405180910390f35b5f5481565b5f819050919050565b6059816049565b82525050565b5f60208201905060705f8301846052565b9291505056fea26469706673582212201a73df3522b78621c03ab2198ced2428e80055f4b32dc9b71881cb75acf3788e64736f6c634300081e0033";
+    auto senderAddress = fixture.coinbase.address();
+
+    Json::Value create;
+    create["from"] = toJS( senderAddress );
+    create["code"] = compiled;
+    create["gas"] = "900000";
+    string txHash = fixture.rpcClient->eth_sendTransaction( create );
+    dev::eth::mineTransaction( *( fixture.client ), 1 );
+
+    auto txReceipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
+    BOOST_REQUIRE( txReceipt["status"].asString() == std::string( "0x0" ) );
+    BOOST_REQUIRE_EQUAL( txReceipt["revertReason"].asString(), std::string( "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= Shanghai" ) );
+}
+
 #endif // MIRAGE
 
 BOOST_AUTO_TEST_CASE( importInvalidBITETransaction ) {

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -5087,8 +5087,15 @@ BOOST_AUTO_TEST_CASE( dencunOpcodesInConstructor ) {
     string txHash = fixture.rpcClient->eth_sendTransaction( create );
     dev::eth::mineTransaction( *( fixture.client ), 1 );
 
+    try {
+        fixture.rpcClient->eth_estimateGas( create, "latest" );
+    } catch ( jsonrpc::JsonRpcException& ex ) {
+        BOOST_CHECK_EQUAL( ex.GetCode(), 3 );
+        BOOST_CHECK_EQUAL( ex.GetMessage(), "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= Shanghai" );
+    }
+
     auto txReceipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
-    BOOST_REQUIRE( txReceipt["status"].asString() == std::string( "0x0" ) );
+    BOOST_REQUIRE_EQUAL( txReceipt["status"].asString(), std::string( "0x0" ) );
     BOOST_REQUIRE_EQUAL( txReceipt["revertReason"].asString(), std::string( "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= Shanghai" ) );
 }
 

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -5099,6 +5099,88 @@ BOOST_AUTO_TEST_CASE( dencunOpcodesInConstructor ) {
     BOOST_REQUIRE_EQUAL( txReceipt["revertReason"].asString(), std::string( "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= Shanghai" ) );
 }
 
+BOOST_AUTO_TEST_CASE( dencunOpcodesInTransaction ) {
+    JsonRpcFixture fixture( c_BITEConfigString, false, false, true );
+
+    // contract DencunContract {
+    //     uint256 public storedValue;
+    
+    //     function test(uint256 _input) external {
+    //         assembly {
+    //             tstore(0x0, _input)
+    
+    //             let val := tload(0x0)
+    
+    //             sstore(0x0, val)
+    //         }
+    //     }
+    
+    //     function mcopyTest() public pure returns (uint256) {
+    //         uint256[] memory source = new uint256[](3);
+    //         source[0] = 10;
+    //         source[1] = 20;
+    //         source[2] = 30;
+    
+    //         uint256[] memory destination = new uint256[](3);
+    
+    //         assembly {
+    //             let length := mul(3, 32) // 3 elements * 32 bytes each
+    
+    //             mcopy(destination, add(source, 32), length)
+    //         }
+    
+    //         return destination[0];
+    //     }
+    // }
+
+    string compiled = "6080604052348015600e575f5ffd5b506102f58061001c5f395ff3fe608060405234801561000f575f5ffd5b506004361061003f575f3560e01c806325c696111461004357806329e99f07146100615780636d619daa1461007d575b5f5ffd5b61004b61009b565b60405161005891906101f3565b60405180910390f35b61007b6004803603810190610076919061023a565b6101ca565b005b6100856101d6565b60405161009291906101f3565b60405180910390f35b5f5f600367ffffffffffffffff8111156100b8576100b7610265565b5b6040519080825280602002602001820160405280156100e65781602001602082028036833780820191505090505b509050600a815f815181106100fe576100fd610292565b5b6020026020010181815250506014816001815181106101205761011f610292565b5b602002602001018181525050601e8160028151811061014257610141610292565b5b6020026020010181815250505f600367ffffffffffffffff81111561016a57610169610265565b5b6040519080825280602002602001820160405280156101985781602001602082028036833780820191505090505b50905060206003028060208401835e50805f815181106101bb576101ba610292565b5b60200260200101519250505090565b805f5d5f5c805f555050565b5f5481565b5f819050919050565b6101ed816101db565b82525050565b5f6020820190506102065f8301846101e4565b92915050565b5f5ffd5b610219816101db565b8114610223575f5ffd5b50565b5f8135905061023481610210565b92915050565b5f6020828403121561024f5761024e61020c565b5b5f61025c84828501610226565b91505092915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffdfea2646970667358221220879e6b5abbaea0d21b84075bdae00106284ac238ab5826f8e7e6519d744550b464736f6c634300081e0033";
+    auto senderAddress = fixture.coinbase.address();
+
+    Json::Value create;
+    create["from"] = toJS( senderAddress );
+    create["code"] = compiled;
+    create["gas"] = "900000";
+    string txHash = fixture.rpcClient->eth_sendTransaction( create );
+    dev::eth::mineTransaction( *( fixture.client ), 1 );
+    auto txReceipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
+    std::string contractAddress = txReceipt["contractAddress"].asString();
+
+    // Call DencunContract.test(111)
+    Json::Value sampleTx;
+    sampleTx["data"] = "0x29e99f07000000000000000000000000000000000000000000000000000000000000006f";
+    sampleTx["to"] = contractAddress;
+
+    try {
+        fixture.rpcClient->eth_estimateGas( sampleTx, "latest" );
+    } catch ( jsonrpc::JsonRpcException& ex ) {
+        BOOST_CHECK_EQUAL( ex.GetCode(), 3 );
+        BOOST_CHECK_EQUAL( ex.GetMessage(), "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= Shanghai" );
+    }
+
+    try {
+        fixture.rpcClient->eth_call( sampleTx, "latest" );
+    } catch ( jsonrpc::JsonRpcException& ex ) {
+        BOOST_CHECK_EQUAL( ex.GetCode(), 3 );
+        BOOST_CHECK_EQUAL( ex.GetMessage(), "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= Shanghai" );
+    }
+
+    txHash = fixture.rpcClient->eth_sendTransaction( sampleTx );
+    dev::eth::mineTransaction( *( fixture.client ), 1 );
+
+    txReceipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
+    BOOST_REQUIRE_EQUAL( txReceipt["status"].asString(), std::string( "0x0" ) );
+    BOOST_REQUIRE_EQUAL( txReceipt["revertReason"].asString(), std::string( "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= Shanghai" ) );
+
+    // Call DencunContract.mcopyTest()
+    sampleTx["data"] = "0x25c69611"; 
+    txHash = fixture.rpcClient->eth_sendTransaction( sampleTx );
+    dev::eth::mineTransaction( *( fixture.client ), 1 );
+
+    txReceipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
+    BOOST_REQUIRE_EQUAL( txReceipt["status"].asString(), std::string( "0x0" ) );
+    BOOST_REQUIRE_EQUAL( txReceipt["revertReason"].asString(), std::string( "Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= Shanghai" ) );
+}
+
 #endif // MIRAGE
 
 BOOST_AUTO_TEST_CASE( importInvalidBITETransaction ) {


### PR DESCRIPTION
## Description

To improve the developer and user experience, transactions sent to contracts that use the following opcodes: `TLOAD`, `TSTORE`, or `MCOPY` will now revert with the message:

> `Contract uses unsupported Dencun opcode. Please ensure it is compiled for EVM <= Shanghai`

This same logic is also applied to `eth_estimateGas` and `eth_call`.

Added 3 new opcodes from Dencun fork to vm:
```
    TLOAD = 0x5c,   // EIP-1153
    TSTORE = 0x5d,  // EIP-1153
    MCOPY = 0x5e,   // EIP-5656
```

## Tests

- Added 2 unit tests  
- Tested locally  
- Verified with the following contracts:
  - `TLoadInConstructor` – to test contract deployment handling  
  - `DencunContract` – to test contract interaction

```
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.25;

contract TLoadInConstructor {
    uint256 public storedValue;

    constructor() {
        assembly {
            // Load it back using TLOAD
            let val := tload(0x0)

            // Store it in persistent storage slot 0 (where `storedValue` is)
            sstore(0x0, val)
        }
    }
}

contract DencunContract {
    uint256 public storedValue;

    function test(uint256 _input) external {
        assembly {
            // Store the input in transient storage at key 0x0
            tstore(0x0, _input)

            // Load it back using TLOAD
            let val := tload(0x0)

            // Store it in persistent storage slot 0 (where `storedValue` is)
            sstore(0x0, val)
        }
    }

    function mcopyTest() public pure returns (uint256) {
        // Define a source memory array
        uint256[] memory source = new uint256[](3);
        source[0] = 10;
        source[1] = 20;
        source[2] = 30;

        // Define a destination memory array
        uint256[] memory destination = new uint256[](3);

        // Use inline assembly to perform the memory copy
        assembly {
            // Calculate the length of the source array in bytes
            let length := mul(3, 32) // 3 elements * 32 bytes each

            // Copy the memory from source to destination
            mcopy(destination, add(source, 32), length)
        }

        // Return the first element of the destination array
        return destination[0];
    }
}

```