### PR TITLE
#2311 max gas price

### DIFF
--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -233,7 +233,8 @@ void validateConfigJson( js::mObject const& _obj ) {
             { "syncNodeReadJsonHeaderTimeoutSec",
                 { { js::int_type }, JsonFieldPresence::Optional } },
             { "dynamicPricingMinPrice", { { js::int_type }, JsonFieldPresence::Optional } },
-            { "dynamicPricingStartPrice", { { js::int_type }, JsonFieldPresence::Optional } } } );
+            { "dynamicPricingStartPrice", { { js::int_type }, JsonFieldPresence::Optional } },
+            { "dynamicPricingMaxPrice", { { js::int_type }, JsonFieldPresence::Optional } } } );
 
 #ifndef FAIR
     std::string keyShareName = "";


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skaled/issues/2311

allow setting max gas price via skaled config file

verified on local machine

```
$ geth attach http://127.0.0.1:1234
Welcome to the Geth JavaScript console!

instance: skaled/4.1.0+commit.067b56ba.dirty/linux/gnu11.4.0/debug
at block: 3 (Thu Nov 06 2025 15:23:23 GMT+0000 (WET))
 modules: debug:1.0 eth:1.0 net:1.0 skale:0.1 skaleStats:1.0 web3:1.0

To exit, press ctrl-d or type exit
> eth.gasPrice
47619047619048
```