### PR TITLE
2271 Remove partial receipts in the beginning of the next block

### DIFF
--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -465,8 +465,7 @@ inline void Block::doPartialCatchupTestIfRequested( unsigned i ) {
     }
 }
 
-
-void Block::cleanupPartialTransactionReceiptsForPreviousBlock( BlockChain const& _bc ) {
+void Block::cleanupPartialTransactionReceiptsForPreviousBlock() {
     if ( KeepPartialReceiptsUntilNextBlockPatch::isEnabledWhen( m_previousBlock.timestamp() ) &&
          m_previousBlock.number() > 0 ) {
         m_state.safeRemovePartialTransactionReceiptsForBlock( m_previousBlock.number() );
@@ -510,7 +509,7 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
         }
     }
 
-    cleanupPartialTransactionReceiptsForPreviousBlock( _bc );
+    cleanupPartialTransactionReceiptsForPreviousBlock();
 
     for ( unsigned i = 0; i < _transactions.size(); ++i ) {
         Transaction const& tr = _transactions[i];

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -465,6 +465,14 @@ inline void Block::doPartialCatchupTestIfRequested( unsigned i ) {
     }
 }
 
+
+void Block::cleanupPartialTransactionReceiptsForPreviousBlock( BlockChain const& _bc ) {
+    if ( KeepPartialReceiptsUntilNextBlockPatch::isEnabledWhen( m_previousBlock.timestamp() ) &&
+         m_previousBlock.number() > 0 ) {
+        m_state.safeRemovePartialTransactionReceiptsForBlock( m_previousBlock.number() );
+    }
+}
+
 tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _bc,
     const Transactions& _transactions, uint64_t _timestamp, u256 _gasPrice ) {
     if ( isSealed() )
@@ -502,6 +510,7 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
         }
     }
 
+    cleanupPartialTransactionReceiptsForPreviousBlock( _bc );
 
     for ( unsigned i = 0; i < _transactions.size(); ++i ) {
         Transaction const& tr = _transactions[i];
@@ -595,7 +604,9 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
 #endif
 
     // we got to the end of the block so we do not need partial transaction receipts anymore
-    m_state.safeRemoveAllPartialTransactionReceipts();
+    if ( !KeepPartialReceiptsUntilNextBlockPatch::isEnabledWhen( m_previousBlock.timestamp() ) ) {
+        m_state.safeRemoveAllPartialTransactionReceipts();
+    }
 
     // since we committed changes corresponding to a particular block
     // we need to create a new readonly snap

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -466,7 +466,7 @@ inline void Block::doPartialCatchupTestIfRequested( unsigned i ) {
 }
 
 void Block::cleanupPartialTransactionReceiptsForPreviousBlock() {
-    if ( KeepPartialReceiptsUntilNextBlockPatch::isEnabledWhen( m_previousBlock.timestamp() ) &&
+    if ( KeepPartialReceiptsUntilNextBlockPatch::isEnabledInWorkingBlock() &&
          m_previousBlock.number() > 0 ) {
         LOG( m_loggerDebug ) << "Removing partial transaction receipts for block "
                              << m_previousBlock.number();
@@ -610,7 +610,7 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
 #endif
 
     // we got to the end of the block so we do not need partial transaction receipts anymore
-    if ( !KeepPartialReceiptsUntilNextBlockPatch::isEnabledWhen( m_previousBlock.timestamp() ) ) {
+    if ( !KeepPartialReceiptsUntilNextBlockPatch::isEnabledInWorkingBlock() ) {
         m_state.safeRemoveAllPartialTransactionReceipts();
     }
 

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -468,7 +468,14 @@ inline void Block::doPartialCatchupTestIfRequested( unsigned i ) {
 void Block::cleanupPartialTransactionReceiptsForPreviousBlock() {
     if ( KeepPartialReceiptsUntilNextBlockPatch::isEnabledWhen( m_previousBlock.timestamp() ) &&
          m_previousBlock.number() > 0 ) {
+        LOG( m_loggerDebug ) << "Removing partial transaction receipts for block "
+                             << m_previousBlock.number();
         m_state.safeRemovePartialTransactionReceiptsForBlock( m_previousBlock.number() );
+    }
+    // do a simple sanity check from time to time
+    static uint64_t sanityCheckCounter = 0;
+    if ( sanityCheckCounter++ % 10000 == 0 ) {
+        LDB_CHECK( m_state.safePartialTransactionReceipts( m_previousBlock.number() ).empty() );
     }
 }
 
@@ -611,12 +618,6 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
     // we need to create a new readonly snap
     LDB_CHECK( m_state.getOriginalDb() );
     m_state.getOriginalDb()->createBlockSnap( info().number() );
-
-    // do a simple sanity check from time to time
-    static uint64_t sanityCheckCounter = 0;
-    if ( sanityCheckCounter++ % 10000 == 0 ) {
-        LDB_CHECK( m_state.safePartialTransactionReceipts( info().number() ).empty() );
-    }
 
     LDB_CHECK( receipts.size() >= countBad );
 

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -360,6 +360,7 @@ private:
 
     /// Creates and updates the special contract for storing block hashes according to EIP96
     void updateBlockhashContract();
+    void cleanupPartialTransactionReceiptsForPreviousBlock( BlockChain const& _bc );
 
     State m_state;                ///< Our state.
     Transactions m_transactions;  ///< The current list of transactions that we've included in the

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -360,7 +360,9 @@ private:
 
     /// Creates and updates the special contract for storing block hashes according to EIP96
     void updateBlockhashContract();
-    void cleanupPartialTransactionReceiptsForPreviousBlock( BlockChain const& _bc );
+
+    // Clear partial transaction receipts for previous block
+    void cleanupPartialTransactionReceiptsForPreviousBlock();
 
     State m_state;                ///< Our state.
     Transactions m_transactions;  ///< The current list of transactions that we've included in the

--- a/libethereum/SchainPatch.cpp
+++ b/libethereum/SchainPatch.cpp
@@ -40,6 +40,8 @@ SchainPatchEnum getEnumForPatchName( const std::string& _patchName ) {
         return SchainPatchEnum::ExternalGasPatch;
     else if ( _patchName == "ClearPartialReceiptsPatch" )
         return SchainPatchEnum::ClearPartialReceiptsPatch;
+    else if ( _patchName == "KeepPartialReceiptsUntilNextBlockPatch" )
+        return SchainPatchEnum::KeepPartialReceiptsUntilNextBlockPatch;
     else if ( _patchName == "InvalidTransactionFormatPatch" )
         return SchainPatchEnum::InvalidTransactionFormatPatch;
     else if ( _patchName == "CurrentBlockRandomPatch" )
@@ -84,6 +86,8 @@ std::string getPatchNameForEnum( SchainPatchEnum _enumValue ) {
         return "ExternalGasPatch";
     case SchainPatchEnum::ClearPartialReceiptsPatch:
         return "ClearPartialReceiptsPatch";
+    case SchainPatchEnum::KeepPartialReceiptsUntilNextBlockPatch:
+        return "KeepPartialReceiptsUntilNextBlockPatch";
     case SchainPatchEnum::InvalidTransactionFormatPatch:
         return "InvalidTransactionFormatPatch";
     case SchainPatchEnum::CurrentBlockRandomPatch:

--- a/libethereum/SchainPatch.h
+++ b/libethereum/SchainPatch.h
@@ -166,6 +166,12 @@ DEFINE_SIMPLE_PATCH( ExternalGasPatch );
 DEFINE_SIMPLE_PATCH( ClearPartialReceiptsPatch );
 
 /*
+ * Purpose: keep partial receipts until next block to ensure sync state with consensus
+ * Version introduced: 4.0.1+
+ */
+DEFINE_SIMPLE_PATCH( KeepPartialReceiptsUntilNextBlockPatch );
+
+/*
  * Context: fix the check in transaction constructor
  * maxFeePerGas cannot be less than maxPriorityFeePerGas
  */

--- a/libethereum/SchainPatch.h
+++ b/libethereum/SchainPatch.h
@@ -167,7 +167,7 @@ DEFINE_SIMPLE_PATCH( ClearPartialReceiptsPatch );
 
 /*
  * Purpose: keep partial receipts until next block to ensure sync state with consensus
- * Version introduced: 4.0.1+
+ * Version introduced: 4.0.3+
  */
 DEFINE_AMNESIC_PATCH( KeepPartialReceiptsUntilNextBlockPatch );
 

--- a/libethereum/SchainPatch.h
+++ b/libethereum/SchainPatch.h
@@ -169,7 +169,7 @@ DEFINE_SIMPLE_PATCH( ClearPartialReceiptsPatch );
  * Purpose: keep partial receipts until next block to ensure sync state with consensus
  * Version introduced: 4.0.1+
  */
-DEFINE_SIMPLE_PATCH( KeepPartialReceiptsUntilNextBlockPatch );
+DEFINE_AMNESIC_PATCH( KeepPartialReceiptsUntilNextBlockPatch );
 
 /*
  * Context: fix the check in transaction constructor

--- a/libethereum/SchainPatchEnum.h
+++ b/libethereum/SchainPatchEnum.h
@@ -21,6 +21,7 @@ enum class SchainPatchEnum {
     FlexibleDeploymentPatch,
     ExternalGasPatch,
     ClearPartialReceiptsPatch,
+    KeepPartialReceiptsUntilNextBlockPatch,
     InvalidTransactionFormatPatch,
     CurrentBlockRandomPatch,
     GroupIndexInitPatch,

--- a/libskale/OverlayDB.cpp
+++ b/libskale/OverlayDB.cpp
@@ -152,25 +152,31 @@ void OverlayDB::cleanupLegacyTransactionReceipts() {
     }
 }
 
-void OverlayDB::removeAllPartialTransactionReceipts() {
-    // first we get all keys
-
-    string prefix( "safeLastTransactionReceipts." );
+void OverlayDB::removePartialTransactionReceiptsByPrefix(
+    std::string& prefix, const string& commitLabel ) {
+    if ( !m_db_face )
+        return;
     vector< string > keys;
-    if ( m_db_face ) {
-        m_db_face->forEachWithPrefix( prefix, [&keys]( Slice key, Slice ) {
-            const std::string keyStr( key.begin(), key.end() );
-            keys.push_back( keyStr );
-            return true;
-        } );
-
-        for ( auto&& key : keys ) {
-            // now remove all of them
-            m_db_face->kill( key );
-        }
+    m_db_face->forEachWithPrefix( prefix, [&keys]( Slice key, Slice ) {
+        const std::string keyStr( key.begin(), key.end() );
+        keys.push_back( keyStr );
+        return true;
+    } );
+    for ( auto key : keys ) {
+        m_db_face->kill( key );
     }
+    m_db_face->commit( commitLabel );
+}
 
-    m_db_face->commit( "Clean partial keys" );
+void OverlayDB::removeAllPartialTransactionReceipts() {
+    std::string prefix = "safeLastTransactionReceipts.";
+    removePartialTransactionReceiptsByPrefix( prefix, "Clean partial keys" );
+}
+
+void OverlayDB::removePartialTransactionReceiptsForBlock( dev::eth::BlockNumber _blockNumber ) {
+    std::string blockPrefix =
+        "safeLastTransactionReceipts." + uint64ToFixedLengthHex( ( uint64_t ) _blockNumber ) + ".";
+    removePartialTransactionReceiptsByPrefix( blockPrefix, "Clean partial keys for block" );
 }
 
 void OverlayDB::setLastExecutedTransactionHash( const dev::h256& _newHash ) {

--- a/libskale/OverlayDB.cpp
+++ b/libskale/OverlayDB.cpp
@@ -162,7 +162,7 @@ void OverlayDB::removePartialTransactionReceiptsByPrefix(
         keys.push_back( keyStr );
         return true;
     } );
-    for ( auto key : keys ) {
+    for ( const auto& key : keys ) {
         m_db_face->kill( key );
     }
     m_db_face->commit( commitLabel );

--- a/libskale/OverlayDB.h
+++ b/libskale/OverlayDB.h
@@ -70,6 +70,7 @@ public:
         dev::eth::BlockNumber _blockNumber ) const;
 
     void removeAllPartialTransactionReceipts();
+    void removePartialTransactionReceiptsForBlock( dev::eth::BlockNumber _blockNumber );
 
     void setLastExecutedTransactionHash( const dev::h256& );
 
@@ -125,6 +126,8 @@ public:
     static std::string uint64ToFixedLengthHex( uint64_t value );
 
 private:
+    void removePartialTransactionReceiptsByPrefix(
+        std::string& prefix, const std::string& commitLabel );
     std::unordered_map< dev::h160, dev::bytes > m_cache;
     std::unordered_map< dev::h160, std::unordered_map< _byte_, dev::bytes > > m_auxiliaryCache;
     std::unordered_map< dev::h160, std::unordered_map< dev::h256, dev::h256 > > m_storageCache;

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -364,6 +364,12 @@ void State::safeRemoveAllPartialTransactionReceipts() {
     }
 }
 
+void State::safeRemovePartialTransactionReceiptsForBlock( dev::eth::BlockNumber _blockNumber ) {
+    if ( m_db_ptr ) {
+        m_db_ptr->removePartialTransactionReceiptsForBlock( _blockNumber );
+    }
+}
+
 
 void State::safeRemoveLegacyPartialTransactionReceipts() {
     if ( m_db_ptr ) {

--- a/libskale/State.h
+++ b/libskale/State.h
@@ -256,6 +256,7 @@ public:
     dev::eth::TransactionReceipts safeLegacyPartialTransactionReceipts();
 
     void safeRemoveAllPartialTransactionReceipts();
+    void safeRemovePartialTransactionReceiptsForBlock( dev::eth::BlockNumber _blockNumber );
     void safeCommitZeroBlockLegacyPartialTransactionReceipts();
 
 

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -2158,6 +2158,82 @@ BOOST_AUTO_TEST_CASE( simplePoWTransaction ) {
 }
 #endif
 
+BOOST_AUTO_TEST_CASE( keepPartialReceiptsUntilNextBlock ) {
+    std::string _config = c_genesisConfigString;
+    Json::Value ret;
+    Json::Reader().parse( _config, ret );
+
+    std::string chainID = "0x97";
+    ret["params"]["chainID"] = chainID;
+
+    time_t keepPatchActivationTs = time( nullptr ) + 10;
+    ret["skaleConfig"]["sChain"]["keepPartialReceiptsUntilNextBlockPatchTimestamp"] =
+        keepPatchActivationTs;
+
+    Json::FastWriter fastWriter;
+    std::string config = fastWriter.write( ret );
+    JsonRpcFixture fixture( config );
+
+    dev::eth::simulateMining( *( fixture.client ), 20 );
+
+    string senderAddress = toJS( fixture.coinbase.address() );
+
+    Json::Value transactionCallObject;
+    transactionCallObject["from"] = toJS( senderAddress );
+    transactionCallObject["to"] = "0x692a70d2e424a56d2c6c27aa97d1a86395877b3a";
+    transactionCallObject["data"] = "0x28b5e32b";
+
+    auto sendAndMine = [&]( dev::eth::BlockNumber& outBlockNumber ) {
+        TransactionSkeleton ts = toTransactionSkeleton( transactionCallObject );
+        ts = fixture.client->populateTransactionWithDefaults( ts );
+        pair< bool, Secret > ar = fixture.accountHolder->authenticate( ts );
+        Transaction tx( ts, ar.second );
+        auto txHash = fixture.rpcClient->eth_sendRawTransaction( toJS( tx.toBytes() ) );
+        dev::eth::mineTransaction( *( fixture.client ), 1 );
+        auto receipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
+        outBlockNumber = jsToInt( receipt["blockNumber"].asString() );
+    };
+
+    dev::eth::BlockNumber preActivationBlockNumber = 0;
+    sendAndMine( preActivationBlockNumber );
+    {
+        State state( fixture.client->state() );
+        BOOST_REQUIRE_EQUAL(
+            state.safePartialTransactionReceipts( preActivationBlockNumber ).size(), 0 );
+    }
+
+    time_t nowTs = time( nullptr );
+    if ( nowTs < keepPatchActivationTs ) {
+        sleep( keepPatchActivationTs - nowTs + 1 );
+    }
+
+    dev::eth::BlockNumber firstPostActivationBlockNumber = 0;
+    sendAndMine( firstPostActivationBlockNumber );
+    {
+        State state( fixture.client->state() );
+        BOOST_REQUIRE_EQUAL(
+            state.safePartialTransactionReceipts( firstPostActivationBlockNumber ).size(), 0 );
+    }
+
+    dev::eth::BlockNumber secondPostActivationBlockNumber = 0;
+    sendAndMine( secondPostActivationBlockNumber );
+    {
+        State state( fixture.client->state() );
+        BOOST_REQUIRE_EQUAL(
+            state.safePartialTransactionReceipts( secondPostActivationBlockNumber ).size(), 1 );
+    }
+
+    dev::eth::BlockNumber thirdPostActivationBlockNumber = 0;
+    sendAndMine( thirdPostActivationBlockNumber );
+    {
+        State state( fixture.client->state() );
+        BOOST_REQUIRE_EQUAL(
+            state.safePartialTransactionReceipts( secondPostActivationBlockNumber ).size(), 0 );
+        BOOST_REQUIRE_EQUAL(
+            state.safePartialTransactionReceipts( thirdPostActivationBlockNumber ).size(), 1 );
+    }
+}
+
 #ifndef FAIR
 BOOST_AUTO_TEST_CASE( clearPartialReceipts ) {
     // Prepare fixture


### PR DESCRIPTION
## Problem

Consider the following scenario:

- **skaled** crashes after all transactions in the current block are executed and the partial receipts are deleted, but **before** the block is committed to `blocks.db`.
- Upon restart, the consensus layer resubmits the same block to **skaled** for execution.
- All transactions are rejected because the nonces no longer match.
- As a result, **skaled** ends up with an empty block (no transactions).

---

## Changes

Starting from the `KeepPartialReceiptsUntilNextBlockPatch`, partial receipts from block `N - 1` are now removed **immediately before executing the first transaction of block `N`**.  
This ensures that partial receipts are only deleted once the next block execution safely begins.

---

## Tests

- Added additional unit tests in `jsonrpc.cpp`  to verify the new behavior.

---

## Performance Impact

With `KeepPartialReceiptsUntilNextBlockPatch`, instead of looking up and removing receipts for **all** previous blocks, only the receipts for **a single block** are looked up and removed.  
The total number of write operations remains the same, so **no performance impact is expected**.


