### PR TITLE
#2291 fix historic calls execution for rng

### DIFF
--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -71,11 +71,13 @@ public:
         return m_cost( _in, _chainParams, _blockNumber );
     }
 #ifdef FAIR
-    std::pair< bool, bytes > execute( bytesConstRef _in ) const { return m_execute( _in ); }
+    std::pair< bool, bytes > execute( bytesConstRef _in, const u256& _bn ) const {
+        return m_execute( _in, _bn );
+    }
 #else
     std::pair< bool, bytes > execute(
-        bytesConstRef _in, skale::OverlayFS* _overlayFS = nullptr ) const {
-        return m_execute( _in, _overlayFS );
+        bytesConstRef _in, cosnt u256& _bn, skale::OverlayFS* _overlayFS = nullptr ) const {
+        return m_execute( _in, _bn, _overlayFS );
     }
 #endif
 
@@ -340,13 +342,13 @@ public:
 
 #ifdef FAIR
     std::pair< bool, bytes > executePrecompiled(
-        Address const& _a, bytesConstRef _in, u256 const& ) const {
-        return precompiled.at( _a ).execute( _in );
+        Address const& _a, bytesConstRef _in, u256 const& _bn ) const {
+        return precompiled.at( _a ).execute( _in, _bn );
     }
 #else
-    std::pair< bool, bytes > executePrecompiled( Address const& _a, bytesConstRef _in, u256 const&,
-        skale::OverlayFS* _overlayFS = nullptr ) const {
-        return precompiled.at( _a ).execute( _in, _overlayFS );
+    std::pair< bool, bytes > executePrecompiled( Address const& _a, bytesConstRef _in,
+        u256 const& _bn, skale::OverlayFS* _overlayFS = nullptr ) const {
+        return precompiled.at( _a ).execute( _in, _bn, _overlayFS );
     }
 #endif
 

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -76,7 +76,7 @@ public:
     }
 #else
     std::pair< bool, bytes > execute(
-        bytesConstRef _in, cosnt u256& _bn, skale::OverlayFS* _overlayFS = nullptr ) const {
+        bytesConstRef _in, const u256& _bn, skale::OverlayFS* _overlayFS = nullptr ) const {
         return m_execute( _in, _bn, _overlayFS );
     }
 #endif

--- a/libethcore/SealEngine.h
+++ b/libethcore/SealEngine.h
@@ -107,8 +107,8 @@ public:
         return m_params.getPrecompiledContract( _a ).cost( _in, m_params, _blockNumber );
     }
     virtual std::pair< bool, bytes > executePrecompiled(
-        Address const& _a, bytesConstRef _in, u256 const& ) const {
-        return m_params.getPrecompiledContract( _a ).execute( _in );
+        Address const& _a, bytesConstRef _in, u256 const& _bn ) const {
+        return m_params.getPrecompiledContract( _a ).execute( _in, _bn );
     }
 
     virtual bool precompiledExecutionAllowedFrom(

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -86,7 +86,7 @@ PrecompiledPricer const& PrecompiledRegistrar::pricer( std::string const& _name 
 
 namespace {
 
-ETH_REGISTER_PRECOMPILED( ecrecover )( bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( ecrecover )( bytesConstRef _in, const dev::u256& ) {
     struct {
         h256 hash;
         h256 v;
@@ -114,15 +114,15 @@ ETH_REGISTER_PRECOMPILED( ecrecover )( bytesConstRef _in ) {
     return { true, {} };
 }
 
-ETH_REGISTER_PRECOMPILED( sha256 )( bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( sha256 )( bytesConstRef _in, const dev::u256& ) {
     return { true, dev::sha256( _in ).asBytes() };
 }
 
-ETH_REGISTER_PRECOMPILED( ripemd160 )( bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( ripemd160 )( bytesConstRef _in, const dev::u256& ) {
     return { true, h256( dev::ripemd160( _in ), h256::AlignRight ).asBytes() };
 }
 
-ETH_REGISTER_PRECOMPILED( identity )( bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( identity )( bytesConstRef _in, const dev::u256& ) {
     MICROPROFILE_SCOPEI( "VM", "identity", MP_RED );
     return { true, _in.toBytes() };
 }
@@ -149,7 +149,7 @@ bigint parseBigEndianRightPadded( bytesConstRef _in, bigint const& _begin, bigin
     return ret;
 }
 
-ETH_REGISTER_PRECOMPILED( modexp )( bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( modexp )( bytesConstRef _in, const dev::u256& ) {
     bigint const baseLength( parseBigEndianRightPadded( _in, 0, 32 ) );
     bigint const expLength( parseBigEndianRightPadded( _in, 32, 32 ) );
     bigint const modLength( parseBigEndianRightPadded( _in, 64, 32 ) );
@@ -208,7 +208,7 @@ ETH_REGISTER_PRECOMPILED_PRICER( modexp )
     return multComplexity( maxLength ) * max< bigint >( adjustedExpLength, 1 ) / 20;
 }
 
-ETH_REGISTER_PRECOMPILED( alt_bn128_G1_add )( bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( alt_bn128_G1_add )( bytesConstRef _in, const dev::u256& ) {
     return dev::crypto::alt_bn128_G1_add( _in );
 }
 
@@ -217,7 +217,7 @@ ETH_REGISTER_PRECOMPILED_PRICER( alt_bn128_G1_add )
     return _blockNumber < _chainParams.getIstanbulForkBlock() ? 500 : 150;
 }
 
-ETH_REGISTER_PRECOMPILED( alt_bn128_G1_mul )( bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( alt_bn128_G1_mul )( bytesConstRef _in, const dev::u256& ) {
     return dev::crypto::alt_bn128_G1_mul( _in );
 }
 
@@ -226,7 +226,7 @@ ETH_REGISTER_PRECOMPILED_PRICER( alt_bn128_G1_mul )
     return _blockNumber < _chainParams.getIstanbulForkBlock() ? 40000 : 6000;
 }
 
-ETH_REGISTER_PRECOMPILED( alt_bn128_pairing_product )( bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( alt_bn128_pairing_product )( bytesConstRef _in, const dev::u256& ) {
     return dev::crypto::alt_bn128_pairing_product( _in );
 }
 
@@ -283,7 +283,8 @@ boost::filesystem::path getFileStorageDir( const Address& _address ) {
 }
 
 // TODO: check file name and file existance
-ETH_REGISTER_FS_PRECOMPILED( createFile )( bytesConstRef _in, skale::OverlayFS* _overlayFS ) {
+ETH_REGISTER_FS_PRECOMPILED( createFile )
+( bytesConstRef _in, const dev::u256&, skale::OverlayFS* _overlayFS ) {
     if ( !_overlayFS )
         throw runtime_error( "_overlayFS is nullptr " );
 
@@ -327,7 +328,8 @@ ETH_REGISTER_FS_PRECOMPILED( createFile )( bytesConstRef _in, skale::OverlayFS* 
     return { false, response };
 }
 
-ETH_REGISTER_FS_PRECOMPILED( uploadChunk )( bytesConstRef _in, skale::OverlayFS* _overlayFS ) {
+ETH_REGISTER_FS_PRECOMPILED( uploadChunk )
+( bytesConstRef _in, const dev::u256&, skale::OverlayFS* _overlayFS ) {
     if ( !_overlayFS )
         throw runtime_error( "_overlayFS is nullptr " );
 
@@ -375,7 +377,7 @@ ETH_REGISTER_FS_PRECOMPILED( uploadChunk )( bytesConstRef _in, skale::OverlayFS*
     return { false, response };
 }
 
-ETH_REGISTER_PRECOMPILED( readChunk )( bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( readChunk )( bytesConstRef _in, const dev::u256& ) {
     MICROPROFILE_SCOPEI( "VM", "readChunk", MP_ORANGERED );
     try {
         auto rawAddress = _in.cropped( 12, 20 ).toBytes();
@@ -426,7 +428,7 @@ ETH_REGISTER_PRECOMPILED( readChunk )( bytesConstRef _in ) {
     return { false, response };
 }
 
-ETH_REGISTER_PRECOMPILED( getFileSize )( bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( getFileSize )( bytesConstRef _in, const dev::u256& ) {
     try {
         auto rawAddress = _in.cropped( 12, 20 ).toBytes();
         std::string address;
@@ -459,7 +461,8 @@ ETH_REGISTER_PRECOMPILED( getFileSize )( bytesConstRef _in ) {
     return { false, response };
 }
 
-ETH_REGISTER_FS_PRECOMPILED( deleteFile )( bytesConstRef _in, skale::OverlayFS* _overlayFS ) {
+ETH_REGISTER_FS_PRECOMPILED( deleteFile )
+( bytesConstRef _in, const dev::u256&, skale::OverlayFS* _overlayFS ) {
     if ( !_overlayFS )
         throw runtime_error( "_overlayFS is nullptr " );
 
@@ -492,7 +495,8 @@ ETH_REGISTER_FS_PRECOMPILED( deleteFile )( bytesConstRef _in, skale::OverlayFS* 
     return { false, response };
 }
 
-ETH_REGISTER_FS_PRECOMPILED( createDirectory )( bytesConstRef _in, skale::OverlayFS* _overlayFS ) {
+ETH_REGISTER_FS_PRECOMPILED( createDirectory )
+( bytesConstRef _in, const dev::u256&, skale::OverlayFS* _overlayFS ) {
     if ( !_overlayFS )
         throw runtime_error( "_overlayFS is nullptr " );
 
@@ -523,7 +527,8 @@ ETH_REGISTER_FS_PRECOMPILED( createDirectory )( bytesConstRef _in, skale::Overla
     return { false, response };
 }
 
-ETH_REGISTER_FS_PRECOMPILED( deleteDirectory )( bytesConstRef _in, skale::OverlayFS* _overlayFS ) {
+ETH_REGISTER_FS_PRECOMPILED( deleteDirectory )
+( bytesConstRef _in, const dev::u256&, skale::OverlayFS* _overlayFS ) {
     if ( !_overlayFS )
         throw runtime_error( "_overlayFS is nullptr " );
 
@@ -562,7 +567,7 @@ ETH_REGISTER_FS_PRECOMPILED( deleteDirectory )( bytesConstRef _in, skale::Overla
 }
 
 ETH_REGISTER_FS_PRECOMPILED( calculateFileHash )
-( bytesConstRef _in, skale::OverlayFS* _overlayFS ) {
+( bytesConstRef _in, const dev::u256&, skale::OverlayFS* _overlayFS ) {
     try {
         auto rawAddress = _in.cropped( 12, 20 ).toBytes();
         std::string address;
@@ -597,7 +602,7 @@ ETH_REGISTER_FS_PRECOMPILED( calculateFileHash )
     return { false, response };
 }
 
-ETH_REGISTER_PRECOMPILED( logTextMessage )( bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( logTextMessage )( bytesConstRef _in, const dev::u256& ) {
     try {
         if ( !g_configAccesssor )
             throw std::runtime_error( "Config accessor was not initialized" );
@@ -808,7 +813,7 @@ static std::pair< std::string, unsigned > parseHistoricFieldRequest( std::string
  * so one should pass the following as calldata:
  * toBytes( input.length + toBytes(input) )
  */
-ETH_REGISTER_PRECOMPILED( getConfigVariableUint256 )( bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( getConfigVariableUint256 )( bytesConstRef _in, const dev::u256& ) {
     try {
         size_t lengthName;
         std::string rawName;
@@ -865,7 +870,7 @@ ETH_REGISTER_PRECOMPILED( getConfigVariableUint256 )( bytesConstRef _in ) {
     return { false, response };  // 1st false - means bad error occur
 }
 
-ETH_REGISTER_PRECOMPILED( getConfigVariableAddress )( bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( getConfigVariableAddress )( bytesConstRef _in, const dev::u256& ) {
     try {
         size_t lengthName;
         std::string rawName;
@@ -919,7 +924,7 @@ ETH_REGISTER_PRECOMPILED( getConfigVariableAddress )( bytesConstRef _in ) {
  * so one should pass the following as calldata
  * toBytes( input.length + toBytes(input) )
  */
-ETH_REGISTER_PRECOMPILED( getConfigVariableString )( bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( getConfigVariableString )( bytesConstRef _in, const dev::u256& ) {
     try {
         size_t lengthName;
         std::string rawName;
@@ -972,7 +977,7 @@ ETH_REGISTER_PRECOMPILED( getConfigVariableString )( bytesConstRef _in ) {
 }
 
 
-ETH_REGISTER_PRECOMPILED( fnReserved0x16 )( bytesConstRef /*_in*/ ) {
+ETH_REGISTER_PRECOMPILED( fnReserved0x16 )( bytesConstRef, const dev::u256& ) {
     u256 code = 0;
     bytes response = toBigEndian( code );
     return { false, response };  // 1st false - means bad error occur
@@ -988,7 +993,7 @@ static dev::u256 stat_s2a( const std::string& saIn ) {
     return u;
 }
 
-ETH_REGISTER_PRECOMPILED( getConfigPermissionFlag )( bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( getConfigPermissionFlag )( bytesConstRef _in, const dev::u256& ) {
     try {
         dev::u256 uValue;
         uValue = 0;
@@ -1051,11 +1056,11 @@ ETH_REGISTER_PRECOMPILED( getConfigPermissionFlag )( bytesConstRef _in ) {
 }
 #endif
 
-ETH_REGISTER_PRECOMPILED( getBlockRandom )( bytesConstRef ) {
+ETH_REGISTER_PRECOMPILED( getBlockRandom )( bytesConstRef, const dev::u256& _bn ) {
     try {
         if ( !g_skaleHost )
             throw std::runtime_error( "SkaleHost accessor was not initialized" );
-        dev::u256 uValue = g_skaleHost->getBlockRandom();
+        dev::u256 uValue = g_skaleHost->getBlockRandom( _bn.convert_to< unsigned >() );
         bytes response = toBigEndian( uValue );
         return { true, response };
     } catch ( std::exception& ex ) {
@@ -1073,14 +1078,14 @@ ETH_REGISTER_PRECOMPILED( getBlockRandom )( bytesConstRef ) {
 }
 
 #ifndef FAIR
-ETH_REGISTER_PRECOMPILED( addBalance )( [[maybe_unused]] bytesConstRef _in ) {
+ETH_REGISTER_PRECOMPILED( addBalance )( [[maybe_unused]] bytesConstRef _in, const dev::u256& ) {
     dev::u256 code = 0;
     bytes response = toBigEndian( code );
     return { false, response };  // 1st false - means bad error occur
 }
 
 
-ETH_REGISTER_PRECOMPILED( getIMABLSPublicKey )( bytesConstRef ) {
+ETH_REGISTER_PRECOMPILED( getIMABLSPublicKey )( bytesConstRef, const dev::u256& ) {
     try {
         if ( !g_skaleHost )
             throw std::runtime_error( "SkaleHost accessor was not initialized" );

--- a/libethereum/Precompiled.h
+++ b/libethereum/Precompiled.h
@@ -85,7 +85,7 @@ private:
     std::function< std::pair< bool, bytes >( bytesConstRef _in, const u256& _bn ) > proxy;
 #else
     std::function< std::pair< bool, bytes >(
-        bytesConstRef _in, , const u256& _bn, skale::OverlayFS* _overlayFS ) >
+        bytesConstRef _in, const u256& _bn, skale::OverlayFS* _overlayFS ) >
         proxy;
 #endif
 };

--- a/libethereum/Precompiled.h
+++ b/libethereum/Precompiled.h
@@ -59,29 +59,33 @@ struct ChainOperationParams;
 class PrecompiledExecutor {
 public:
 #ifdef FAIR
-    std::pair< bool, bytes > operator()( bytesConstRef _in ) const { return proxy( _in ); }
+    std::pair< bool, bytes > operator()( bytesConstRef _in, const u256& _bn ) const {
+        return proxy( _in, _bn );
+    }
 #else
     std::pair< bool, bytes > operator()(
-        bytesConstRef _in, skale::OverlayFS* _overlayFS = nullptr ) const {
-        return proxy( _in, _overlayFS );
+        bytesConstRef _in, const u256& _bn, skale::OverlayFS* _overlayFS = nullptr ) const {
+        return proxy( _in, _bn, _overlayFS );
     }
 #endif
     PrecompiledExecutor() {}
 #ifdef FAIR
     PrecompiledExecutor(
-        const std::function< std::pair< bool, bytes >( bytesConstRef _in ) >& _func )
+        const std::function< std::pair< bool, bytes >( bytesConstRef _in, const u256& _bn ) >&
+            _func )
         : proxy( _func ) {}
 #else
     PrecompiledExecutor( const std::function< std::pair< bool, bytes >(
-            bytesConstRef _in, skale::OverlayFS* _overlayFS ) >& _func )
+            bytesConstRef _in, const u256& _bn, skale::OverlayFS* _overlayFS ) >& _func )
         : proxy( _func ) {}
 #endif
 
 private:
 #ifdef FAIR
-    std::function< std::pair< bool, bytes >( bytesConstRef _in ) > proxy;
+    std::function< std::pair< bool, bytes >( bytesConstRef _in, const u256& _bn ) > proxy;
 #else
-    std::function< std::pair< bool, bytes >( bytesConstRef _in, skale::OverlayFS* _overlayFS ) >
+    std::function< std::pair< bool, bytes >(
+        bytesConstRef _in, , const u256& _bn, skale::OverlayFS* _overlayFS ) >
         proxy;
 #endif
 };
@@ -129,30 +133,33 @@ private:
 };
 
 #ifdef FAIR
-#define ETH_REGISTER_PRECOMPILED( Name )                                                          \
-    static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name( bytesConstRef _in ); \
-    static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =                           \
-        ::dev::eth::PrecompiledRegistrar::registerExecutor(                                       \
-            #Name, PrecompiledExecutor( []( bytesConstRef _in ) -> std::pair< bool, bytes > {     \
-                return __eth_registerPrecompiledFunction##Name( _in );                            \
-            } ) );                                                                                \
+#define ETH_REGISTER_PRECOMPILED( Name )                                                      \
+    static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name(                  \
+        bytesConstRef _in, const u256& _bn );                                                 \
+    static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =                       \
+        ::dev::eth::PrecompiledRegistrar::registerExecutor(                                   \
+            #Name, PrecompiledExecutor(                                                       \
+                       []( bytesConstRef _in, const u256& _bn ) -> std::pair< bool, bytes > { \
+                           return __eth_registerPrecompiledFunction##Name( _in, _bn );        \
+                       } ) );                                                                 \
     static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name
 #else
-// ignore _overlayFS param and call registered function with 1 parameter
+// ignore _overlayFS param and call registered function with 2 parameters
 // TODO: unregister on unload with a static object.
-#define ETH_REGISTER_PRECOMPILED( Name )                                                          \
-    static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name( bytesConstRef _in ); \
-    static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =                           \
-        ::dev::eth::PrecompiledRegistrar::registerExecutor(                                       \
-            #Name, PrecompiledExecutor(                                                           \
-                       []( bytesConstRef _in, skale::OverlayFS* ) -> std::pair< bool, bytes > {   \
-                           return __eth_registerPrecompiledFunction##Name( _in );                 \
-                       } ) );                                                                     \
+#define ETH_REGISTER_PRECOMPILED( Name )                                                      \
+    static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name(                  \
+        bytesConstRef _in, const u256& _bn );                                                 \
+    static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =                       \
+        ::dev::eth::PrecompiledRegistrar::registerExecutor(                                   \
+            #Name, PrecompiledExecutor( []( bytesConstRef _in, const u256& _bn,               \
+                                            skale::OverlayFS* ) -> std::pair< bool, bytes > { \
+                return __eth_registerPrecompiledFunction##Name( _in, _bn );                   \
+            } ) );                                                                            \
     static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name
 
 #define ETH_REGISTER_FS_PRECOMPILED( Name )                                           \
     static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name(          \
-        bytesConstRef _in, skale::OverlayFS* _overlayFS );                            \
+        bytesConstRef _in, const u256& _bn, skale::OverlayFS* _overlayFS );           \
     static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =               \
         ::dev::eth::PrecompiledRegistrar::registerExecutor(                           \
             #Name, PrecompiledExecutor( &__eth_registerPrecompiledFunction##Name ) ); \

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -978,9 +978,9 @@ u256 SkaleHost::getGasPrice( unsigned _blockNumber ) const {
     return m_consensus->getPriceForBlockId( _blockNumber );
 }
 
-u256 SkaleHost::getBlockRandom() const {
+u256 SkaleHost::getBlockRandom( unsigned _blockNumber ) const {
     if ( CurrentBlockRandomPatch::isEnabledInWorkingBlock() ) {
-        return m_consensus->getRandomForBlockId( m_client.pendingInfo().number() );
+        return m_consensus->getRandomForBlockId( _blockNumber );
     }
     return m_consensus->getRandomForBlockId( m_client.number() );
 }

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -980,6 +980,10 @@ u256 SkaleHost::getGasPrice( unsigned _blockNumber ) const {
 
 u256 SkaleHost::getBlockRandom( unsigned _blockNumber ) const {
     if ( CurrentBlockRandomPatch::isEnabledInWorkingBlock() ) {
+        if ( _blockNumber > m_client.number() )
+            // cant get info about future blocks
+            // only possible if responding eth_call or eth_estimateGas request
+            _blockNumber = m_client.number();
         return m_consensus->getRandomForBlockId( _blockNumber );
     }
     return m_consensus->getRandomForBlockId( m_client.number() );

--- a/libethereum/SkaleHost.h
+++ b/libethereum/SkaleHost.h
@@ -132,7 +132,7 @@ public:
     void pushToBroadcastQueue( const dev::eth::Transaction& _transaction );
 
     dev::u256 getGasPrice( unsigned _blockNumber = dev::eth::LatestBlock ) const;
-    dev::u256 getBlockRandom() const;
+    dev::u256 getBlockRandom( unsigned _blockNumber = dev::eth::LatestBlock ) const;
     dev::eth::SyncStatus syncStatus() const;
     std::map< std::string, uint64_t > getConsensusDbUsage() const;
     std::array< std::string, 4 > getCurrentBLSPublicKey() const;

--- a/libethereum/SkaleHost.h
+++ b/libethereum/SkaleHost.h
@@ -132,7 +132,7 @@ public:
     void pushToBroadcastQueue( const dev::eth::Transaction& _transaction );
 
     dev::u256 getGasPrice( unsigned _blockNumber = dev::eth::LatestBlock ) const;
-    dev::u256 getBlockRandom( unsigned _blockNumber = dev::eth::LatestBlock ) const;
+    dev::u256 getBlockRandom( unsigned _blockNumber ) const;
     dev::eth::SyncStatus syncStatus() const;
     std::map< std::string, uint64_t > getConsensusDbUsage() const;
     std::array< std::string, 4 > getCurrentBLSPublicKey() const;

--- a/libhistoric/AlethExecutive.cpp
+++ b/libhistoric/AlethExecutive.cpp
@@ -135,7 +135,6 @@ bool AlethExecutive::execute() {
     bytes const& dataToPassToEvm = m_t.data();
     Address receiverAddressToPassToEvm = m_t.receiveAddress();
 #endif
-    LOG( m_loggerTrace ) << "Data: " << dev::toHexPrefixed( dataToPassToEvm ) << " Address: " << m_t.sender().hex();
 
     assert( m_t.gas() >= ( u256 ) m_baseGasRequired );
     if ( m_t.isCreation() )
@@ -356,7 +355,6 @@ bool AlethExecutive::go( OnOpFunc const& _onOp ) {
         } catch ( RevertInstruction& _e ) {
             revert();
             m_output = _e.output();
-            LOG( m_loggerTrace ) << "EVM output: " << dev::toHexPrefixed(m_output);
             m_excepted = TransactionException::RevertInstruction;
         } catch ( VMException const& _e ) {
             LOG( m_loggerTrace ) << "Safe VM Exception. " << diagnostic_information( _e );

--- a/libhistoric/AlethExecutive.cpp
+++ b/libhistoric/AlethExecutive.cpp
@@ -135,6 +135,7 @@ bool AlethExecutive::execute() {
     bytes const& dataToPassToEvm = m_t.data();
     Address receiverAddressToPassToEvm = m_t.receiveAddress();
 #endif
+    LOG( m_loggerTrace ) << "Data: " << dev::toHexPrefixed( dataToPassToEvm ) << " Address: " << m_t.sender().hex();
 
     assert( m_t.gas() >= ( u256 ) m_baseGasRequired );
     if ( m_t.isCreation() )
@@ -355,6 +356,7 @@ bool AlethExecutive::go( OnOpFunc const& _onOp ) {
         } catch ( RevertInstruction& _e ) {
             revert();
             m_output = _e.output();
+            LOG( m_loggerTrace ) << "EVM output: " << dev::toHexPrefixed(m_output);
             m_excepted = TransactionException::RevertInstruction;
         } catch ( VMException const& _e ) {
             LOG( m_loggerTrace ) << "Safe VM Exception. " << diagnostic_information( _e );

--- a/test/unittests/libethereum/PrecompiledTest.cpp
+++ b/test/unittests/libethereum/PrecompiledTest.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE( modexpFermatTheorem,
         "03"
         "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2e"
         "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ) );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "0000000000000000000000000000000000000000000000000000000000000001" );
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE( modexpZeroBase,
         "0000000000000000000000000000000000000000000000000000000000000020"
         "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2e"
         "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ) );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "0000000000000000000000000000000000000000000000000000000000000000" );
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE( modexpExtraByteIgnored,
         "ffff"
         "8000000000000000000000000000000000000000000000000000000000000000"
         "07" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ) );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "3b01b01ac41f2d6e917c6d6a221ce793802469026d9ab7578fa2e79e4da6aaab" );
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE( modexpRightPadding,
         "03"
         "ffff"
         "80" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ) );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "3b01b01ac41f2d6e917c6d6a221ce793802469026d9ab7578fa2e79e4da6aaab" );
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE( modexpMissingValues ) {
         "0000000000000000000000000000000000000000000000000000000000000002"
         "0000000000000000000000000000000000000000000000000000000000000020"
         "03" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ) );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "0000000000000000000000000000000000000000000000000000000000000000" );
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE( modexpEmptyValue,
         "0000000000000000000000000000000000000000000000000000000000000020"
         "03"
         "8000000000000000000000000000000000000000000000000000000000000000" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ) );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "0000000000000000000000000000000000000000000000000000000000000001" );
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE( modexpZeroPowerZero,
         "00"
         "00"
         "80" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ) );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "0000000000000000000000000000000000000000000000000000000000000001" );
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE( modexpZeroPowerZeroModZero,
         "00"
         "00"
         "00" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ) );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "0000000000000000000000000000000000000000000000000000000000000000" );
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE( modexpModLengthZero,
         "0000000000000000000000000000000000000000000000000000000000000000"
         "01"
         "01" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ) );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( res.second.empty() );
@@ -1459,13 +1459,13 @@ void benchmarkPrecompiled( char const name[], vector_ref< const PrecompiledTest 
         bytes input = fromHex( test.input );
         bytesConstRef inputRef = &input;
 
-        auto res = exec( inputRef );
+        auto res = exec( inputRef, 1 );
         BOOST_REQUIRE_MESSAGE( res.first, test.name );
         BOOST_REQUIRE_EQUAL( toHex( res.second ), test.expected );
 
         timer.restart();
         for ( int i = 0; i < n; ++i )
-            exec( inputRef );
+            exec( inputRef, 1 );
         auto d = timer.duration() / n;
 
         auto t = std::chrono::duration_cast< std::chrono::nanoseconds >( d ).count();
@@ -1744,7 +1744,7 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
     input = input.substr(0, 58); // remove 0s in the end
 
     bytes in = fromHex( numberToHex( 29 ) + input );
-    auto res = exec( bytesConstRef( in.data(), in.size() ) );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( dev::fromBigEndian<dev::u256>( res.second ) == 30 );
@@ -1752,7 +1752,7 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
     input = stringToHex( "skaleConfig.sChain.nodes.0.schainIndex" );
     input = input.substr(0, 76); // remove 0s in the end
     in = fromHex( numberToHex( 38 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ) );
+    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( dev::fromBigEndian<dev::u256>( res.second ) == 13 );
@@ -1760,21 +1760,21 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
     input = stringToHex( "skaleConfig.sChain.nodes.0.publicKey" );
     input = input.substr(0, 72); // remove 0s in the end
     in = fromHex( numberToHex( 36 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ) );
+    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( !res.first );
 
     input = stringToHex( "skaleConfig.sChain.nodes.0.unknownField" );
     input = input.substr(0, 78); // remove 0s in the end
     in = fromHex( numberToHex( 39 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ) );
+    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( !res.first );
 
     input = stringToHex( "skaleConfig.nodeInfo.wallets.ima.n" );
     input = input.substr(0, 68); // remove 0s in the end
     in = fromHex( numberToHex( 34 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ) );
+    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( dev::fromBigEndian<dev::u256>( res.second ) == 1 );
@@ -1782,7 +1782,7 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
     input = stringToHex( "skaleConfig.nodeInfo.wallets.ima.t" );
     input = input.substr(0, 68); // remove 0s in the end
     in = fromHex( numberToHex( 34 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ) );
+    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( !res.first );
 
@@ -1791,7 +1791,7 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
     input = stringToHex( "skaleConfig.sChain.nodes.0.publicKey" );
     input = input.substr(0, 72); // remove 0s in the end
     in = fromHex( numberToHex( 36 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ) );
+    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( res.second == fromHex("0x6180cde2cbbcc6b6a17efec4503a7d4316f8612f411ee171587089f770335f484003ad236c534b9afa82befc1f69533723abdb6ec2601e582b72dcfd7919338b") );
@@ -1800,21 +1800,21 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
     input = input.substr(0, 58); // remove 0s in the end
 
     in = fromHex( numberToHex( 29 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ) );
+    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( !res.first );
 
     input = stringToHex( "skaleConfig.sChain.nodes.0.schainIndex" );
     input = input.substr(0, 76); // remove 0s in the end
     in = fromHex( numberToHex( 38 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ) );
+    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( !res.first );
 
     input = stringToHex( "skaleConfig.sChain.nodes.0.unknownField" );
     input = input.substr(0, 78); // remove 0s in the end
     in = fromHex( numberToHex( 39 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ) );
+    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
 
     BOOST_REQUIRE( !res.first );
 }
@@ -1869,7 +1869,7 @@ BOOST_AUTO_TEST_CASE( createFile ) {
 
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
                         numberToHex( fileSize ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
 
     BOOST_REQUIRE( res.first );
 
@@ -1887,7 +1887,7 @@ BOOST_AUTO_TEST_CASE( fileWithHashExtension ) {
 
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
             numberToHex( fileSize ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
     BOOST_REQUIRE( res.first == false);
 
     m_overlayFS->commit();
@@ -1900,7 +1900,7 @@ BOOST_AUTO_TEST_CASE( uploadChunk ) {
     std::string data = "random_data";
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
                         numberToHex( 0 ) + numberToHex( data.length() ) + stringToHex( data ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
     BOOST_REQUIRE( res.first );
 
     m_overlayFS->commit();
@@ -1916,7 +1916,7 @@ BOOST_AUTO_TEST_CASE( readChunk ) {
 
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
                         numberToHex( 0 ) + numberToHex( fileSize ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
     BOOST_REQUIRE( res.first );
 
     std::ifstream file( pathToFile.c_str(), std::ios_base::binary );
@@ -1933,7 +1933,7 @@ BOOST_AUTO_TEST_CASE( readMaliciousChunk ) {
     fileName = "../../test";
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
                         numberToHex( 0 ) + numberToHex( fileSize ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
     BOOST_REQUIRE( res.first == false);
 }
 
@@ -1941,7 +1941,7 @@ BOOST_AUTO_TEST_CASE( getFileSize ) {
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "getFileSize" );
 
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( res.second == toBigEndian( static_cast< u256 >( fileSize ) ) );
 }
@@ -1952,7 +1952,7 @@ BOOST_AUTO_TEST_CASE( getMaliciousFileSize ) {
     fileName = "../../test";
 
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
     BOOST_REQUIRE( !res.first );
 }
 
@@ -1960,20 +1960,20 @@ BOOST_AUTO_TEST_CASE( deleteFile ) {
     PrecompiledExecutor execCreate = PrecompiledRegistrar::executor( "createFile" );
     bytes inCreate = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
                             numberToHex( fileSize ) );
-    execCreate( bytesConstRef( inCreate.data(), inCreate.size() ), m_overlayFS.get() );
+    execCreate( bytesConstRef( inCreate.data(), inCreate.size() ), 1, m_overlayFS.get() );
     m_overlayFS->commit();
 
     PrecompiledExecutor execHash = PrecompiledRegistrar::executor( "calculateFileHash" );
     bytes inHash = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
                         numberToHex( fileSize ) );
-    execHash( bytesConstRef( inHash.data(), inHash.size() ), m_overlayFS.get() );
+    execHash( bytesConstRef( inHash.data(), inHash.size() ), 1, m_overlayFS.get() );
     m_overlayFS->commit();
 
     BOOST_REQUIRE( boost::filesystem::exists( pathToFile.string() + "._hash" ) );
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "deleteFile" );
 
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
     BOOST_REQUIRE( res.first );
 
     m_overlayFS->commit();
@@ -1989,7 +1989,7 @@ BOOST_AUTO_TEST_CASE( createDirectory ) {
         dev::getDataDir() / "filestorage" / ownerAddress.hex() / dirName;
 
     bytes in = fromHex( hexAddress + numberToHex( dirName.length() ) + stringToHex( dirName ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
     BOOST_REQUIRE( res.first );
 
     m_overlayFS->commit();
@@ -2006,7 +2006,7 @@ BOOST_AUTO_TEST_CASE( deleteDirectory ) {
     boost::filesystem::create_directories( pathToDir );
 
     bytes in = fromHex( hexAddress + numberToHex( dirName.length() ) + stringToHex( dirName ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
 
     BOOST_REQUIRE( res.first );
 
@@ -2028,7 +2028,7 @@ BOOST_AUTO_TEST_CASE( calculateFileHash ) {
 
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
                         numberToHex( fileSize ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
 
     BOOST_REQUIRE( res.first );
 

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -1415,7 +1415,7 @@ BOOST_AUTO_TEST_CASE( getBlockRandom ) {
 
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "getBlockRandom" );
     auto res = exec( bytesConstRef(), 1 );
-    u256 blockRandom = skaleHost->getBlockRandom();
+    u256 blockRandom = skaleHost->getBlockRandom( 0 );
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( res.second == toBigEndian( static_cast< u256 >( blockRandom ) ) );
 }

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -1426,7 +1426,7 @@ BOOST_AUTO_TEST_CASE( getCurrentBLSPublicKey ) {
     auto& skaleHost = fixture.skaleHost;
 
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "getIMABLSPublicKey" );
-    auto res = exec( bytesConstRef() );
+    auto res = exec( bytesConstRef(), 1 );
     std::array< std::string, 4 > imaBLSPublicKey = skaleHost->getCurrentBLSPublicKey();
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( res.second == toBigEndian( dev::u256( imaBLSPublicKey[0] ) ) +

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -1414,7 +1414,7 @@ BOOST_AUTO_TEST_CASE( getBlockRandom ) {
     auto& skaleHost = fixture.skaleHost;
 
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "getBlockRandom" );
-    auto res = exec( bytesConstRef() );
+    auto res = exec( bytesConstRef(), 1 );
     u256 blockRandom = skaleHost->getBlockRandom();
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( res.second == toBigEndian( static_cast< u256 >( blockRandom ) ) );


### PR DESCRIPTION
fixes #2291 https://github.com/skalenetwork/skaled/issues/2284

added a new input parameter for precompiled contracts - block number
fixed historic calls / `eth_call` / `eth_estimateGas` execution for txn that include calls to rng precompiled contract