### PR TITLE
IS-1341 fix block random

### DIFF
--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -71,13 +71,13 @@ public:
         return m_cost( _in, _chainParams, _blockNumber );
     }
 #ifdef FAIR
-    std::pair< bool, bytes > execute( bytesConstRef _in, const u256& _bn ) const {
-        return m_execute( _in, _bn );
+    std::pair< bool, bytes > execute( bytesConstRef _in, const PrecompiledCallContext& _ctx ) const {
+        return m_execute( _in, _ctx );
     }
 #else
     std::pair< bool, bytes > execute(
-        bytesConstRef _in, const u256& _bn, skale::OverlayFS* _overlayFS = nullptr ) const {
-        return m_execute( _in, _bn, _overlayFS );
+        bytesConstRef _in, const PrecompiledCallContext& _ctx, skale::OverlayFS* _overlayFS = nullptr ) const {
+        return m_execute( _in, _ctx, _overlayFS );
     }
 #endif
 
@@ -342,13 +342,13 @@ public:
 
 #ifdef FAIR
     std::pair< bool, bytes > executePrecompiled(
-        Address const& _a, bytesConstRef _in, u256 const& _bn ) const {
-        return precompiled.at( _a ).execute( _in, _bn );
+        Address const& _a, bytesConstRef _in, const PrecompiledCallContext& _ctx ) const {
+        return precompiled.at( _a ).execute( _in, _ctx );
     }
 #else
     std::pair< bool, bytes > executePrecompiled( Address const& _a, bytesConstRef _in,
-        u256 const& _bn, skale::OverlayFS* _overlayFS = nullptr ) const {
-        return precompiled.at( _a ).execute( _in, _bn, _overlayFS );
+        const PrecompiledCallContext& _ctx, skale::OverlayFS* _overlayFS = nullptr ) const {
+        return precompiled.at( _a ).execute( _in, _ctx, _overlayFS );
     }
 #endif
 

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -71,12 +71,13 @@ public:
         return m_cost( _in, _chainParams, _blockNumber );
     }
 #ifdef FAIR
-    std::pair< bool, bytes > execute( bytesConstRef _in, const PrecompiledCallContext& _ctx ) const {
+    std::pair< bool, bytes > execute(
+        bytesConstRef _in, const PrecompiledCallContext& _ctx ) const {
         return m_execute( _in, _ctx );
     }
 #else
-    std::pair< bool, bytes > execute(
-        bytesConstRef _in, const PrecompiledCallContext& _ctx, skale::OverlayFS* _overlayFS = nullptr ) const {
+    std::pair< bool, bytes > execute( bytesConstRef _in, const PrecompiledCallContext& _ctx,
+        skale::OverlayFS* _overlayFS = nullptr ) const {
         return m_execute( _in, _ctx, _overlayFS );
     }
 #endif

--- a/libethcore/SealEngine.h
+++ b/libethcore/SealEngine.h
@@ -107,8 +107,8 @@ public:
         return m_params.getPrecompiledContract( _a ).cost( _in, m_params, _blockNumber );
     }
     virtual std::pair< bool, bytes > executePrecompiled(
-        Address const& _a, bytesConstRef _in, u256 const& _bn ) const {
-        return m_params.getPrecompiledContract( _a ).execute( _in, _bn );
+        Address const& _a, bytesConstRef _in, const PrecompiledCallContext& _ctx ) const {
+        return m_params.getPrecompiledContract( _a ).execute( _in, _ctx );
     }
 
     virtual bool precompiledExecutionAllowedFrom(

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -361,7 +361,7 @@ private:
     /// Creates and updates the special contract for storing block hashes according to EIP96
     void updateBlockhashContract();
 
-    State m_state;                ///< Our state.
+    skale::State m_state;                ///< Our state.
     Transactions m_transactions;  ///< The current list of transactions that we've included in the
                                   ///< state.
     TransactionReceipts m_receipts;  ///< The corresponding list of transaction receipts.

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -361,7 +361,7 @@ private:
     /// Creates and updates the special contract for storing block hashes according to EIP96
     void updateBlockhashContract();
 
-    skale::State m_state;                ///< Our state.
+    skale::State m_state;         ///< Our state.
     Transactions m_transactions;  ///< The current list of transactions that we've included in the
                                   ///< state.
     TransactionReceipts m_receipts;  ///< The corresponding list of transaction receipts.

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -366,13 +366,14 @@ bool Executive::call( CallParameters const& _p, u256 const& _gasPrice, Address c
             m_gas = ( u256 )( _p.gas - g );
             bytes output;
             bool success;
+            PrecompiledCallContext ctx{ m_envInfo.number(), m_readOnly };
 #ifdef FAIR
             tie( success, output ) =
-                m_chainParams.executePrecompiled( _p.codeAddress, _p.data, m_envInfo.number() );
+                m_chainParams.executePrecompiled( _p.codeAddress, _p.data, ctx );
 
 #else
             tie( success, output ) = m_chainParams.executePrecompiled(
-                _p.codeAddress, _p.data, m_envInfo.number(), m_s.fs().get() );
+                _p.codeAddress, _p.data, ctx, m_s.fs().get() );
 #endif
 
             size_t outputSize = output.size();

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -372,8 +372,8 @@ bool Executive::call( CallParameters const& _p, u256 const& _gasPrice, Address c
                 m_chainParams.executePrecompiled( _p.codeAddress, _p.data, ctx );
 
 #else
-            tie( success, output ) = m_chainParams.executePrecompiled(
-                _p.codeAddress, _p.data, ctx, m_s.fs().get() );
+            tie( success, output ) =
+                m_chainParams.executePrecompiled( _p.codeAddress, _p.data, ctx, m_s.fs().get() );
 #endif
 
             size_t outputSize = output.size();

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -226,7 +226,8 @@ ETH_REGISTER_PRECOMPILED_PRICER( alt_bn128_G1_mul )
     return _blockNumber < _chainParams.getIstanbulForkBlock() ? 40000 : 6000;
 }
 
-ETH_REGISTER_PRECOMPILED( alt_bn128_pairing_product )( bytesConstRef _in, const PrecompiledCallContext& ) {
+ETH_REGISTER_PRECOMPILED( alt_bn128_pairing_product )
+( bytesConstRef _in, const PrecompiledCallContext& ) {
     return dev::crypto::alt_bn128_pairing_product( _in );
 }
 
@@ -818,7 +819,8 @@ static std::pair< std::string, unsigned > parseHistoricFieldRequest( std::string
  * so one should pass the following as calldata:
  * toBytes( input.length + toBytes(input) )
  */
-ETH_REGISTER_PRECOMPILED( getConfigVariableUint256 )( bytesConstRef _in, const PrecompiledCallContext& ) {
+ETH_REGISTER_PRECOMPILED( getConfigVariableUint256 )
+( bytesConstRef _in, const PrecompiledCallContext& ) {
     try {
         size_t lengthName;
         std::string rawName;
@@ -875,7 +877,8 @@ ETH_REGISTER_PRECOMPILED( getConfigVariableUint256 )( bytesConstRef _in, const P
     return { false, response };  // 1st false - means bad error occur
 }
 
-ETH_REGISTER_PRECOMPILED( getConfigVariableAddress )( bytesConstRef _in, const PrecompiledCallContext& ) {
+ETH_REGISTER_PRECOMPILED( getConfigVariableAddress )
+( bytesConstRef _in, const PrecompiledCallContext& ) {
     try {
         size_t lengthName;
         std::string rawName;
@@ -929,7 +932,8 @@ ETH_REGISTER_PRECOMPILED( getConfigVariableAddress )( bytesConstRef _in, const P
  * so one should pass the following as calldata
  * toBytes( input.length + toBytes(input) )
  */
-ETH_REGISTER_PRECOMPILED( getConfigVariableString )( bytesConstRef _in, const PrecompiledCallContext& ) {
+ETH_REGISTER_PRECOMPILED( getConfigVariableString )
+( bytesConstRef _in, const PrecompiledCallContext& ) {
     try {
         size_t lengthName;
         std::string rawName;
@@ -998,7 +1002,8 @@ static dev::u256 stat_s2a( const std::string& saIn ) {
     return u;
 }
 
-ETH_REGISTER_PRECOMPILED( getConfigPermissionFlag )( bytesConstRef _in, const PrecompiledCallContext& ) {
+ETH_REGISTER_PRECOMPILED( getConfigPermissionFlag )
+( bytesConstRef _in, const PrecompiledCallContext& ) {
     try {
         dev::u256 uValue;
         uValue = 0;
@@ -1090,12 +1095,12 @@ ETH_REGISTER_PRECOMPILED( getBlockRandom )( bytesConstRef, const PrecompiledCall
 }
 
 #ifndef FAIR
-ETH_REGISTER_PRECOMPILED( addBalance )( [[maybe_unused]] bytesConstRef _in, const PrecompiledCallContext& ) {
+ETH_REGISTER_PRECOMPILED( addBalance )
+( [[maybe_unused]] bytesConstRef _in, const PrecompiledCallContext& ) {
     dev::u256 code = 0;
     bytes response = toBigEndian( code );
     return { false, response };  // 1st false - means bad error occur
 }
-
 
 ETH_REGISTER_PRECOMPILED( getIMABLSPublicKey )( bytesConstRef, const PrecompiledCallContext& ) {
     try {

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -86,7 +86,7 @@ PrecompiledPricer const& PrecompiledRegistrar::pricer( std::string const& _name 
 
 namespace {
 
-ETH_REGISTER_PRECOMPILED( ecrecover )( bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( ecrecover )( bytesConstRef _in, const PrecompiledCallContext& ) {
     struct {
         h256 hash;
         h256 v;
@@ -114,15 +114,15 @@ ETH_REGISTER_PRECOMPILED( ecrecover )( bytesConstRef _in, const dev::u256& ) {
     return { true, {} };
 }
 
-ETH_REGISTER_PRECOMPILED( sha256 )( bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( sha256 )( bytesConstRef _in, const PrecompiledCallContext& ) {
     return { true, dev::sha256( _in ).asBytes() };
 }
 
-ETH_REGISTER_PRECOMPILED( ripemd160 )( bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( ripemd160 )( bytesConstRef _in, const PrecompiledCallContext& ) {
     return { true, h256( dev::ripemd160( _in ), h256::AlignRight ).asBytes() };
 }
 
-ETH_REGISTER_PRECOMPILED( identity )( bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( identity )( bytesConstRef _in, const PrecompiledCallContext& ) {
     MICROPROFILE_SCOPEI( "VM", "identity", MP_RED );
     return { true, _in.toBytes() };
 }
@@ -149,7 +149,7 @@ bigint parseBigEndianRightPadded( bytesConstRef _in, bigint const& _begin, bigin
     return ret;
 }
 
-ETH_REGISTER_PRECOMPILED( modexp )( bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( modexp )( bytesConstRef _in, const PrecompiledCallContext& ) {
     bigint const baseLength( parseBigEndianRightPadded( _in, 0, 32 ) );
     bigint const expLength( parseBigEndianRightPadded( _in, 32, 32 ) );
     bigint const modLength( parseBigEndianRightPadded( _in, 64, 32 ) );
@@ -208,7 +208,7 @@ ETH_REGISTER_PRECOMPILED_PRICER( modexp )
     return multComplexity( maxLength ) * max< bigint >( adjustedExpLength, 1 ) / 20;
 }
 
-ETH_REGISTER_PRECOMPILED( alt_bn128_G1_add )( bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( alt_bn128_G1_add )( bytesConstRef _in, const PrecompiledCallContext& ) {
     return dev::crypto::alt_bn128_G1_add( _in );
 }
 
@@ -217,7 +217,7 @@ ETH_REGISTER_PRECOMPILED_PRICER( alt_bn128_G1_add )
     return _blockNumber < _chainParams.getIstanbulForkBlock() ? 500 : 150;
 }
 
-ETH_REGISTER_PRECOMPILED( alt_bn128_G1_mul )( bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( alt_bn128_G1_mul )( bytesConstRef _in, const PrecompiledCallContext& ) {
     return dev::crypto::alt_bn128_G1_mul( _in );
 }
 
@@ -226,7 +226,7 @@ ETH_REGISTER_PRECOMPILED_PRICER( alt_bn128_G1_mul )
     return _blockNumber < _chainParams.getIstanbulForkBlock() ? 40000 : 6000;
 }
 
-ETH_REGISTER_PRECOMPILED( alt_bn128_pairing_product )( bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( alt_bn128_pairing_product )( bytesConstRef _in, const PrecompiledCallContext& ) {
     return dev::crypto::alt_bn128_pairing_product( _in );
 }
 
@@ -284,7 +284,7 @@ boost::filesystem::path getFileStorageDir( const Address& _address ) {
 
 // TODO: check file name and file existance
 ETH_REGISTER_FS_PRECOMPILED( createFile )
-( bytesConstRef _in, const dev::u256&, skale::OverlayFS* _overlayFS ) {
+( bytesConstRef _in, const PrecompiledCallContext&, skale::OverlayFS* _overlayFS ) {
     if ( !_overlayFS )
         throw runtime_error( "_overlayFS is nullptr " );
 
@@ -329,7 +329,7 @@ ETH_REGISTER_FS_PRECOMPILED( createFile )
 }
 
 ETH_REGISTER_FS_PRECOMPILED( uploadChunk )
-( bytesConstRef _in, const dev::u256&, skale::OverlayFS* _overlayFS ) {
+( bytesConstRef _in, const PrecompiledCallContext&, skale::OverlayFS* _overlayFS ) {
     if ( !_overlayFS )
         throw runtime_error( "_overlayFS is nullptr " );
 
@@ -378,7 +378,7 @@ ETH_REGISTER_FS_PRECOMPILED( uploadChunk )
     return { false, response };
 }
 
-ETH_REGISTER_PRECOMPILED( readChunk )( bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( readChunk )( bytesConstRef _in, const PrecompiledCallContext& ) {
     MICROPROFILE_SCOPEI( "VM", "readChunk", MP_ORANGERED );
     try {
         auto rawAddress = _in.cropped( 12, 20 ).toBytes();
@@ -429,7 +429,7 @@ ETH_REGISTER_PRECOMPILED( readChunk )( bytesConstRef _in, const dev::u256& ) {
     return { false, response };
 }
 
-ETH_REGISTER_PRECOMPILED( getFileSize )( bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( getFileSize )( bytesConstRef _in, const PrecompiledCallContext& ) {
     try {
         auto rawAddress = _in.cropped( 12, 20 ).toBytes();
         std::string address;
@@ -464,7 +464,7 @@ ETH_REGISTER_PRECOMPILED( getFileSize )( bytesConstRef _in, const dev::u256& ) {
 }
 
 ETH_REGISTER_FS_PRECOMPILED( deleteFile )
-( bytesConstRef _in, const dev::u256&, skale::OverlayFS* _overlayFS ) {
+( bytesConstRef _in, const PrecompiledCallContext&, skale::OverlayFS* _overlayFS ) {
     if ( !_overlayFS )
         throw runtime_error( "_overlayFS is nullptr " );
 
@@ -498,7 +498,7 @@ ETH_REGISTER_FS_PRECOMPILED( deleteFile )
 }
 
 ETH_REGISTER_FS_PRECOMPILED( createDirectory )
-( bytesConstRef _in, const dev::u256&, skale::OverlayFS* _overlayFS ) {
+( bytesConstRef _in, const PrecompiledCallContext&, skale::OverlayFS* _overlayFS ) {
     if ( !_overlayFS )
         throw runtime_error( "_overlayFS is nullptr " );
 
@@ -531,7 +531,7 @@ ETH_REGISTER_FS_PRECOMPILED( createDirectory )
 }
 
 ETH_REGISTER_FS_PRECOMPILED( deleteDirectory )
-( bytesConstRef _in, const dev::u256&, skale::OverlayFS* _overlayFS ) {
+( bytesConstRef _in, const PrecompiledCallContext&, skale::OverlayFS* _overlayFS ) {
     if ( !_overlayFS )
         throw runtime_error( "_overlayFS is nullptr " );
 
@@ -571,7 +571,7 @@ ETH_REGISTER_FS_PRECOMPILED( deleteDirectory )
 }
 
 ETH_REGISTER_FS_PRECOMPILED( calculateFileHash )
-( bytesConstRef _in, const dev::u256&, skale::OverlayFS* _overlayFS ) {
+( bytesConstRef _in, const PrecompiledCallContext&, skale::OverlayFS* _overlayFS ) {
     try {
         auto rawAddress = _in.cropped( 12, 20 ).toBytes();
         std::string address;
@@ -606,7 +606,7 @@ ETH_REGISTER_FS_PRECOMPILED( calculateFileHash )
     return { false, response };
 }
 
-ETH_REGISTER_PRECOMPILED( logTextMessage )( bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( logTextMessage )( bytesConstRef _in, const PrecompiledCallContext& ) {
     try {
         if ( !g_configAccesssor )
             throw std::runtime_error( "Config accessor was not initialized" );
@@ -818,7 +818,7 @@ static std::pair< std::string, unsigned > parseHistoricFieldRequest( std::string
  * so one should pass the following as calldata:
  * toBytes( input.length + toBytes(input) )
  */
-ETH_REGISTER_PRECOMPILED( getConfigVariableUint256 )( bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( getConfigVariableUint256 )( bytesConstRef _in, const PrecompiledCallContext& ) {
     try {
         size_t lengthName;
         std::string rawName;
@@ -875,7 +875,7 @@ ETH_REGISTER_PRECOMPILED( getConfigVariableUint256 )( bytesConstRef _in, const d
     return { false, response };  // 1st false - means bad error occur
 }
 
-ETH_REGISTER_PRECOMPILED( getConfigVariableAddress )( bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( getConfigVariableAddress )( bytesConstRef _in, const PrecompiledCallContext& ) {
     try {
         size_t lengthName;
         std::string rawName;
@@ -929,7 +929,7 @@ ETH_REGISTER_PRECOMPILED( getConfigVariableAddress )( bytesConstRef _in, const d
  * so one should pass the following as calldata
  * toBytes( input.length + toBytes(input) )
  */
-ETH_REGISTER_PRECOMPILED( getConfigVariableString )( bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( getConfigVariableString )( bytesConstRef _in, const PrecompiledCallContext& ) {
     try {
         size_t lengthName;
         std::string rawName;
@@ -982,7 +982,7 @@ ETH_REGISTER_PRECOMPILED( getConfigVariableString )( bytesConstRef _in, const de
 }
 
 
-ETH_REGISTER_PRECOMPILED( fnReserved0x16 )( bytesConstRef, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( fnReserved0x16 )( bytesConstRef, const PrecompiledCallContext& ) {
     u256 code = 0;
     bytes response = toBigEndian( code );
     return { false, response };  // 1st false - means bad error occur
@@ -998,7 +998,7 @@ static dev::u256 stat_s2a( const std::string& saIn ) {
     return u;
 }
 
-ETH_REGISTER_PRECOMPILED( getConfigPermissionFlag )( bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( getConfigPermissionFlag )( bytesConstRef _in, const PrecompiledCallContext& ) {
     try {
         dev::u256 uValue;
         uValue = 0;
@@ -1061,11 +1061,17 @@ ETH_REGISTER_PRECOMPILED( getConfigPermissionFlag )( bytesConstRef _in, const de
 }
 #endif
 
-ETH_REGISTER_PRECOMPILED( getBlockRandom )( bytesConstRef, const dev::u256& _bn ) {
+ETH_REGISTER_PRECOMPILED( getBlockRandom )( bytesConstRef, const PrecompiledCallContext& _ctx ) {
     try {
         if ( !g_skaleHost )
             throw std::runtime_error( "SkaleHost accessor was not initialized" );
-        dev::u256 uValue = g_skaleHost->getBlockRandom( _bn.convert_to< unsigned >() );
+        unsigned blockNumberToCall = _ctx.blockNumber.convert_to< unsigned >();
+        if ( _ctx.isReadOnly ) {
+            // means a call outside of block is being executed
+            // if blockNumberToCall > currentBlockNumber, need to decrease it by 1
+            --blockNumberToCall;
+        }
+        dev::u256 uValue = g_skaleHost->getBlockRandom( blockNumberToCall );
         bytes response = toBigEndian( uValue );
         return { true, response };
     } catch ( std::exception& ex ) {
@@ -1084,14 +1090,14 @@ ETH_REGISTER_PRECOMPILED( getBlockRandom )( bytesConstRef, const dev::u256& _bn 
 }
 
 #ifndef FAIR
-ETH_REGISTER_PRECOMPILED( addBalance )( [[maybe_unused]] bytesConstRef _in, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( addBalance )( [[maybe_unused]] bytesConstRef _in, const PrecompiledCallContext& ) {
     dev::u256 code = 0;
     bytes response = toBigEndian( code );
     return { false, response };  // 1st false - means bad error occur
 }
 
 
-ETH_REGISTER_PRECOMPILED( getIMABLSPublicKey )( bytesConstRef, const dev::u256& ) {
+ETH_REGISTER_PRECOMPILED( getIMABLSPublicKey )( bytesConstRef, const PrecompiledCallContext& ) {
     try {
         if ( !g_skaleHost )
             throw std::runtime_error( "SkaleHost accessor was not initialized" );

--- a/libethereum/Precompiled.h
+++ b/libethereum/Precompiled.h
@@ -51,7 +51,8 @@ extern std::shared_ptr< SkaleHost > g_skaleHost;
 
 struct PrecompiledCallContext {
     PrecompiledCallContext() : blockNumber( 0 ), isReadOnly( true ) {}
-    PrecompiledCallContext( dev::u256 bn, bool readOnly ) : blockNumber( bn ), isReadOnly( readOnly ) {}
+    PrecompiledCallContext( dev::u256 bn, bool readOnly )
+        : blockNumber( bn ), isReadOnly( readOnly ) {}
     dev::u256 blockNumber;
     bool isReadOnly;
 };
@@ -62,30 +63,32 @@ struct ChainOperationParams;
 class PrecompiledExecutor {
 public:
 #ifdef FAIR
-    std::pair< bool, bytes > operator()( bytesConstRef _in, const PrecompiledCallContext& _ctx ) const {
+    std::pair< bool, bytes > operator()(
+        bytesConstRef _in, const PrecompiledCallContext& _ctx ) const {
         return proxy( _in, _ctx );
     }
 #else
-    std::pair< bool, bytes > operator()(
-        bytesConstRef _in, const PrecompiledCallContext& _ctx, skale::OverlayFS* _overlayFS = nullptr ) const {
+    std::pair< bool, bytes > operator()( bytesConstRef _in, const PrecompiledCallContext& _ctx,
+        skale::OverlayFS* _overlayFS = nullptr ) const {
         return proxy( _in, _ctx, _overlayFS );
     }
 #endif
     PrecompiledExecutor() {}
 #ifdef FAIR
-    PrecompiledExecutor(
-        const std::function< std::pair< bool, bytes >( bytesConstRef _in, const PrecompiledCallContext& _ctx ) >&
-            _func )
+    PrecompiledExecutor( const std::function< std::pair< bool, bytes >(
+        bytesConstRef _in, const PrecompiledCallContext& _ctx ) >& _func )
         : proxy( _func ) {}
 #else
-    PrecompiledExecutor( const std::function< std::pair< bool, bytes >(
-            bytesConstRef _in, const PrecompiledCallContext& _ctx, skale::OverlayFS* _overlayFS ) >& _func )
+    PrecompiledExecutor( const std::function< std::pair< bool, bytes >( bytesConstRef _in,
+        const PrecompiledCallContext& _ctx, skale::OverlayFS* _overlayFS ) >& _func )
         : proxy( _func ) {}
 #endif
 
 private:
 #ifdef FAIR
-    std::function< std::pair< bool, bytes >( bytesConstRef _in, const PrecompiledCallContext& _ctx ) > proxy;
+    std::function< std::pair< bool, bytes >(
+        bytesConstRef _in, const PrecompiledCallContext& _ctx ) >
+        proxy;
 #else
     std::function< std::pair< bool, bytes >(
         bytesConstRef _in, const PrecompiledCallContext& _ctx, skale::OverlayFS* _overlayFS ) >
@@ -138,7 +141,7 @@ private:
 #ifdef FAIR
 #define ETH_REGISTER_PRECOMPILED( Name )                                                      \
     static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name(                  \
-        bytesConstRef _in, const PrecompiledCallContext& _ctx );                                                 \
+        bytesConstRef _in, const PrecompiledCallContext& _ctx );                              \
     static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =                       \
         ::dev::eth::PrecompiledRegistrar::registerExecutor(                                   \
             #Name, PrecompiledExecutor(                                                       \
@@ -149,24 +152,23 @@ private:
 #else
 // ignore _overlayFS param and call registered function with 2 parameters
 // TODO: unregister on unload with a static object.
-#define ETH_REGISTER_PRECOMPILED( Name )                                                      \
-    static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name(                  \
-        bytesConstRef _in, const PrecompiledCallContext& _ctx );                                                 \
-    static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =                       \
-        ::dev::eth::PrecompiledRegistrar::registerExecutor(                                   \
-            #Name, PrecompiledExecutor( []( bytesConstRef _in, const PrecompiledCallContext& _ctx,               \
-                                            skale::OverlayFS* ) -> std::pair< bool, bytes > { \
-                return __eth_registerPrecompiledFunction##Name( _in, _ctx );                   \
-            } ) );                                                                            \
+#define ETH_REGISTER_PRECOMPILED( Name )                                                           \
+    static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name(                       \
+        bytesConstRef _in, const PrecompiledCallContext& _ctx );                                   \
+    static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =                            \
+        ::dev::eth::PrecompiledRegistrar::registerExecutor(                                        \
+            #Name, PrecompiledExecutor( []( bytesConstRef _in, const PrecompiledCallContext& _ctx, \
+                                            skale::OverlayFS* ) -> std::pair< bool, bytes > {      \
+                return __eth_registerPrecompiledFunction##Name( _in, _ctx );                       \
+            } ) );                                                                                 \
     static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name
 
-#define ETH_REGISTER_FS_PRECOMPILED( Name )                                           \
-    static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name(          \
-        bytesConstRef _in, const PrecompiledCallContext& _ctx, skale::OverlayFS* _overlayFS );           \
-    static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =               \
-        ::dev::eth::PrecompiledRegistrar::registerExecutor(                           \
-            #Name, PrecompiledExecutor( &__eth_registerPrecompiledFunction##Name ) ); \
-    static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name
+#define ETH_REGISTER_FS_PRECOMPILED( Name )                                                    \
+    static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name(                   \
+        bytesConstRef _in, const PrecompiledCallContext& _ctx, skale::OverlayFS* _overlayFS ); \
+    static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =                        \
+        ::dev::eth::PrecompiledRegistrar::registerExecutor(                                    \
+            #Name, PrecompiledExecutor( &__eth_registerPrecompiledFunction##Name ) );          \
 #endif
 
 #define ETH_REGISTER_PRECOMPILED_PRICER( Name )                                                  \

--- a/libethereum/Precompiled.h
+++ b/libethereum/Precompiled.h
@@ -51,7 +51,8 @@ namespace eth {
 
 extern std::shared_ptr< skutils::json_config_file_accessor > g_configAccesssor;
 extern std::shared_ptr< SkaleHost > g_skaleHost;
-extern skale::State g_state;
+
+inline thread_local int64_t g_currentTransactionIndex = -1;
 
 struct ChainOperationParams;
 

--- a/libethereum/Precompiled.h
+++ b/libethereum/Precompiled.h
@@ -76,11 +76,11 @@ public:
     PrecompiledExecutor() {}
 #ifdef FAIR
     PrecompiledExecutor( const std::function< std::pair< bool, bytes >(
-        bytesConstRef _in, const PrecompiledCallContext& _ctx ) >& _func )
+            bytesConstRef _in, const PrecompiledCallContext& _ctx ) >& _func )
         : proxy( _func ) {}
 #else
     PrecompiledExecutor( const std::function< std::pair< bool, bytes >( bytesConstRef _in,
-        const PrecompiledCallContext& _ctx, skale::OverlayFS* _overlayFS ) >& _func )
+            const PrecompiledCallContext& _ctx, skale::OverlayFS* _overlayFS ) >& _func )
         : proxy( _func ) {}
 #endif
 

--- a/libethereum/Precompiled.h
+++ b/libethereum/Precompiled.h
@@ -38,13 +38,10 @@
 class SkaleHost;
 
 namespace skale {
-class State;
 #ifndef FAIR
 class OverlayFS;
 #endif
 }  // namespace skale
-
-using skale::State;
 
 namespace dev {
 namespace eth {

--- a/libethereum/Precompiled.h
+++ b/libethereum/Precompiled.h
@@ -49,7 +49,12 @@ namespace eth {
 extern std::shared_ptr< skutils::json_config_file_accessor > g_configAccesssor;
 extern std::shared_ptr< SkaleHost > g_skaleHost;
 
-inline thread_local int64_t g_currentTransactionIndex = -1;
+struct PrecompiledCallContext {
+    PrecompiledCallContext() : blockNumber( 0 ), isReadOnly( true ) {}
+    PrecompiledCallContext( dev::u256 bn, bool readOnly ) : blockNumber( bn ), isReadOnly( readOnly ) {}
+    dev::u256 blockNumber;
+    bool isReadOnly;
+};
 
 struct ChainOperationParams;
 
@@ -57,33 +62,33 @@ struct ChainOperationParams;
 class PrecompiledExecutor {
 public:
 #ifdef FAIR
-    std::pair< bool, bytes > operator()( bytesConstRef _in, const u256& _bn ) const {
-        return proxy( _in, _bn );
+    std::pair< bool, bytes > operator()( bytesConstRef _in, const PrecompiledCallContext& _ctx ) const {
+        return proxy( _in, _ctx );
     }
 #else
     std::pair< bool, bytes > operator()(
-        bytesConstRef _in, const u256& _bn, skale::OverlayFS* _overlayFS = nullptr ) const {
-        return proxy( _in, _bn, _overlayFS );
+        bytesConstRef _in, const PrecompiledCallContext& _ctx, skale::OverlayFS* _overlayFS = nullptr ) const {
+        return proxy( _in, _ctx, _overlayFS );
     }
 #endif
     PrecompiledExecutor() {}
 #ifdef FAIR
     PrecompiledExecutor(
-        const std::function< std::pair< bool, bytes >( bytesConstRef _in, const u256& _bn ) >&
+        const std::function< std::pair< bool, bytes >( bytesConstRef _in, const PrecompiledCallContext& _ctx ) >&
             _func )
         : proxy( _func ) {}
 #else
     PrecompiledExecutor( const std::function< std::pair< bool, bytes >(
-            bytesConstRef _in, const u256& _bn, skale::OverlayFS* _overlayFS ) >& _func )
+            bytesConstRef _in, const PrecompiledCallContext& _ctx, skale::OverlayFS* _overlayFS ) >& _func )
         : proxy( _func ) {}
 #endif
 
 private:
 #ifdef FAIR
-    std::function< std::pair< bool, bytes >( bytesConstRef _in, const u256& _bn ) > proxy;
+    std::function< std::pair< bool, bytes >( bytesConstRef _in, const PrecompiledCallContext& _ctx ) > proxy;
 #else
     std::function< std::pair< bool, bytes >(
-        bytesConstRef _in, const u256& _bn, skale::OverlayFS* _overlayFS ) >
+        bytesConstRef _in, const PrecompiledCallContext& _ctx, skale::OverlayFS* _overlayFS ) >
         proxy;
 #endif
 };
@@ -133,12 +138,12 @@ private:
 #ifdef FAIR
 #define ETH_REGISTER_PRECOMPILED( Name )                                                      \
     static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name(                  \
-        bytesConstRef _in, const u256& _bn );                                                 \
+        bytesConstRef _in, const PrecompiledCallContext& _ctx );                                                 \
     static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =                       \
         ::dev::eth::PrecompiledRegistrar::registerExecutor(                                   \
             #Name, PrecompiledExecutor(                                                       \
-                       []( bytesConstRef _in, const u256& _bn ) -> std::pair< bool, bytes > { \
-                           return __eth_registerPrecompiledFunction##Name( _in, _bn );        \
+                       []( bytesConstRef _in, const PrecompiledCallContext& _ctx ) -> std::pair< bool, bytes > { \
+                           return __eth_registerPrecompiledFunction##Name( _in, _ctx );       ;
                        } ) );                                                                 \
     static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name
 #else
@@ -149,15 +154,15 @@ private:
         bytesConstRef _in, const u256& _bn );                                                 \
     static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =                       \
         ::dev::eth::PrecompiledRegistrar::registerExecutor(                                   \
-            #Name, PrecompiledExecutor( []( bytesConstRef _in, const u256& _bn,               \
+            #Name, PrecompiledExecutor( []( bytesConstRef _in, const PrecompiledCallContext& _ctx,               \
                                             skale::OverlayFS* ) -> std::pair< bool, bytes > { \
-                return __eth_registerPrecompiledFunction##Name( _in, _bn );                   \
+                return __eth_registerPrecompiledFunction##Name( _in, _ctx );                   \
             } ) );                                                                            \
     static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name
 
 #define ETH_REGISTER_FS_PRECOMPILED( Name )                                           \
     static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name(          \
-        bytesConstRef _in, const u256& _bn, skale::OverlayFS* _overlayFS );           \
+        bytesConstRef _in, const PrecompiledCallContext& _ctx, skale::OverlayFS* _overlayFS );           \
     static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =               \
         ::dev::eth::PrecompiledRegistrar::registerExecutor(                           \
             #Name, PrecompiledExecutor( &__eth_registerPrecompiledFunction##Name ) ); \

--- a/libethereum/Precompiled.h
+++ b/libethereum/Precompiled.h
@@ -146,7 +146,7 @@ private:
         ::dev::eth::PrecompiledRegistrar::registerExecutor(                                   \
             #Name, PrecompiledExecutor(                                                       \
                        []( bytesConstRef _in,                                                 \
-                        const PrecompiledCallContext& _ctx ) -> std::pair< bool, bytes > {    \
+                           const PrecompiledCallContext& _ctx ) -> std::pair< bool, bytes > { \
                            return __eth_registerPrecompiledFunction##Name( _in, _ctx );       \
                        } ) );                                                                 \
     static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name

--- a/libethereum/Precompiled.h
+++ b/libethereum/Precompiled.h
@@ -145,8 +145,8 @@ private:
     static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =                       \
         ::dev::eth::PrecompiledRegistrar::registerExecutor(                                   \
             #Name, PrecompiledExecutor(                                                       \
-                       []( bytesConstRef _in, const PrecompiledCallContext& _ctx )            \
-                                                                -> std::pair< bool, bytes > { \
+                       []( bytesConstRef _in,                                                 \
+                        const PrecompiledCallContext& _ctx ) -> std::pair< bool, bytes > {    \
                            return __eth_registerPrecompiledFunction##Name( _in, _ctx );       \
                        } ) );                                                                 \
     static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name

--- a/libethereum/Precompiled.h
+++ b/libethereum/Precompiled.h
@@ -170,6 +170,7 @@ private:
     static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =                        \
         ::dev::eth::PrecompiledRegistrar::registerExecutor(                                    \
             #Name, PrecompiledExecutor( &__eth_registerPrecompiledFunction##Name ) );          \
+    static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name
 #endif
 
 #define ETH_REGISTER_PRECOMPILED_PRICER( Name )                                                  \

--- a/libethereum/Precompiled.h
+++ b/libethereum/Precompiled.h
@@ -145,8 +145,9 @@ private:
     static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =                       \
         ::dev::eth::PrecompiledRegistrar::registerExecutor(                                   \
             #Name, PrecompiledExecutor(                                                       \
-                       []( bytesConstRef _in, const PrecompiledCallContext& _ctx ) -> std::pair< bool, bytes > { \
-                           return __eth_registerPrecompiledFunction##Name( _in, _ctx );       ;
+                       []( bytesConstRef _in, const PrecompiledCallContext& _ctx )            \
+                                                                -> std::pair< bool, bytes > { \
+                           return __eth_registerPrecompiledFunction##Name( _in, _ctx );       \
                        } ) );                                                                 \
     static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name
 #else

--- a/libethereum/Precompiled.h
+++ b/libethereum/Precompiled.h
@@ -151,7 +151,7 @@ private:
 // TODO: unregister on unload with a static object.
 #define ETH_REGISTER_PRECOMPILED( Name )                                                      \
     static std::pair< bool, bytes > __eth_registerPrecompiledFunction##Name(                  \
-        bytesConstRef _in, const u256& _bn );                                                 \
+        bytesConstRef _in, const PrecompiledCallContext& _ctx );                                                 \
     static PrecompiledExecutor __eth_registerPrecompiledFactory##Name =                       \
         ::dev::eth::PrecompiledRegistrar::registerExecutor(                                   \
             #Name, PrecompiledExecutor( []( bytesConstRef _in, const PrecompiledCallContext& _ctx,               \

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -984,11 +984,13 @@ u256 SkaleHost::getGasPrice( unsigned _blockNumber ) const {
 
 u256 SkaleHost::getBlockRandom( unsigned _blockNumber ) const {
     if ( CurrentBlockRandomPatch::isEnabledInWorkingBlock() ) {
-        if ( _blockNumber > m_client.number() )
-            // cant get info about future blocks
-            // only possible if responding eth_call or eth_estimateGas request
-            _blockNumber = m_client.number();
-        return m_consensus->getRandomForBlockId( _blockNumber );
+        if ( dev::eth::g_currentTransactionIndex == -1 ) {
+            // means a call outside of block is being executed
+            // if _blockNumber > currentBlockNumber, need to decrease it by 1
+            if ( _blockNumber > m_client.number() )
+                --_blockNumber;
+        }
+        m_consensus->getRandomForBlockId( _blockNumber );
     }
     return m_consensus->getRandomForBlockId( m_client.number() );
 }

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -990,7 +990,7 @@ u256 SkaleHost::getBlockRandom( unsigned _blockNumber ) const {
             if ( _blockNumber > m_client.number() )
                 --_blockNumber;
         }
-        m_consensus->getRandomForBlockId( _blockNumber );
+        return m_consensus->getRandomForBlockId( _blockNumber );
     }
     return m_consensus->getRandomForBlockId( m_client.number() );
 }

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -984,12 +984,6 @@ u256 SkaleHost::getGasPrice( unsigned _blockNumber ) const {
 
 u256 SkaleHost::getBlockRandom( unsigned _blockNumber ) const {
     if ( CurrentBlockRandomPatch::isEnabledInWorkingBlock() ) {
-        if ( dev::eth::g_currentTransactionIndex == -1 ) {
-            // means a call outside of block is being executed
-            // if _blockNumber > currentBlockNumber, need to decrease it by 1
-            if ( _blockNumber > m_client.number() )
-                --_blockNumber;
-        }
         return m_consensus->getRandomForBlockId( _blockNumber );
     }
     return m_consensus->getRandomForBlockId( m_client.number() );

--- a/libhistoric/AlethExecutive.cpp
+++ b/libhistoric/AlethExecutive.cpp
@@ -191,8 +191,9 @@ bool AlethExecutive::call(
             m_gas = ( u256 )( _p.gas - g );
             bytes output;
             bool success;
+            PrecompiledCallContext ctx{ m_envInfo.number(), m_readOnly };
             tie( success, output ) =
-                m_chainParams.executePrecompiled( _p.codeAddress, _p.data, m_envInfo.number() );
+                m_chainParams.executePrecompiled( _p.codeAddress, _p.data, ctx );
             size_t outputSize = output.size();
             m_output = owning_bytes_ref{ std::move( output ), 0, outputSize };
             if ( !success ) {

--- a/libhistoric/AlethExecutive.cpp
+++ b/libhistoric/AlethExecutive.cpp
@@ -191,7 +191,7 @@ bool AlethExecutive::call(
             m_gas = ( u256 )( _p.gas - g );
             bytes output;
             bool success;
-            PrecompiledCallContext ctx{ m_envInfo.number(), m_readOnly };
+            PrecompiledCallContext ctx{ m_envInfo.number(), true };
             tie( success, output ) =
                 m_chainParams.executePrecompiled( _p.codeAddress, _p.data, ctx );
             size_t outputSize = output.size();

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -1114,6 +1114,7 @@ std::pair< ExecutionResult, TransactionReceipt > State::execute( EnvInfo const& 
     // transaction is bad in any way.
     // HACK 0 here is for gasPrice
     // TODO Not sure that 1st 0 as timestamp is acceptable here
+    dev::eth::g_currentTransactionIndex = _transactionIndex;
     Executive e( *this, _envInfo, _chainParams, 0, 0, _p != Permanence::Committed );
     ExecutionResult res;
     e.setResultRecipient( res );

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -1114,7 +1114,6 @@ std::pair< ExecutionResult, TransactionReceipt > State::execute( EnvInfo const& 
     // transaction is bad in any way.
     // HACK 0 here is for gasPrice
     // TODO Not sure that 1st 0 as timestamp is acceptable here
-    dev::eth::g_currentTransactionIndex = _transactionIndex;
     Executive e( *this, _envInfo, _chainParams, 0, 0, _p != Permanence::Committed );
     ExecutionResult res;
     e.setResultRecipient( res );

--- a/test/tools/libtesteth/BlockChainHelper.h
+++ b/test/tools/libtesteth/BlockChainHelper.h
@@ -76,7 +76,7 @@ public:
     void verify( TestBlockChain const& _bc ) const;
 
     void setBlockHeader( BlockHeader const& _header );
-    void setState( State const& _state );
+    void setState( skale::State const& _state );
     void clearState();
 
     BlockHeader const& premineHeader() {

--- a/test/tools/libtesteth/ImportTest.h
+++ b/test/tools/libtesteth/ImportTest.h
@@ -59,12 +59,12 @@ public:
     bytes executeTest( bool _isFilling );
     int exportTest();
 #ifdef FAIR
-    static int compareStatesFAIR( skale::State const& _stateExpect, State const& _statePost,
+    static int compareStatesFAIR( skale::State const& _stateExpect, skale::State const& _statePost,
         std::unordered_set<Address> const& owners,
         eth::AccountMaskMap const _expectedStateOptions = eth::AccountMaskMap(),
         WhenError _throw = WhenError::Throw );
 #endif
-    static int compareStates( skale::State const& _stateExpect, State const& _statePost,
+    static int compareStates( skale::State const& _stateExpect, skale::State const& _statePost,
         eth::AccountMaskMap const _expectedStateOptions = eth::AccountMaskMap(),
         WhenError _throw = WhenError::Throw );
     bool checkGeneralTestSection( json_spirit::mObject const& _expects,

--- a/test/tools/libtesteth/TestHelper.h
+++ b/test/tools/libtesteth/TestHelper.h
@@ -140,9 +140,9 @@ dev::eth::BlockHeader constructHeader( h256 const& _parentHash, h256 const& _sha
 void updateEthashSeal(
     dev::eth::BlockHeader& _header, h256 const& _mixHash, dev::eth::Nonce const& _nonce );
 RLPStream createRLPStreamFromTransactionFields( json_spirit::mObject const& _tObj );
-json_spirit::mObject fillJsonWithStateChange( State const& _stateOrig,
+json_spirit::mObject fillJsonWithStateChange( skale::State const& _stateOrig,
     skale::State const& _statePost, skale::ChangeLog const& _changeLog );
-json_spirit::mObject fillJsonWithState( State const& _state );
+json_spirit::mObject fillJsonWithState( skale::State const& _state );
 json_spirit::mObject fillJsonWithState(
     skale::State const& _state, eth::AccountMaskMap const& _map );
 json_spirit::mObject fillJsonWithTransaction( eth::Transaction const& _txn );

--- a/test/unittests/libethereum/PrecompiledTest.cpp
+++ b/test/unittests/libethereum/PrecompiledTest.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE( modexpFermatTheorem,
         "03"
         "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2e"
         "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "0000000000000000000000000000000000000000000000000000000000000001" );
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE( modexpZeroBase,
         "0000000000000000000000000000000000000000000000000000000000000020"
         "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2e"
         "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "0000000000000000000000000000000000000000000000000000000000000000" );
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE( modexpExtraByteIgnored,
         "ffff"
         "8000000000000000000000000000000000000000000000000000000000000000"
         "07" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "3b01b01ac41f2d6e917c6d6a221ce793802469026d9ab7578fa2e79e4da6aaab" );
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE( modexpRightPadding,
         "03"
         "ffff"
         "80" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "3b01b01ac41f2d6e917c6d6a221ce793802469026d9ab7578fa2e79e4da6aaab" );
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE( modexpMissingValues ) {
         "0000000000000000000000000000000000000000000000000000000000000002"
         "0000000000000000000000000000000000000000000000000000000000000020"
         "03" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "0000000000000000000000000000000000000000000000000000000000000000" );
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE( modexpEmptyValue,
         "0000000000000000000000000000000000000000000000000000000000000020"
         "03"
         "8000000000000000000000000000000000000000000000000000000000000000" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "0000000000000000000000000000000000000000000000000000000000000001" );
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE( modexpZeroPowerZero,
         "00"
         "00"
         "80" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "0000000000000000000000000000000000000000000000000000000000000001" );
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE( modexpZeroPowerZeroModZero,
         "00"
         "00"
         "00" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( res.first );
     bytes expected = fromHex( "0000000000000000000000000000000000000000000000000000000000000000" );
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE( modexpModLengthZero,
         "0000000000000000000000000000000000000000000000000000000000000000"
         "01"
         "01" );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( res.second.empty() );
@@ -1459,13 +1459,13 @@ void benchmarkPrecompiled( char const name[], vector_ref< const PrecompiledTest 
         bytes input = fromHex( test.input );
         bytesConstRef inputRef = &input;
 
-        auto res = exec( inputRef, 1 );
+        auto res = exec( inputRef, { 1, true } );
         BOOST_REQUIRE_MESSAGE( res.first, test.name );
         BOOST_REQUIRE_EQUAL( toHex( res.second ), test.expected );
 
         timer.restart();
         for ( int i = 0; i < n; ++i )
-            exec( inputRef, 1 );
+            exec( inputRef, { 1, true } );
         auto d = timer.duration() / n;
 
         auto t = std::chrono::duration_cast< std::chrono::nanoseconds >( d ).count();
@@ -1744,7 +1744,7 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
     input = input.substr(0, 58); // remove 0s in the end
 
     bytes in = fromHex( numberToHex( 29 ) + input );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( dev::fromBigEndian<dev::u256>( res.second ) == 30 );
@@ -1752,7 +1752,7 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
     input = stringToHex( "skaleConfig.sChain.nodes.0.schainIndex" );
     input = input.substr(0, 76); // remove 0s in the end
     in = fromHex( numberToHex( 38 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( dev::fromBigEndian<dev::u256>( res.second ) == 13 );
@@ -1760,21 +1760,21 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
     input = stringToHex( "skaleConfig.sChain.nodes.0.publicKey" );
     input = input.substr(0, 72); // remove 0s in the end
     in = fromHex( numberToHex( 36 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( !res.first );
 
     input = stringToHex( "skaleConfig.sChain.nodes.0.unknownField" );
     input = input.substr(0, 78); // remove 0s in the end
     in = fromHex( numberToHex( 39 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( !res.first );
 
     input = stringToHex( "skaleConfig.nodeInfo.wallets.ima.n" );
     input = input.substr(0, 68); // remove 0s in the end
     in = fromHex( numberToHex( 34 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( dev::fromBigEndian<dev::u256>( res.second ) == 1 );
@@ -1782,7 +1782,7 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
     input = stringToHex( "skaleConfig.nodeInfo.wallets.ima.t" );
     input = input.substr(0, 68); // remove 0s in the end
     in = fromHex( numberToHex( 34 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( !res.first );
 
@@ -1791,7 +1791,7 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
     input = stringToHex( "skaleConfig.sChain.nodes.0.publicKey" );
     input = input.substr(0, 72); // remove 0s in the end
     in = fromHex( numberToHex( 36 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( res.second == fromHex("0x6180cde2cbbcc6b6a17efec4503a7d4316f8612f411ee171587089f770335f484003ad236c534b9afa82befc1f69533723abdb6ec2601e582b72dcfd7919338b") );
@@ -1800,21 +1800,21 @@ BOOST_AUTO_TEST_CASE( getConfigVariable ) {
     input = input.substr(0, 58); // remove 0s in the end
 
     in = fromHex( numberToHex( 29 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( !res.first );
 
     input = stringToHex( "skaleConfig.sChain.nodes.0.schainIndex" );
     input = input.substr(0, 76); // remove 0s in the end
     in = fromHex( numberToHex( 38 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( !res.first );
 
     input = stringToHex( "skaleConfig.sChain.nodes.0.unknownField" );
     input = input.substr(0, 78); // remove 0s in the end
     in = fromHex( numberToHex( 39 ) + input );
-    res = exec( bytesConstRef( in.data(), in.size() ), 1 );
+    res = exec( bytesConstRef( in.data(), in.size() ), { 1, true } );
 
     BOOST_REQUIRE( !res.first );
 }
@@ -1869,7 +1869,7 @@ BOOST_AUTO_TEST_CASE( createFile ) {
 
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
                         numberToHex( fileSize ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true }, m_overlayFS.get() );
 
     BOOST_REQUIRE( res.first );
 
@@ -1887,7 +1887,7 @@ BOOST_AUTO_TEST_CASE( fileWithHashExtension ) {
 
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
             numberToHex( fileSize ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true }, m_overlayFS.get() );
     BOOST_REQUIRE( res.first == false);
 
     m_overlayFS->commit();
@@ -1900,7 +1900,7 @@ BOOST_AUTO_TEST_CASE( uploadChunk ) {
     std::string data = "random_data";
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
                         numberToHex( 0 ) + numberToHex( data.length() ) + stringToHex( data ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true }, m_overlayFS.get() );
     BOOST_REQUIRE( res.first );
 
     m_overlayFS->commit();
@@ -1916,7 +1916,7 @@ BOOST_AUTO_TEST_CASE( readChunk ) {
 
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
                         numberToHex( 0 ) + numberToHex( fileSize ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true }, m_overlayFS.get() );
     BOOST_REQUIRE( res.first );
 
     std::ifstream file( pathToFile.c_str(), std::ios_base::binary );
@@ -1933,7 +1933,7 @@ BOOST_AUTO_TEST_CASE( readMaliciousChunk ) {
     fileName = "../../test";
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
                         numberToHex( 0 ) + numberToHex( fileSize ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true }, m_overlayFS.get() );
     BOOST_REQUIRE( res.first == false);
 }
 
@@ -1941,7 +1941,7 @@ BOOST_AUTO_TEST_CASE( getFileSize ) {
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "getFileSize" );
 
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true }, m_overlayFS.get() );
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( res.second == toBigEndian( static_cast< u256 >( fileSize ) ) );
 }
@@ -1952,7 +1952,7 @@ BOOST_AUTO_TEST_CASE( getMaliciousFileSize ) {
     fileName = "../../test";
 
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true }, m_overlayFS.get() );
     BOOST_REQUIRE( !res.first );
 }
 
@@ -1960,20 +1960,20 @@ BOOST_AUTO_TEST_CASE( deleteFile ) {
     PrecompiledExecutor execCreate = PrecompiledRegistrar::executor( "createFile" );
     bytes inCreate = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
                             numberToHex( fileSize ) );
-    execCreate( bytesConstRef( inCreate.data(), inCreate.size() ), 1, m_overlayFS.get() );
+    execCreate( bytesConstRef( inCreate.data(), inCreate.size() ), { 1, true }, m_overlayFS.get() );
     m_overlayFS->commit();
 
     PrecompiledExecutor execHash = PrecompiledRegistrar::executor( "calculateFileHash" );
     bytes inHash = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
                         numberToHex( fileSize ) );
-    execHash( bytesConstRef( inHash.data(), inHash.size() ), 1, m_overlayFS.get() );
+    execHash( bytesConstRef( inHash.data(), inHash.size() ), { 1, true }, m_overlayFS.get() );
     m_overlayFS->commit();
 
     BOOST_REQUIRE( boost::filesystem::exists( pathToFile.string() + "._hash" ) );
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "deleteFile" );
 
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true }, m_overlayFS.get() );
     BOOST_REQUIRE( res.first );
 
     m_overlayFS->commit();
@@ -1989,7 +1989,7 @@ BOOST_AUTO_TEST_CASE( createDirectory ) {
         dev::getDataDir() / "filestorage" / ownerAddress.hex() / dirName;
 
     bytes in = fromHex( hexAddress + numberToHex( dirName.length() ) + stringToHex( dirName ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true }, m_overlayFS.get() );
     BOOST_REQUIRE( res.first );
 
     m_overlayFS->commit();
@@ -2006,7 +2006,7 @@ BOOST_AUTO_TEST_CASE( deleteDirectory ) {
     boost::filesystem::create_directories( pathToDir );
 
     bytes in = fromHex( hexAddress + numberToHex( dirName.length() ) + stringToHex( dirName ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true }, m_overlayFS.get() );
 
     BOOST_REQUIRE( res.first );
 
@@ -2028,7 +2028,7 @@ BOOST_AUTO_TEST_CASE( calculateFileHash ) {
 
     bytes in = fromHex( hexAddress + numberToHex( fileName.length() ) + stringToHex( fileName ) +
                         numberToHex( fileSize ) );
-    auto res = exec( bytesConstRef( in.data(), in.size() ), 1, m_overlayFS.get() );
+    auto res = exec( bytesConstRef( in.data(), in.size() ), { 1, true }, m_overlayFS.get() );
 
     BOOST_REQUIRE( res.first );
 

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -1415,7 +1415,7 @@ BOOST_AUTO_TEST_CASE( getBlockRandom ) {
     auto& skaleHost = fixture.skaleHost;
 
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "getBlockRandom" );
-    auto res = exec( bytesConstRef(), 1 );
+    auto res = exec( bytesConstRef(), { 1, true } );
     u256 blockRandom = skaleHost->getBlockRandom( 0 );
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( res.second == toBigEndian( static_cast< u256 >( blockRandom ) ) );
@@ -1427,7 +1427,7 @@ BOOST_AUTO_TEST_CASE( getCurrentBLSPublicKey ) {
     auto& skaleHost = fixture.skaleHost;
 
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "getIMABLSPublicKey" );
-    auto res = exec( bytesConstRef(), 1 );
+    auto res = exec( bytesConstRef(), { 1, true } );
     std::array< std::string, 4 > imaBLSPublicKey = skaleHost->getCurrentBLSPublicKey();
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( res.second == toBigEndian( dev::u256( imaBLSPublicKey[0] ) ) +

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -2202,7 +2202,7 @@ BOOST_AUTO_TEST_CASE( clearPartialReceipts ) {
         dev::eth::mineTransaction( *( fixture.client ), 1 );
         auto receipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
         dev::eth::BlockNumber blockNumber = jsToInt( receipt["blockNumber"].asString() );
-        State state( fixture.client->state() );
+        skale::State state( fixture.client->state() );
         BOOST_REQUIRE_EQUAL( blockNumber, block );
         BOOST_REQUIRE_EQUAL( state.safePartialTransactionReceipts( blockNumber ).size(), 0 );
         int64_t expectedSize = block == expectedNoLegacyReceiptsBlock ? 0 : 1;


### PR DESCRIPTION
fixes https://github.com/skalenetwork/internal-support/issues/1341

pass `PrecompiledCallContext` to precompiled contracts to differentiate external call against transaction execution
`PrecompiledCallContext` can also be used in the future to pass more info to precompiled contracts

verified on a devnet