### PR TITLE
Add patch for getBlockRandom

### DIFF
--- a/libethereum/SchainPatch.cpp
+++ b/libethereum/SchainPatch.cpp
@@ -42,6 +42,8 @@ SchainPatchEnum getEnumForPatchName( const std::string& _patchName ) {
         return SchainPatchEnum::ClearPartialReceiptsPatch;
     else if ( _patchName == "InvalidTransactionFormatPatch" )
         return SchainPatchEnum::InvalidTransactionFormatPatch;
+    else if ( _patchName == "CurrentBlockRandomPatch" )
+        return SchainPatchEnum::CurrentBlockRandomPatch;
     else
         throw std::out_of_range( _patchName );
 }
@@ -82,6 +84,8 @@ std::string getPatchNameForEnum( SchainPatchEnum _enumValue ) {
         return "ClearPartialReceiptsPatch";
     case SchainPatchEnum::InvalidTransactionFormatPatch:
         return "InvalidTransactionFormatPatch";
+    case SchainPatchEnum::CurrentBlockRandomPatch:
+        return "CurrentBlockRandomPatch";
     default:
         throw std::out_of_range(
             "UnknownPatch #" + std::to_string( static_cast< size_t >( _enumValue ) ) );
@@ -96,7 +100,7 @@ const std::unordered_set< SchainPatchEnum > SchainPatch::preEnabledForMIRAGE = {
     SchainPatchEnum::SkipInvalidTransactionsPatch, SchainPatchEnum::VerifyDaSigsPatch,
     SchainPatchEnum::FastConsensusPatch, SchainPatchEnum::EIP1559TransactionsPatch,
     SchainPatchEnum::VerifyBlsSyncPatch, SchainPatchEnum::ClearPartialReceiptsPatch,
-    SchainPatchEnum::InvalidTransactionFormatPatch
+    SchainPatchEnum::InvalidTransactionFormatPatch, SchainPatchEnum::CurrentBlockRandomPatch
 };
 const std::unordered_set< SchainPatchEnum > SchainPatch::preDisabledForMIRAGE = {
     SchainPatchEnum::RevertableFSPatch, SchainPatchEnum::FlexibleDeploymentPatch,

--- a/libethereum/SchainPatch.h
+++ b/libethereum/SchainPatch.h
@@ -171,4 +171,10 @@ DEFINE_SIMPLE_PATCH( ClearPartialReceiptsPatch );
  */
 DEFINE_SIMPLE_PATCH( InvalidTransactionFormatPatch );
 
+/*
+ * Purpose: using current block in getBlockRandom
+ * Version introduced: 4.1.0
+ */
+DEFINE_SIMPLE_PATCH( CurrentBlockRandomPatch );
+
 #endif  // SCHAINPATCH_H

--- a/libethereum/SchainPatchEnum.h
+++ b/libethereum/SchainPatchEnum.h
@@ -22,6 +22,7 @@ enum class SchainPatchEnum {
     ExternalGasPatch,
     ClearPartialReceiptsPatch,
     InvalidTransactionFormatPatch,
+    CurrentBlockRandomPatch,
     PatchesCount
 };
 

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -979,6 +979,9 @@ u256 SkaleHost::getGasPrice( unsigned _blockNumber ) const {
 }
 
 u256 SkaleHost::getBlockRandom() const {
+    if ( CurrentBlockRandomPatch::isEnabledInWorkingBlock() ) {
+        return m_consensus->getRandomForBlockId( m_client.pendingInfo().number() );
+    }
     return m_consensus->getRandomForBlockId( m_client.number() );
 }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/skalenetwork/internal-support/issues/1294

- Introduces new patch `CurrentBlockRandomPatch` 
- Patch will be enabled by default for FAIR build

## Tests

- Tested on 1-node skaled
- Steps to verify the fix are described here: https://github.com/skalenetwork/internal-support/issues/1294#issuecomment-3271851017

## Performance Impact

No impact 
