### PR TITLE
Feature/2255 split block rewards to staking contract

### DIFF
--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -206,6 +206,7 @@ struct CurrentGroup {
     std::string keyShareName;
     std::array< std::string, 4 > BLSPublicKeys;
     std::array< std::string, 4 > commonBLSPublicKeys;
+    dev::Address stakingContractAddress;
 };
 
 using CurrentGroups = std::array< CurrentGroup, c_currentGroupsSize >;
@@ -265,10 +266,7 @@ public:
 #endif
         nodes.push_back( me );
 #ifdef MIRAGE
-        currentGroups[0] = {
-            nodes,
-            1,
-            "",
+        currentGroups[0] = { nodes, 1, "",
             { "1085704699902305713594457076223282948137075635957851808699051999328"
               "5655852781",
                 "11559732032986387107991004021392285783925812861821192530917403151452391805634",
@@ -279,11 +277,8 @@ public:
                 "11559732032986387107991004021392285783925812861821192530917403151452391805634",
                 "8495653923123431417604973247489272438418190587263600148770280649306958101930",
                 "4082367875863433681332203403145435568316851327593401208105741076214120093531" },
-        };
-        currentGroups[1] = {
-            nodes,
-            2,
-            "",
+            dev::ZeroAddress };
+        currentGroups[1] = { nodes, 2, "",
             { "1085704699902305713594457076223282948137075635957851808699051999328"
               "5655852781",
                 "11559732032986387107991004021392285783925812861821192530917403151452391805634",
@@ -294,7 +289,7 @@ public:
                 "11559732032986387107991004021392285783925812861821192530917403151452391805634",
                 "8495653923123431417604973247489272438418190587263600148770280649306958101930",
                 "4082367875863433681332203403145435568316851327593401208105741076214120093531" },
-        };
+            dev::ZeroAddress };
 #endif
     }
 };
@@ -398,6 +393,12 @@ public:
 
 #ifdef MIRAGE
     bool getAllowPreEIP155Txns() const { return allowPreEIP155Txns; }
+
+    // only called from the block execution thread
+    // no mutex needed
+    Address getStakingContractAddress() const {
+        return sChain.currentGroups.back().stakingContractAddress;
+    }
 #endif
 
     /// General chain params.

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -393,12 +393,6 @@ public:
 
 #ifdef MIRAGE
     bool getAllowPreEIP155Txns() const { return allowPreEIP155Txns; }
-
-    // only called from the block execution thread
-    // no mutex needed
-    Address getStakingContractAddress() const {
-        return sChain.currentGroups.back().stakingContractAddress;
-    }
 #endif
 
     /// General chain params.

--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -95,8 +95,13 @@ struct EVMSchedule {
     // at network start transaction fees will not be distributed to block authors / stakers
     // this number will be changed in later patches
     size_t shareOfTransactionFeeToRewardPromille = 0;
+
     // block rewards are disabled initially and will be enabled in later patches
     u256 blockRewardOverwrite = 0;
+
+    // block rewards should be split between block author and staking contract
+    // initially rewards are split equally
+    size_t shareOfBlockRewardToBlockAuthorPromille = 500;
 #else
     boost::optional< u256 > blockRewardOverwrite;
 #endif
@@ -137,7 +142,9 @@ static const EVMSchedule ByzantiumSchedule = [] {
     schedule.haveRevert = true;
     schedule.haveReturnData = true;
     schedule.haveStaticCall = true;
+#ifndef MIRAGE
     schedule.blockRewardOverwrite = { 3 * ether };
+#endif
     return schedule;
 }();
 
@@ -147,7 +154,9 @@ static const EVMSchedule ConstantinopleSchedule = [] {
     schedule.haveBitwiseShifting = true;
     schedule.haveExtcodehash = true;
     schedule.eip1283Mode = true;
+#ifndef MIRAGE
     schedule.blockRewardOverwrite = { 2 * ether };
+#endif
     return schedule;
 }();
 

--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -100,8 +100,7 @@ struct EVMSchedule {
     u256 blockRewardOverwrite = 0;
 
     // block rewards should be split between block author and staking contract
-    // initially rewards are split equally
-    size_t shareOfBlockRewardToBlockAuthorPromille = 500;
+    size_t shareOfBlockRewardToBlockAuthorPromille = 1000;
 #else
     boost::optional< u256 > blockRewardOverwrite;
 #endif

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -1024,10 +1024,16 @@ ExecutionResult Block::execute( LastBlockHashesFace const& _lh, Transaction cons
 void Block::rewardAllForNonDefaultBlock(
     const dev::Address& _stakingContractAddress, u256 const& _blockReward ) {
     // if staking contract is set to ZeroAddress, full reward goes to block author
-    size_t blockAuthorSharePromile = _stakingContractAddress == dev::ZeroAddress ? 1000 : sealEngine()->evmSchedule( m_previousBlock.timestamp(), m_currentBlock.number() ).shareOfBlockRewardToBlockAuthorPromille;
+    size_t blockAuthorSharePromile =
+        _stakingContractAddress == dev::ZeroAddress ?
+            1000 :
+            sealEngine()
+                ->evmSchedule( m_previousBlock.timestamp(), m_currentBlock.number() )
+                .shareOfBlockRewardToBlockAuthorPromille;
 
     // calculate block author's share
-    u256 blockAuthorReward = dev::calculateShareWithPrecision( _blockReward, blockAuthorSharePromile );
+    u256 blockAuthorReward =
+        dev::calculateShareWithPrecision( _blockReward, blockAuthorSharePromile );
     // calculate amount to be sent to staking contract
     u256 stakingContractReward = _blockReward - blockAuthorReward;
 

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -1023,26 +1023,21 @@ ExecutionResult Block::execute( LastBlockHashesFace const& _lh, Transaction cons
 #ifdef MIRAGE
 void Block::rewardAllForNonDefaultBlock(
     const dev::Address& _stakingContractAddress, u256 const& _blockReward ) {
+    // if staking contract is set to ZeroAddress, full reward goes to block author
+    size_t blockAuthorSharePromile = _stakingContractAddress == dev::ZeroAddress ? 1000 : sealEngine()->evmSchedule( m_previousBlock.timestamp(), m_currentBlock.number() ).shareOfBlockRewardToBlockAuthorPromille;
+
     // calculate block author's share
-    u256 blockAuthorReward = dev::calculateShareWithPrecision(
-        _blockReward, sealEngine()
-                          ->evmSchedule( m_previousBlock.timestamp(), m_currentBlock.number() )
-                          .shareOfBlockRewardToBlockAuthorPromille );
+    u256 blockAuthorReward = dev::calculateShareWithPrecision( _blockReward, blockAuthorSharePromile );
     // calculate amount to be sent to staking contract
     u256 stakingContractReward = _blockReward - blockAuthorReward;
-
-    std::cout << "BLOCK AUTHOR REWARD: " << _blockReward << '\n'
-              << "STAKING CONTRACT REWARD: " << stakingContractReward << '\n';
 
     // only distribute rewards for non-default blocks
     if ( m_currentBlock.author() != DEFAULT_BLOCK_OWNER_ADDRESS ) {
         // send to block author
         m_state.addBalance( m_currentBlock.author(), blockAuthorReward );
 
-        // send to staking contract if it is non-empty
-        if ( _stakingContractAddress != dev::ZeroAddress ) {
-            m_state.addBalance( _stakingContractAddress, stakingContractReward );
-        }
+        // send to staking contract
+        m_state.addBalance( _stakingContractAddress, stakingContractReward );
     }
 }
 

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -1024,12 +1024,11 @@ ExecutionResult Block::execute( LastBlockHashesFace const& _lh, Transaction cons
 void Block::rewardAllForNonDefaultBlock(
     const dev::Address& _stakingContractAddress, u256 const& _blockReward ) {
     // if staking contract is set to ZeroAddress, full reward goes to block author
-    size_t blockAuthorSharePromille =
-        _stakingContractAddress == dev::ZeroAddress ?
-            1000 :
-            sealEngine()
-                ->evmSchedule( m_previousBlock.timestamp(), m_currentBlock.number() )
-                .shareOfBlockRewardToBlockAuthorPromille;
+    auto evmSchedule =
+        sealEngine()->evmSchedule( m_previousBlock.timestamp(), m_currentBlock.number() );
+    size_t blockAuthorSharePromille = evmSchedule.shareOfBlockRewardToBlockAuthorPromille;
+    if ( _stakingContractAddress == dev::ZeroAddress )
+        blockAuthorSharePromille = 1000;
 
     // calculate block author's share
     u256 blockAuthorReward =

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -579,9 +579,9 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
 #ifdef MIRAGE
     auto lastRewardedBlockNumber = m_state.getLastRewardedBlockNumber();
     if ( lastRewardedBlockNumber < m_currentBlock.number() ) {
-        auto blockTimestamp = m_currentBlock.timestamp();
+        auto blockTimestamp = m_previousBlock.timestamp();
         auto reward = _bc.sealEngine()->blockReward( blockTimestamp, m_currentBlock.number() );
-        rewardBlockAuthorForNonDefaultBlock( reward );
+        rewardAllForNonDefaultBlock( _bc.chainParams().getStakingContractAddress(), reward );
         m_state.safeSetLastRewardedBlockNumber( m_currentBlock.number() );
         bool removeEmptyAccounts =
             m_currentBlock.number() >= _bc.chainParams().getEIP158ForkBlock();
@@ -852,7 +852,7 @@ u256 Block::enact( VerifiedBlockRef const& _block, BlockChain const& _bc ) {
     DEV_TIMED_ABOVE( "applyRewards", 500 )
 
 #ifdef MIRAGE
-    rewardBlockAuthorForNonDefaultBlock(
+    rewardAllForNonDefaultBlock( _bc.chainParams().getStakingContractAddress(),
         _bc.sealEngine()->blockReward( m_currentBlock.timestamp(), m_currentBlock.number() ) );
 #else
     applyRewards( rewarded,
@@ -1021,9 +1021,28 @@ ExecutionResult Block::execute( LastBlockHashesFace const& _lh, Transaction cons
 }
 
 #ifdef MIRAGE
-void Block::rewardBlockAuthorForNonDefaultBlock( u256 const& _blockReward ) {
+void Block::rewardAllForNonDefaultBlock(
+    const dev::Address& _stakingContractAddress, u256 const& _blockReward ) {
+    // calculate block author's share
+    u256 blockAuthorReward = dev::calculateShareWithPrecision(
+        _blockReward, sealEngine()
+                          ->evmSchedule( m_previousBlock.timestamp(), m_currentBlock.number() )
+                          .shareOfBlockRewardToBlockAuthorPromille );
+    // calculate amount to be sent to staking contract
+    u256 stakingContractReward = _blockReward - blockAuthorReward;
+
+    std::cout << "BLOCK AUTHOR REWARD: " << _blockReward << '\n'
+              << "STAKING CONTRACT REWARD: " << stakingContractReward << '\n';
+
+    // only distribute rewards for non-default blocks
     if ( m_currentBlock.author() != DEFAULT_BLOCK_OWNER_ADDRESS ) {
-        m_state.addBalance( m_currentBlock.author(), _blockReward );
+        // send to block author
+        m_state.addBalance( m_currentBlock.author(), blockAuthorReward );
+
+        // send to staking contract if it is non-empty
+        if ( _stakingContractAddress != dev::ZeroAddress ) {
+            m_state.addBalance( _stakingContractAddress, stakingContractReward );
+        }
     }
 }
 

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -1024,7 +1024,7 @@ ExecutionResult Block::execute( LastBlockHashesFace const& _lh, Transaction cons
 void Block::rewardAllForNonDefaultBlock(
     const dev::Address& _stakingContractAddress, u256 const& _blockReward ) {
     // if staking contract is set to ZeroAddress, full reward goes to block author
-    size_t blockAuthorSharePromile =
+    size_t blockAuthorSharePromille =
         _stakingContractAddress == dev::ZeroAddress ?
             1000 :
             sealEngine()
@@ -1033,7 +1033,7 @@ void Block::rewardAllForNonDefaultBlock(
 
     // calculate block author's share
     u256 blockAuthorReward =
-        dev::calculateShareWithPrecision( _blockReward, blockAuthorSharePromile );
+        dev::calculateShareWithPrecision( _blockReward, blockAuthorSharePromille );
     // calculate amount to be sent to staking contract
     u256 stakingContractReward = _blockReward - blockAuthorReward;
 

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -344,8 +344,9 @@ private:
     u256 enact( VerifiedBlockRef const& _block, BlockChain const& _bc );
 
 #ifdef MIRAGE
-    // Apply block reward for block author, if it is not default block
-    void rewardBlockAuthorForNonDefaultBlock( u256 const& _blockReward );
+    // Distribute block rewards to block author and staking contract, if it is not default block
+    void rewardAllForNonDefaultBlock(
+        const dev::Address& _stakingContractAddress, u256 const& _blockReward );
 #endif
     /// Finalise the block, applying the earned rewards.
     void applyRewards(
@@ -393,7 +394,6 @@ private:
     Logger m_loggerError{ createLogger( VerbosityError, "block" ) };
 
     Counter< Block > c;
-    ;
 
 public:
     static uint64_t howMany() { return Counter< Block >::howMany(); }

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -537,8 +537,11 @@ void ChainParams::processSkaleConfigItems( json_spirit::mObject& obj ) {
                     }
                 }
                 // read staking contract address
-                stakingContractAddress =
-                    dev::Address( it->second.get_obj().at( "stakingContractAddress" ).get_str() );
+                try {
+                    stakingContractAddress = dev::Address(
+                        it->second.get_obj().at( "stakingContractAddress" ).get_str() );
+                } catch ( ... ) {
+                }
             } else {
                 // timestamp is set to 0 for BOOT group
                 startTs = 0;

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -429,6 +429,7 @@ void ChainParams::processSkaleConfigItems( json_spirit::mObject& obj ) {
                 << "Node " << node.id << ": owner is not set, using zero address as fallback";
             node.owner = ZeroAddress;
         }
+
         try {
             node.rewardWalletAddress =
                 jsToAddress( nodeConfObj.at( "rewardWalletAddress" ).get_str() );
@@ -438,8 +439,6 @@ void ChainParams::processSkaleConfigItems( json_spirit::mObject& obj ) {
                 << ": rewardWalletAddress is not set, using zero address as fallback";
             node.rewardWalletAddress = ZeroAddress;
         }
-
-
 #endif
         node.ip = nodeConfObj.at( "ip" ).get_str();
         node.port = nodeConfObj.at( "basePort" ).get_uint64();
@@ -489,9 +488,10 @@ void ChainParams::processSkaleConfigItems( json_spirit::mObject& obj ) {
             s.nodes.push_back( node );
         }
         s.t = t;
-        s.currentGroups[1] = { s.nodes, 1, keyShareName, BLSPublicKeys, commonBLSPublicKeys };
+        s.currentGroups[1] = { s.nodes, 1, keyShareName, BLSPublicKeys, commonBLSPublicKeys,
+            dev::ZeroAddress };
         // make it default
-        s.currentGroups[0] = { {}, 0, "", {}, {} };
+        s.currentGroups[0] = { {}, 0, "", {}, {}, dev::Address() };
     } else {
         auto nodesObjects = sChainObj.at( "nodes" ).get_obj();
         if ( nodesObjects.size() != c_currentGroupsSize )
@@ -505,6 +505,8 @@ void ChainParams::processSkaleConfigItems( json_spirit::mObject& obj ) {
             } catch ( const std::exception& ) {
                 BOOST_THROW_EXCEPTION( runtime_error( "Invalid startTs in nodes section." ) );
             }
+
+            dev::Address stakingContractAddress = dev::ZeroAddress;
 
             std::vector< sChainNode > nodes;
 
@@ -534,12 +536,16 @@ void ChainParams::processSkaleConfigItems( json_spirit::mObject& obj ) {
                         BLSPublicKeys[3] = blsKeyInfo.at( "BLSPublicKey3" ).get_str();
                     }
                 }
+                // read staking contract address
+                stakingContractAddress =
+                    dev::Address( it->second.get_obj().at( "stakingContractAddress" ).get_str() );
             } else {
                 // timestamp is set to 0 for BOOT group
                 startTs = 0;
             }
             s.currentGroups[std::distance( nodesObjects.begin(), it )] = { nodes,
-                ( uint64_t ) startTs, keyShareName, BLSPublicKeys, commonBLSPublicKeys };
+                ( uint64_t ) startTs, keyShareName, BLSPublicKeys, commonBLSPublicKeys,
+                stakingContractAddress };
             s.t = t;
         }
     }

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -882,6 +882,11 @@ void ChainParams::fillDefaultTestsParameters( size_t _port ) {
 }
 
 #ifdef MIRAGE
+Address ChainParams::getStakingContractAddress() const {
+    std::shared_lock< std::shared_mutex > lock( m_mutex );
+    return sChain.currentGroups.back().stakingContractAddress;
+}
+
 std::string ChainParams::getConfigForConsensus() const {
     js::mValue val;
     json_spirit::read_string_or_throw( getOriginalJson(), val );

--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -159,6 +159,10 @@ struct ChainParams : public ChainOperationParams {
 
     size_t getThresholdCount() const { return sChain.t; }
 
+#ifdef MIRAGE
+    Address getStakingContractAddress() const;
+#endif
+
     // SGX GETTERS
 
     bool isTestSignaturesEnabled() const { return nodeInfo.testSignatures; }

--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -362,7 +362,9 @@ void validateConfigJson( js::mObject const& _obj ) {
                 const js::mObject& groupInfo = nodeGroup.second.get_obj();
                 requireJsonFields( groupInfo, "ChainParams::loadConfig::skaleConfig::sChain::nodes",
                     { { "group", { { js::array_type }, JsonFieldPresence::Required } },
-                        { "blsKey", { { js::obj_type }, JsonFieldPresence::Optional } } } );
+                        { "blsKey", { { js::obj_type }, JsonFieldPresence::Optional } },
+                        { "stakingContractAddress",
+                            { { js::str_type }, JsonFieldPresence::Optional } } } );
                 if ( groupInfo.count( "blsKey" ) ) {
                     const js::mObject& blsKeyInfo = groupInfo.at( "blsKey" ).get_obj();
                     requireJsonFields( blsKeyInfo,

--- a/libskale/BlockRewardsActivationPatch.cpp
+++ b/libskale/BlockRewardsActivationPatch.cpp
@@ -15,10 +15,14 @@ dev::Address BlockRewardsActivationPatch::getMagicAddress() {
 
 bool BlockRewardsActivationPatch::isEnabled( uint64_t _chainId ) {
     if ( _chainId != fairChainId ) {
-        // means that we are in tests or testnet environment
-        if ( client )
-            // we are on testnet. enable only after first committee rotation
-            return client->getCurrentEpochId() > 0;
+        // means that we are in unit test or testnet environment
+        // always enable for unit tests by default
+        // check epochId for testnet
+        if ( client ) {
+            if ( !client->chainParams().isTestSignaturesEnabled() )
+                // we are on testnet. enable only after first committee rotation
+                return client->getCurrentEpochId() > 0;
+        }
         return true;
     }
     // we are on mainnet
@@ -29,6 +33,6 @@ dev::eth::EVMSchedule BlockRewardsActivationPatch::makeSchedule(
     const dev::eth::EVMSchedule& _base ) {
     dev::eth::EVMSchedule ret = _base;
     ret.blockRewardOverwrite = { 5 * dev::eth::ether };
-    ret.shareOfTransactionFeeToRewardPromille = 500;
+    ret.shareOfTransactionFeeToRewardPromille = 500; // 50%
     return ret;
 }

--- a/libskale/BlockRewardsActivationPatch.cpp
+++ b/libskale/BlockRewardsActivationPatch.cpp
@@ -33,6 +33,6 @@ dev::eth::EVMSchedule BlockRewardsActivationPatch::makeSchedule(
     const dev::eth::EVMSchedule& _base ) {
     dev::eth::EVMSchedule ret = _base;
     ret.blockRewardOverwrite = { 5 * dev::eth::ether };
-    ret.shareOfTransactionFeeToRewardPromille = 500; // 50%
+    ret.shareOfTransactionFeeToRewardPromille = 500;  // 50%
     return ret;
 }

--- a/libskale/BlockRewardsActivationPatch.cpp
+++ b/libskale/BlockRewardsActivationPatch.cpp
@@ -34,5 +34,6 @@ dev::eth::EVMSchedule BlockRewardsActivationPatch::makeSchedule(
     dev::eth::EVMSchedule ret = _base;
     ret.blockRewardOverwrite = { 5 * dev::eth::ether };
     ret.shareOfTransactionFeeToRewardPromille = 500;  // 50%
+    ret.shareOfBlockRewardToBlockAuthorPromille = 500;  // 50%
     return ret;
 }

--- a/libskale/BlockRewardsActivationPatch.cpp
+++ b/libskale/BlockRewardsActivationPatch.cpp
@@ -14,8 +14,14 @@ dev::Address BlockRewardsActivationPatch::getMagicAddress() {
 }
 
 bool BlockRewardsActivationPatch::isEnabled( uint64_t _chainId ) {
-    if ( _chainId != fairChainId )
+    if ( _chainId != fairChainId ) {
+        // means that we are in tests or testnet environment
+        if ( client )
+            // we are on testnet. enable only after first committee rotation
+            return client->getCurrentEpochId() > 0;
         return true;
+    }
+    // we are on mainnet
     return client->countAt( getMagicAddress() ) != 0;
 }
 

--- a/libskale/BlockRewardsActivationPatch.cpp
+++ b/libskale/BlockRewardsActivationPatch.cpp
@@ -33,7 +33,7 @@ dev::eth::EVMSchedule BlockRewardsActivationPatch::makeSchedule(
     const dev::eth::EVMSchedule& _base ) {
     dev::eth::EVMSchedule ret = _base;
     ret.blockRewardOverwrite = { 5 * dev::eth::ether };
-    ret.shareOfTransactionFeeToRewardPromille = 500;  // 50%
+    ret.shareOfTransactionFeeToRewardPromille = 500;    // 50%
     ret.shareOfBlockRewardToBlockAuthorPromille = 500;  // 50%
     return ret;
 }

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -289,6 +289,7 @@ static std::string const c_genesisConfigString =
             "nodeGroups": {},
             "nodes": {
                 "1": {
+                    "stakingContractAddress": "0x5C60C315985977b7a408eBF4256984Acdf949549",
                     "group": [
                   { "nodeID": 1112, "owner": "0x0E7d7F1D34a502bD609542576941C3FCc087c588", "ip": "127.0.0.1", "basePort": )" +
         std::to_string( rand_port ) +
@@ -4471,6 +4472,7 @@ BOOST_AUTO_TEST_CASE( getZeroBlock ) {
 #ifdef MIRAGE
 BOOST_AUTO_TEST_CASE( block_author_balance ) {
     // when rewardWalletAddress is not defined
+
     // for testBlockRewardsActivationPatchAddress
     setenv( "TEST_BLOCK_REWARDS_ACTIVATION", "1", 1 );
 
@@ -4480,6 +4482,8 @@ BOOST_AUTO_TEST_CASE( block_author_balance ) {
     // Set FAIR chainID
     std::string chainID = "0x3a6";
     ret["params"]["chainID"] = chainID;
+    // disable block rewards at startup
+    ret["params"]["blockReward"] = "0x00";
 
     Json::FastWriter fastWriter;
     std::string config = fastWriter.write( ret );
@@ -4495,13 +4499,10 @@ BOOST_AUTO_TEST_CASE( block_author_balance ) {
     auto etherbase_address = jsToAddress( etherbase );
 
     u256 etherbaseBalance = fixture.client->balanceAt( etherbase_address );
+    BOOST_REQUIRE_EQUAL( etherbaseBalance, 0 );
 
-    // mine blocks without transactions
-    dev::eth::simulateMining( *( fixture.client ), 10 );
-    sleep( 3 );
-    etherbaseBalance = fixture.client->balanceAt( etherbase_address );
-
-    BOOST_REQUIRE_GT( etherbaseBalance, 0 );
+    dev::Address stakingContractAddress = fixture.client->chainParams().getStakingContractAddress();
+    BOOST_REQUIRE_EQUAL( fixture.client->balanceAt( stakingContractAddress ), 0 );
 
     // mine transaction not from testBlockRewardsActivationPatchAddress - block rewards should stay disabled
     Json::Value silentTx;
@@ -4523,6 +4524,10 @@ BOOST_AUTO_TEST_CASE( block_author_balance ) {
     dev::eth::mineTransaction( *( fixture.client ), 1 );
     BOOST_REQUIRE( fixture.rpcClient->eth_getTransactionReceipt( txHash )["status"] == "0x1" );
     BOOST_REQUIRE( !BlockRewardsActivationPatch::isEnabled( fixture.client->chainId() ) );
+    // staking contract balance only geets changed when block rewards are activated
+    BOOST_REQUIRE_EQUAL( fixture.client->balanceAt( stakingContractAddress ), 0 );
+    etherbaseBalance = fixture.client->balanceAt( etherbase_address );
+    BOOST_REQUIRE_EQUAL( etherbaseBalance, 0 );
 
     // mine transaction from testBlockRewardsActivationPatchAddress - block rewards should enable
     Json::Value activationTx;
@@ -4541,10 +4546,14 @@ BOOST_AUTO_TEST_CASE( block_author_balance ) {
     dev::eth::mineTransaction( *( fixture.client ), 1 );
     BOOST_REQUIRE( fixture.rpcClient->eth_getTransactionReceipt( txHash )["status"] == "0x1" );
     BOOST_REQUIRE( BlockRewardsActivationPatch::isEnabled( fixture.client->chainId() ) );
+    etherbaseBalance = fixture.client->balanceAt( etherbase_address );
+    BOOST_REQUIRE_EQUAL( etherbaseBalance, 0 );
+    BOOST_REQUIRE_EQUAL( fixture.client->balanceAt( stakingContractAddress ), 0 );
 
     etherbaseBalance = fixture.client->balanceAt( jsToAddress( etherbase ) );
 
     auto authorInitialBalance = fixture.client->balanceAt( jsToAddress( "0x0E7d7F1D34a502bD609542576941C3FCc087c588" ) );
+    auto stakingContractInitialBalance = fixture.client->balanceAt( stakingContractAddress );
 
     auto initialBlockNumber = jsToU256( fixture.rpcClient->eth_blockNumber() );
 
@@ -4574,14 +4583,22 @@ BOOST_AUTO_TEST_CASE( block_author_balance ) {
 
     auto totalReward = fixture.client->chainParams().blockReward(
         fixture.client->latestBlock().info().timestamp(), fixture.client->number() );
+    auto blockAuthorReward = dev::calculateShareWithPrecision( totalReward, fixture.client->evmSchedule().shareOfBlockRewardToBlockAuthorPromille );
+    auto stakingContractReward = totalReward - blockAuthorReward;
+
     auto feeForTx =
         jsToU256( sampleTx["gasPrice"].asString() ) * jsToU256( txData["gasUsed"].asString() );
     feeForTx = dev::calculateShareWithPrecision( feeForTx, fixture.client->evmSchedule().shareOfTransactionFeeToRewardPromille );
-    auto expectedBalanceChange = ( blockNumber - initialBlockNumber ) * totalReward + feeForTx;
+
+    auto expectedAuthorBalanceChange = ( blockNumber - initialBlockNumber ) * blockAuthorReward + feeForTx;
+    auto expectedContractBalanceChange = ( blockNumber - initialBlockNumber ) * stakingContractReward;
 
     BOOST_REQUIRE_EQUAL(
         fixture.client->balanceAt( jsToAddress( author.asString() ) ) - authorInitialBalance,
-        expectedBalanceChange );
+        expectedAuthorBalanceChange );
+    BOOST_REQUIRE_EQUAL(
+        fixture.client->balanceAt( stakingContractAddress ) - stakingContractInitialBalance,
+        expectedContractBalanceChange );
 }
 
 BOOST_AUTO_TEST_CASE( block_author_balance_reward_wallet ) {

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -4648,10 +4648,14 @@ BOOST_AUTO_TEST_CASE( block_author_balance_reward_wallet ) {
     BOOST_REQUIRE( author == node_reward_wallet );
 
     auto totalReward = fixture.client->chainParams().blockReward(
-                fixture.client->latestBlock().info().timestamp(), fixture.client->number() );
+        fixture.client->latestBlock().info().timestamp(), fixture.client->number() );
+    auto blockAuthorReward =
+            dev::calculateShareWithPrecision( totalReward,
+                fixture.client->evmSchedule().shareOfBlockRewardToBlockAuthorPromille );
+
     auto feeForTx = jsToU256( sampleTx["gasPrice"].asString() ) * jsToU256( txData["gasUsed"].asString() );
     feeForTx = dev::calculateShareWithPrecision( feeForTx, fixture.client->evmSchedule().shareOfTransactionFeeToRewardPromille );
-    auto expectedBalanceChange = ( blockNumber - initialBlockNumber ) * totalReward + feeForTx;
+    auto expectedBalanceChange = ( blockNumber - initialBlockNumber ) * blockAuthorReward + feeForTx;
 
     BOOST_REQUIRE_EQUAL(
         fixture.client->balanceAt( jsToAddress( author.asString() ) ) - authorInitialBalance,

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -5435,7 +5435,6 @@ BOOST_AUTO_TEST_CASE( dencunOpcodesInTransaction ) {
 BOOST_AUTO_TEST_CASE( importInvalidBITETransaction ) {
     JsonRpcFixture fixture( c_BITEConfigString, false, false, true, true );
 
-    dev::eth::simulateMining( *( fixture.client ), 20 );
     string senderAddress = toJS( fixture.coinbase.address() );
     size_t nonce = 0;
     std::string biteAddress = "0x" + std::string( BITE_ADDRESS_AS_STRING );
@@ -5664,7 +5663,6 @@ BOOST_AUTO_TEST_CASE( importInvalidBITETransaction ) {
 BOOST_AUTO_TEST_CASE( BITETransactionCouldNotBeDecrypted ) {
     JsonRpcFixture fixture( c_BITEConfigString, false, false, true, true );
 
-    dev::eth::simulateMining( *( fixture.client ), 20 );
     string senderAddress = toJS( fixture.coinbase.address() );
 
     // address 0x7aa5e36aa15e93d10f4f26357c30f052dacdde5f is preset in config
@@ -6024,8 +6022,6 @@ BOOST_AUTO_TEST_CASE( committeeRotation ) {
     Json::FastWriter fastWriter;
     std::string config = fastWriter.write( ret );
     JsonRpcFixture fixture( config, false, false, true );
-
-    dev::eth::simulateMining( *( fixture.client ), 20 );
 
     Json::Value txRefill;
     txRefill["to"] = "0xc868AF52a6549c773082A334E5AE232e0Ea3B513";

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -4524,7 +4524,7 @@ BOOST_AUTO_TEST_CASE( block_author_balance ) {
     dev::eth::mineTransaction( *( fixture.client ), 1 );
     BOOST_REQUIRE( fixture.rpcClient->eth_getTransactionReceipt( txHash )["status"] == "0x1" );
     BOOST_REQUIRE( !BlockRewardsActivationPatch::isEnabled( fixture.client->chainId() ) );
-    // staking contract balance only geets changed when block rewards are activated
+    // staking contract balance only gets changed when block rewards are activated
     BOOST_REQUIRE_EQUAL( fixture.client->balanceAt( stakingContractAddress ), 0 );
     etherbaseBalance = fixture.client->balanceAt( etherbase_address );
     BOOST_REQUIRE_EQUAL( etherbaseBalance, 0 );


### PR DESCRIPTION
fixes #2255 

once block rewards are activated on the mainnet, block author receives only a share of block reward. the rest is distributed to staking contract
on a testnet, block rewards are activated by default and distribution to staking contract starts after first committee rotation

more details on block rewards can be found [here](https://github.com/skalenetwork/internal-support/blob/block-rewards-spec/docs/specifications/skaled/FAIR/rewards.md#staking-reward-address)