### PR TITLE
NODE-CLI 891 Fix snapshot downloading

### DIFF
--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -906,6 +906,14 @@ bool ChainParams::updateCurrentGroupIfNeeded( uint64_t _latestBlockTimestamp ) {
     return false;
 }
 
+CurrentGroup ChainParams::getNewestGroup() const {
+    size_t newestIndex = 0;
+    if ( sChain.currentGroups[1].startTs >= sChain.currentGroups[0].startTs ) {
+        newestIndex = 1;
+    }
+    return sChain.currentGroups[newestIndex];
+}
+
 Address ChainParams::getSChainNodeAddressByIndex( uint64_t _sChainIndex ) const {
     const auto& sChainNodes = sChain.nodes;
     auto has_schain_index = [&_sChainIndex]( const sChainNode& node ) {

--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -155,6 +155,7 @@ struct ChainParams : public ChainOperationParams {
 
 #ifdef MIRAGE
     Address getSChainNodeAddressByIndex( uint64_t sChainIndex ) const;
+    CurrentGroup getNewestGroup() const;
 #endif
 
     size_t getNodesCount() const;

--- a/libskale/SnapshotHashAgent.cpp
+++ b/libskale/SnapshotHashAgent.cpp
@@ -286,6 +286,10 @@ std::vector< std::string > SnapshotHashAgent::getNodesToDownloadSnapshotFrom(
     unsigned blockNumber ) {
     libff::init_alt_bn128_params();
     std::vector< std::thread > threads;
+    LOG( m_loggerInfo ) << "NODE0 " << this->chainParams_.getNodeByIndex( 0 ).id;
+    LOG( m_loggerInfo ) << "NODE1 " << this->chainParams_.getNodeByIndex( 1 ).id;
+    LOG( m_loggerInfo ) << "NODE2 " << this->chainParams_.getNodeByIndex( 2 ).id;
+    LOG( m_loggerInfo ) << "NODE3 " << this->chainParams_.getNodeByIndex( 3 ).id;
 
     if ( urlToDownloadSnapshotFrom_.empty() ) {
         for ( size_t i = 0; i < this->n_; ++i ) {

--- a/libskale/SnapshotHashAgent.cpp
+++ b/libskale/SnapshotHashAgent.cpp
@@ -286,10 +286,6 @@ std::vector< std::string > SnapshotHashAgent::getNodesToDownloadSnapshotFrom(
     unsigned blockNumber ) {
     libff::init_alt_bn128_params();
     std::vector< std::thread > threads;
-    LOG( m_loggerInfo ) << "NODE0 " << this->chainParams_.getNodeByIndex( 0 ).id;
-    LOG( m_loggerInfo ) << "NODE1 " << this->chainParams_.getNodeByIndex( 1 ).id;
-    LOG( m_loggerInfo ) << "NODE2 " << this->chainParams_.getNodeByIndex( 2 ).id;
-    LOG( m_loggerInfo ) << "NODE3 " << this->chainParams_.getNodeByIndex( 3 ).id;
 
     if ( urlToDownloadSnapshotFrom_.empty() ) {
         for ( size_t i = 0; i < this->n_; ++i ) {

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -259,6 +259,30 @@ unsigned getLatestSnapshotBlockNumber( const std::string& strURLWeb3 ) {
     return block_number;
 }
 
+#ifdef MIRAGE
+uint64_t fetchLatestBlockTimestamp( const std::string& url ) {
+    skutils::rest::client cli( skutils::rest::g_nClientConnectionTimeoutMS );
+    if ( !cli.open( url ) ) {
+        throw std::runtime_error( "REST failed to connect to server" );
+    }
+    nlohmann::json request = nlohmann::json::object();
+    nlohmann::json params = request["jsonrpc"] = "2.0";
+    request["method"] = "eth_getBlockByNumber";
+    request["params"] = nlohmann::json::array( { "latest", false } );
+    skutils::rest::data_t response = cli.call( request );
+    if ( !response.err_s_.empty() )
+        throw std::runtime_error( "Error during eth_getBlockByNumber call: " + response.err_s_ );
+    if ( response.empty() )
+
+        throw std::runtime_error( "Empty response from eth_getBlockByNumber call" );
+    nlohmann::json responseData = nlohmann::json::parse( response.s_ );
+
+    auto result = responseData["result"];
+    std::string timestampStringRep = result["timestamp"].get< std::string >();
+    return jsToInt( timestampStringRep );
+}
+#endif
+
 void downloadSnapshot( unsigned block_number, std::shared_ptr< SnapshotManager >& snapshotManager,
     const std::string& strURLWeb3, const ChainParams& chainParams ) {
     static Logger loggerInfo{ createLogger( VerbosityInfo, "downloadSnapshot" ) };
@@ -526,6 +550,31 @@ bool downloadSnapshotFromUrl( std::shared_ptr< SnapshotManager >& snapshotManage
 
     return successfullDownload;
 }
+
+#ifdef MIRAGE
+uint64_t fetchLatestBlockTimestampFromNodes( const std::vector< sChainNode >& nodes ) {
+    static Logger loggerWarning{ createLogger(
+        VerbosityWarning, "fetchLatestBlockTimestampFromNodes" ) };
+    uint64_t timestamp = 0;
+    for ( auto& node : nodes ) {
+        std::string nodeUrl = std::string( "http://" ) + std::string( node.ip ) +
+                              std::string( ":" ) + ( node.port + 3 ).convert_to< std::string >();
+
+        try {
+            timestamp = fetchLatestBlockTimestamp( nodeUrl );
+        } catch ( ... ) {
+            LOG( loggerWarning ) << "Could not fetch latest block timestamp from " << nodeUrl;
+        }
+
+        if ( timestamp > 0 ) {
+            break;
+        }
+    }
+    if ( !timestamp ) {
+        throw std::runtime_error( "Could not fetch current block timestamp from provided nodes " );
+    }
+}
+#endif
 
 void downloadAndProccessSnapshot( std::shared_ptr< SnapshotManager >& snapshotManager,
     const ChainParams& chainParams, const std::string& urlToDownloadSnapshotFrom,
@@ -1593,12 +1642,6 @@ int main( int argc, char** argv ) {
             chainParams->setSgxServerUrl( strURL );
         }
 
-#ifdef MIRAGE
-        uint64_t latestBlockTs = BlockChain::getLatestBlockTimestamp( *chainParams, getDataDir() );
-        LOG( loggerInfo ) << "Latest block timestamp is: " << latestBlockTs;
-        chainParams->updateCurrentGroupIfNeeded( latestBlockTs );
-#endif
-
         std::shared_ptr< StatusAndControl > statusAndControl =
             std::make_shared< StatusAndControlFile >(
                 boost::filesystem::path( configPath ).remove_filename() );
@@ -1646,6 +1689,16 @@ int main( int argc, char** argv ) {
         }
 
         if ( downloadSnapshotFlag ) {
+#ifdef MIRAGE
+            // To process correct signatures we fetch current block timestamp
+            // from one of the nodes and temporarily changing current group
+
+            CurrentGroup latestGroup = chainParams->getNewestGroup();
+
+            uint64_t fetchedCurrentBlockTimetamp =
+                fetchLatestBlockTimestampFromNodes( latestGroup.nodes );
+            chainParams->updateCurrentGroupIfNeeded( fetchedCurrentBlockTimetamp );
+#endif
             statusAndControl->setExitState( StatusAndControl::StartAgain, true );
             statusAndControl->setExitState( StatusAndControl::StartFromSnapshot, true );
             statusAndControl->setSubsystemRunning( StatusAndControl::SnapshotDownloader, true );
@@ -1702,6 +1755,12 @@ int main( int argc, char** argv ) {
                 }
             }
         }
+
+#ifdef MIRAGE
+        uint64_t latestBlockTs = BlockChain::getLatestBlockTimestamp( *chainParams, getDataDir() );
+        LOG( loggerInfo ) << "Latest block timestamp is: " << latestBlockTs;
+        chainParams->updateCurrentGroupIfNeeded( latestBlockTs );
+#endif
 
         statusAndControl->setSubsystemRunning( StatusAndControl::SnapshotDownloader, false );
 

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -573,6 +573,7 @@ uint64_t fetchLatestBlockTimestampFromNodes( const std::vector< sChainNode >& no
     if ( !timestamp ) {
         throw std::runtime_error( "Could not fetch current block timestamp from provided nodes " );
     }
+    return timestamp;
 }
 #endif
 

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -270,11 +270,13 @@ uint64_t fetchLatestBlockTimestamp( const std::string& url ) {
     request["method"] = "eth_getBlockByNumber";
     request["params"] = nlohmann::json::array( { "latest", false } );
     skutils::rest::data_t response = cli.call( request );
+
     if ( !response.err_s_.empty() )
         throw std::runtime_error( "Error during eth_getBlockByNumber call: " + response.err_s_ );
-    if ( response.empty() )
 
+    if ( response.empty() )
         throw std::runtime_error( "Empty response from eth_getBlockByNumber call" );
+
     nlohmann::json responseData = nlohmann::json::parse( response.s_ );
 
     auto result = responseData["result"];
@@ -555,11 +557,13 @@ bool downloadSnapshotFromUrl( std::shared_ptr< SnapshotManager >& snapshotManage
 uint64_t fetchLatestBlockTimestampFromNodes( const std::vector< sChainNode >& nodes ) {
     static Logger loggerWarning{ createLogger(
         VerbosityWarning, "fetchLatestBlockTimestampFromNodes" ) };
+    static Logger loggerInfo{ createLogger( VerbosityInfo, "fetchLatestBlockTimestampFromNodes" ) };
+
     uint64_t timestamp = 0;
     for ( auto& node : nodes ) {
         std::string nodeUrl = std::string( "http://" ) + std::string( node.ip ) +
                               std::string( ":" ) + ( node.port + 3 ).convert_to< std::string >();
-
+        LOG( loggerInfo ) << "Trying to fetch latest block timestamp from " << nodeUrl;
         try {
             timestamp = fetchLatestBlockTimestamp( nodeUrl );
         } catch ( ... ) {
@@ -573,6 +577,7 @@ uint64_t fetchLatestBlockTimestampFromNodes( const std::vector< sChainNode >& no
     if ( !timestamp ) {
         throw std::runtime_error( "Could not fetch current block timestamp from provided nodes " );
     }
+    LOG( loggerInfo ) << "Successfully fetched latest block timestamp";
     return timestamp;
 }
 #endif
@@ -1758,6 +1763,10 @@ int main( int argc, char** argv ) {
         }
 
 #ifdef MIRAGE
+
+        // Configuring current group if it is regular syncing from catchup.
+        // Setting back correct group if it starting from snapshot mode.
+
         uint64_t latestBlockTs = BlockChain::getLatestBlockTimestamp( *chainParams, getDataDir() );
         LOG( loggerInfo ) << "Latest block timestamp is: " << latestBlockTs;
         chainParams->updateCurrentGroupIfNeeded( latestBlockTs );


### PR DESCRIPTION
## Description

Fix snapshot verification by temporary switching to the group corresponding to chain's latest block fetched from other nodes. 

## Tests

- Verified on local network setup

## Performance Impact

- Additional Json Rpc API request is executed each time we need to download snapshot
