### PR TITLE
Bug/2280 wrong group index on start

### DIFF
--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -1406,7 +1406,6 @@ void Client::initHistoricGroupIndex() {
     auto nodeGroups = chainParams().getNodeGroups();
 
     uint64_t currentBlockTimestamp = blockInfo( hashFromNumber( number() ) ).timestamp();
-    uint64_t previousBlockTimestamp = blockInfo( hashFromNumber( number() - 1 ) ).timestamp();
 
     // always returns it != end() because current finish ts equals to uint64_t(-1)
     auto it = std::find_if( nodeGroups.begin(), nodeGroups.end(),
@@ -1418,11 +1417,14 @@ void Client::initHistoricGroupIndex() {
             std::runtime_error( "Assertion failed: it == chainParams().sChain.nodeGroups.end()" ) );
     }
 
-    if ( it != nodeGroups.begin() ) {
-        auto prevIt = std::prev( it );
-        if ( currentBlockTimestamp >= prevIt->finishTs &&
-             previousBlockTimestamp < prevIt->finishTs )
-            it = prevIt;
+    if ( !GroupIndexInitPatch::isEnabledInWorkingBlock() ) {
+        uint64_t previousBlockTimestamp = blockInfo( hashFromNumber( number() - 1 ) ).timestamp();
+        if ( it != nodeGroups.begin() ) {
+            auto prevIt = std::prev( it );
+            if ( currentBlockTimestamp >= prevIt->finishTs &&
+                 previousBlockTimestamp < prevIt->finishTs )
+                it = prevIt;
+        }
     }
 
     historicGroupIndex = std::distance( nodeGroups.begin(), it );

--- a/libethereum/SchainPatch.cpp
+++ b/libethereum/SchainPatch.cpp
@@ -44,6 +44,8 @@ SchainPatchEnum getEnumForPatchName( const std::string& _patchName ) {
         return SchainPatchEnum::InvalidTransactionFormatPatch;
     else if ( _patchName == "CurrentBlockRandomPatch" )
         return SchainPatchEnum::CurrentBlockRandomPatch;
+    else if ( _patchName == "GroupIndexInitPatch" )
+        return SchainPatchEnum::GroupIndexInitPatch;
     else
         throw std::out_of_range( _patchName );
 }
@@ -86,6 +88,8 @@ std::string getPatchNameForEnum( SchainPatchEnum _enumValue ) {
         return "InvalidTransactionFormatPatch";
     case SchainPatchEnum::CurrentBlockRandomPatch:
         return "CurrentBlockRandomPatch";
+    case SchainPatchEnum::GroupIndexInitPatch:
+        return "GroupIndexInitPatch";
     default:
         throw std::out_of_range(
             "UnknownPatch #" + std::to_string( static_cast< size_t >( _enumValue ) ) );
@@ -100,7 +104,8 @@ const std::unordered_set< SchainPatchEnum > SchainPatch::preEnabledForFAIR = {
     SchainPatchEnum::SkipInvalidTransactionsPatch, SchainPatchEnum::VerifyDaSigsPatch,
     SchainPatchEnum::FastConsensusPatch, SchainPatchEnum::EIP1559TransactionsPatch,
     SchainPatchEnum::VerifyBlsSyncPatch, SchainPatchEnum::ClearPartialReceiptsPatch,
-    SchainPatchEnum::InvalidTransactionFormatPatch, SchainPatchEnum::CurrentBlockRandomPatch
+    SchainPatchEnum::InvalidTransactionFormatPatch, SchainPatchEnum::CurrentBlockRandomPatch,
+    SchainPatchEnum::GroupIndexInitPatch
 };
 const std::unordered_set< SchainPatchEnum > SchainPatch::preDisabledForFAIR = {
     SchainPatchEnum::RevertableFSPatch, SchainPatchEnum::FlexibleDeploymentPatch,

--- a/libethereum/SchainPatch.h
+++ b/libethereum/SchainPatch.h
@@ -181,6 +181,7 @@ DEFINE_SIMPLE_PATCH( CurrentBlockRandomPatch );
  * Context: fix group index initialization on startup
  * if skaled exits after the first block after rotation timestamp
  * then it starts again and initializes with wrong group index
+ * Version introduced: 4.1.0
  */
 DEFINE_AMNESIC_PATCH( GroupIndexInitPatch );
 

--- a/libethereum/SchainPatch.h
+++ b/libethereum/SchainPatch.h
@@ -177,4 +177,11 @@ DEFINE_SIMPLE_PATCH( InvalidTransactionFormatPatch );
  */
 DEFINE_SIMPLE_PATCH( CurrentBlockRandomPatch );
 
+/*
+ * Context: fix group index initialization on startup
+ * if skaled exits after the first block after rotation timestamp
+ * then it starts again and initializes with wrong group index
+ */
+DEFINE_AMNESIC_PATCH( GroupIndexInitPatch );
+
 #endif  // SCHAINPATCH_H

--- a/libethereum/SchainPatchEnum.h
+++ b/libethereum/SchainPatchEnum.h
@@ -23,6 +23,7 @@ enum class SchainPatchEnum {
     ClearPartialReceiptsPatch,
     InvalidTransactionFormatPatch,
     CurrentBlockRandomPatch,
+    GroupIndexInitPatch,
     PatchesCount
 };
 


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skaled/issues/2280

if skaled exited right after the rotation was completed, then on startup it initialised with wrong group index. 

for L2 the bug was silent because the scenario to reproduce it is hard to make - the fix requires patch timestamp to make sure the existing chains won't be affected
for FAIR patch timestamp will be enabled by default

tested on local machine - bug was present for both L2 and FAIR builds

