### PR TITLE
2300 No balance transfer after self destruct

### DIFF
--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -629,11 +629,9 @@ bool Executive::finalize() {
     }
 
     // Suicides...
-#ifndef FAIR
     if ( m_ext )
         for ( auto a : m_ext->sub.suicides )
             m_s.kill( a );
-#endif
 
     // Logs..
     if ( m_ext )

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -629,9 +629,11 @@ bool Executive::finalize() {
     }
 
     // Suicides...
+#ifndef FAIR
     if ( m_ext )
         for ( auto a : m_ext->sub.suicides )
             m_s.kill( a );
+#endif
 
     // Logs..
     if ( m_ext )

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -170,6 +170,7 @@ CreateResult ExtVM::create( u256 _endowment, u256& io_gas, bytesConstRef _code, 
 }
 
 void ExtVM::suicide( Address _a ) {
+#ifdef FAIR
     // Why transfer is not used here? That caused a consensus issue before (see Quirk #2 in
     // http://martin.swende.se/blog/Ethereum_quirks_and_vulns.html). There is one test case
     // witnessing the current consensus
@@ -177,6 +178,7 @@ void ExtVM::suicide( Address _a ) {
     m_s.addBalance( _a, m_s.balance( myAddress ) );
     m_s.setBalance( myAddress, 0 );
     ExtVMFace::suicide( _a );
+#endif
 }
 
 h256 ExtVM::blockHash( u256 _number ) {

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -170,11 +170,11 @@ CreateResult ExtVM::create( u256 _endowment, u256& io_gas, bytesConstRef _code, 
 }
 
 void ExtVM::suicide( Address _a ) {
-#ifdef FAIR
     // Why transfer is not used here? That caused a consensus issue before (see Quirk #2 in
     // http://martin.swende.se/blog/Ethereum_quirks_and_vulns.html). There is one test case
     // witnessing the current consensus
     // 'GeneralStateTests/stSystemOperationsTest/suicideSendEtherPostDeath.json'.
+#ifndef FAIR
     m_s.addBalance( _a, m_s.balance( myAddress ) );
     m_s.setBalance( myAddress, 0 );
     ExtVMFace::suicide( _a );

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -28,6 +28,9 @@
 #include <boost/thread.hpp>
 
 #include "LastBlockHashesFace.h"
+#ifdef FAIR
+#include "SchainPatch.h"
+#endif
 
 using namespace dev;
 using namespace dev::eth;
@@ -174,7 +177,13 @@ void ExtVM::suicide( [[maybe_unused]] Address _a ) {
     // http://martin.swende.se/blog/Ethereum_quirks_and_vulns.html). There is one test case
     // witnessing the current consensus
     // 'GeneralStateTests/stSystemOperationsTest/suicideSendEtherPostDeath.json'.
-#ifndef FAIR
+#ifdef FAIR
+    if ( !DisableSelfDestructPatch::isEnabledInWorkingBlock() ) {
+        m_s.addBalance( _a, m_s.balance( myAddress ) );
+        m_s.setBalance( myAddress, 0 );
+        ExtVMFace::suicide( _a );
+    }
+#else
     m_s.addBalance( _a, m_s.balance( myAddress ) );
     m_s.setBalance( myAddress, 0 );
     ExtVMFace::suicide( _a );

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -178,16 +178,13 @@ void ExtVM::suicide( [[maybe_unused]] Address _a ) {
     // witnessing the current consensus
     // 'GeneralStateTests/stSystemOperationsTest/suicideSendEtherPostDeath.json'.
 #ifdef FAIR
-    if ( !DisableSelfDestructPatch::isEnabledInWorkingBlock() ) {
-        m_s.addBalance( _a, m_s.balance( myAddress ) );
-        m_s.setBalance( myAddress, 0 );
-        ExtVMFace::suicide( _a );
+    if ( DisableSelfDestructPatch::isEnabledWhen( envInfo().committedBlockTimestamp() ) ) {
+        return;
     }
-#else
+#endif
     m_s.addBalance( _a, m_s.balance( myAddress ) );
     m_s.setBalance( myAddress, 0 );
     ExtVMFace::suicide( _a );
-#endif
 }
 
 h256 ExtVM::blockHash( u256 _number ) {

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -169,7 +169,7 @@ CreateResult ExtVM::create( u256 _endowment, u256& io_gas, bytesConstRef _code, 
         e.newAddress() };
 }
 
-void ExtVM::suicide( Address _a ) {
+void ExtVM::suicide( [[maybe_unused]] Address _a ) {
     // Why transfer is not used here? That caused a consensus issue before (see Quirk #2 in
     // http://martin.swende.se/blog/Ethereum_quirks_and_vulns.html). There is one test case
     // witnessing the current consensus

--- a/libethereum/SchainPatch.cpp
+++ b/libethereum/SchainPatch.cpp
@@ -46,6 +46,10 @@ SchainPatchEnum getEnumForPatchName( const std::string& _patchName ) {
         return SchainPatchEnum::CurrentBlockRandomPatch;
     else if ( _patchName == "GroupIndexInitPatch" )
         return SchainPatchEnum::GroupIndexInitPatch;
+#ifdef FAIR
+    else if ( _patchName == "DisableSelfDestructPatch" )
+        return SchainPatchEnum::DisableSelfDestructPatch;
+#endif
     else
         throw std::out_of_range( _patchName );
 }
@@ -90,6 +94,10 @@ std::string getPatchNameForEnum( SchainPatchEnum _enumValue ) {
         return "CurrentBlockRandomPatch";
     case SchainPatchEnum::GroupIndexInitPatch:
         return "GroupIndexInitPatch";
+#ifdef FAIR
+    case SchainPatchEnum::DisableSelfDestructPatch:
+        return "DisableSelfdestructPatch";
+#endif
     default:
         throw std::out_of_range(
             "UnknownPatch #" + std::to_string( static_cast< size_t >( _enumValue ) ) );

--- a/libethereum/SchainPatch.cpp
+++ b/libethereum/SchainPatch.cpp
@@ -96,7 +96,7 @@ std::string getPatchNameForEnum( SchainPatchEnum _enumValue ) {
         return "GroupIndexInitPatch";
 #ifdef FAIR
     case SchainPatchEnum::DisableSelfDestructPatch:
-        return "DisableSelfdestructPatch";
+        return "DisableSelfDestructPatch";
 #endif
     default:
         throw std::out_of_range(

--- a/libethereum/SchainPatch.h
+++ b/libethereum/SchainPatch.h
@@ -186,6 +186,6 @@ DEFINE_SIMPLE_PATCH( CurrentBlockRandomPatch );
 DEFINE_AMNESIC_PATCH( GroupIndexInitPatch );
 
 #ifdef FAIR
-DEFINE_AMNESIC_PATCH( DisableSelfDestructPatch );
+DEFINE_SIMPLE_PATCH( DisableSelfDestructPatch );
 #endif
 #endif  // SCHAINPATCH_H

--- a/libethereum/SchainPatch.h
+++ b/libethereum/SchainPatch.h
@@ -185,4 +185,7 @@ DEFINE_SIMPLE_PATCH( CurrentBlockRandomPatch );
  */
 DEFINE_AMNESIC_PATCH( GroupIndexInitPatch );
 
+#ifdef FAIR
+DEFINE_AMNESIC_PATCH( DisableSelfDestructPatch );
+#endif
 #endif  // SCHAINPATCH_H

--- a/libethereum/SchainPatchEnum.h
+++ b/libethereum/SchainPatchEnum.h
@@ -24,6 +24,9 @@ enum class SchainPatchEnum {
     InvalidTransactionFormatPatch,
     CurrentBlockRandomPatch,
     GroupIndexInitPatch,
+#ifdef FAIR
+    DisableSelfDestructPatch,
+#endif
     PatchesCount
 };
 

--- a/libhistoric/AlethExtVM.cpp
+++ b/libhistoric/AlethExtVM.cpp
@@ -170,16 +170,13 @@ void AlethExtVM::suicide( [[maybe_unused]] dev::Address _a ) {
     // witnessing the current consensus
     // 'GeneralStateTests/stSystemOperationsTest/suicideSendEtherPostDeath.json'.
 #ifdef FAIR
-    if ( !DisableSelfDestructPatch::isEnabledInWorkingBlock() ) {
-        m_s.addBalance( _a, m_s.balance( myAddress ) );
-        m_s.setBalance( myAddress, 0 );
-        ExtVMFace::suicide( _a );
+    if ( DisableSelfDestructPatch::isEnabledWhen( envInfo().committedBlockTimestamp() ) ) {
+        return;
     }
-#else
+#endif
     m_s.addBalance( _a, m_s.balance( myAddress ) );
     m_s.setBalance( myAddress, 0 );
     ExtVMFace::suicide( _a );
-#endif
 }
 
 h256 AlethExtVM::blockHash( u256 _number ) {

--- a/libhistoric/AlethExtVM.cpp
+++ b/libhistoric/AlethExtVM.cpp
@@ -161,14 +161,16 @@ CreateResult AlethExtVM::create( u256 _endowment, u256& io_gas, bytesConstRef _c
         e.newAddress() };
 }
 
-void AlethExtVM::suicide( dev::Address _a ) {
+void AlethExtVM::suicide( [[maybe_unused]] dev::Address _a ) {
     // Why transfer is not used here? That caused a consensus issue before (see Quirk #2 in
     // http://martin.swende.se/blog/Ethereum_quirks_and_vulns.html). There is one test case
     // witnessing the current consensus
     // 'GeneralStateTests/stSystemOperationsTest/suicideSendEtherPostDeath.json'.
+#ifndef FAIR
     m_s.addBalance( _a, m_s.balance( myAddress ) );
     m_s.setBalance( myAddress, 0 );
     ExtVMFace::suicide( _a );
+#endif
 }
 
 h256 AlethExtVM::blockHash( u256 _number ) {

--- a/libhistoric/AlethExtVM.cpp
+++ b/libhistoric/AlethExtVM.cpp
@@ -10,6 +10,9 @@
 #include "libethereum/LastBlockHashesFace.h"
 #include "libhistoric/AlethExecutive.h"
 #include <exception>
+#ifdef FAIR
+#include "libethereum/SchainPatch.h"
+#endif
 
 
 using namespace dev;
@@ -166,7 +169,13 @@ void AlethExtVM::suicide( [[maybe_unused]] dev::Address _a ) {
     // http://martin.swende.se/blog/Ethereum_quirks_and_vulns.html). There is one test case
     // witnessing the current consensus
     // 'GeneralStateTests/stSystemOperationsTest/suicideSendEtherPostDeath.json'.
-#ifndef FAIR
+#ifdef FAIR
+    if ( !DisableSelfDestructPatch::isEnabledInWorkingBlock() ) {
+        m_s.addBalance( _a, m_s.balance( myAddress ) );
+        m_s.setBalance( myAddress, 0 );
+        ExtVMFace::suicide( _a );
+    }
+#else
     m_s.addBalance( _a, m_s.balance( myAddress ) );
     m_s.setBalance( myAddress, 0 );
     ExtVMFace::suicide( _a );


### PR DESCRIPTION
## Problem

The SELFDESTRUCT opcode currently allows contracts to send remaining Ether to a specified address upon destruction. This behavior can be exploited for unexpected or unauthorized fund transfers. 

## Changes

For FAIR build sending balance to specified target after self destruct is disabled. 

## Tests

- Tested on local setup.

## Performance Impact

- No performance related changes were introduced.

## Contract example
```
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.0;

contract Game {
    address owner_addr;
    address[] participants;
    uint participatorID = 0;

    constructor() {
        owner_addr = msg.sender;
    }

    receive() external payable {
        if (msg.value != 1 ether) revert();

        participants.push(msg.sender);
        participatorID++;

        if (address(this).balance >= 10 ether) getWinner();
    }

    function getWinner() internal {
        uint random = uint(blockhash(block.number - 1)) % participants.length;
        payable(participants[random]).transfer(9 ether);

        // Reset for next round
        delete participants;
        participatorID = 0;
    }

    modifier onlyOwner() {
        require(msg.sender == owner_addr);
        _;
    }

    function selfDestruct(address addr) public onlyOwner {
        selfdestruct(payable(addr));
    }
}
```

## Steps to test

1. Deploy contract that has self destruct transaction.
2. Fund contract address.
3. Destroy the transaction using selfDestruct(address a).
4. Balance of address a should not change.