### PR TITLE
1247 leveldb options

### DIFF
--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -269,6 +269,7 @@ db::LevelDB::LevelDBOptions State::getLevelDBConfig() const {
     levelDbOptions.dbOptions.write_buffer_size = 64 * 1024 * 1024;
     levelDbOptions.dbOptions.max_file_size = 16 * 1024 * 1024;
     levelDbOptions.dbOptions.max_open_files = 2000;
+    levelDbOptions.dbOptions.block_size = 32 * 1024;
     return levelDbOptions;
 }
 

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -240,7 +240,13 @@ skale::OverlayDB State::openDB(
 
     fs::path state_path = path / fs::path( "state" );
     try {
-        m_orig_db.reset( new db::DBImpl( state_path ) );
+        db::LevelDB::LevelDBOptions levelDbOptions;
+        levelDbOptions.dbOptions.write_buffer_size = 64 * 1024 * 1024;
+        levelDbOptions.dbOptions.max_file_size = 16 * 1024 * 1024;
+        levelDbOptions.dbOptions.max_open_files = 2000;
+        levelDbOptions.dbOptions.block_size = 32 * 1024;
+        levelDbOptions.dbOptions.filter_policy = leveldb::NewBloomFilterPolicy( 10 );
+        m_orig_db.reset( new db::DBImpl( state_path, levelDbOptions ) );
         std::unique_ptr< batched_io::batched_db > bdb = make_unique< batched_io::batched_db >();
         bdb->open( m_orig_db );
         assert( bdb->is_open() );

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -269,8 +269,6 @@ db::LevelDB::LevelDBOptions State::getLevelDBConfig() const {
     levelDbOptions.dbOptions.write_buffer_size = 64 * 1024 * 1024;
     levelDbOptions.dbOptions.max_file_size = 16 * 1024 * 1024;
     levelDbOptions.dbOptions.max_open_files = 2000;
-    levelDbOptions.dbOptions.block_size = 32 * 1024;
-    levelDbOptions.dbOptions.filter_policy = leveldb::NewBloomFilterPolicy( 10 );
     return levelDbOptions;
 }
 

--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -240,13 +240,7 @@ skale::OverlayDB State::openDB(
 
     fs::path state_path = path / fs::path( "state" );
     try {
-        db::LevelDB::LevelDBOptions levelDbOptions;
-        levelDbOptions.dbOptions.write_buffer_size = 64 * 1024 * 1024;
-        levelDbOptions.dbOptions.max_file_size = 16 * 1024 * 1024;
-        levelDbOptions.dbOptions.max_open_files = 2000;
-        levelDbOptions.dbOptions.block_size = 32 * 1024;
-        levelDbOptions.dbOptions.filter_policy = leveldb::NewBloomFilterPolicy( 10 );
-        m_orig_db.reset( new db::DBImpl( state_path, levelDbOptions ) );
+        m_orig_db.reset( new db::DBImpl( state_path, getLevelDBConfig() ) );
         std::unique_ptr< batched_io::batched_db > bdb = make_unique< batched_io::batched_db >();
         bdb->open( m_orig_db );
         assert( bdb->is_open() );
@@ -268,6 +262,16 @@ skale::OverlayDB State::openDB(
             BOOST_THROW_EXCEPTION( eth::DatabaseAlreadyOpen() );
         }
     }
+}
+
+db::LevelDB::LevelDBOptions State::getLevelDBConfig() const {
+    db::LevelDB::LevelDBOptions levelDbOptions;
+    levelDbOptions.dbOptions.write_buffer_size = 64 * 1024 * 1024;
+    levelDbOptions.dbOptions.max_file_size = 16 * 1024 * 1024;
+    levelDbOptions.dbOptions.max_open_files = 2000;
+    levelDbOptions.dbOptions.block_size = 32 * 1024;
+    levelDbOptions.dbOptions.filter_policy = leveldb::NewBloomFilterPolicy( 10 );
+    return levelDbOptions;
 }
 
 State::State( const State& _s )

--- a/libskale/State.h
+++ b/libskale/State.h
@@ -467,6 +467,7 @@ private:
     /// necessary.
     OverlayDB openDB( boost::filesystem::path const& _path, dev::h256 const& _genesisHash,
         dev::WithExisting _we = dev::WithExisting::Trust );
+    db::LevelDB::LevelDBOptions getLevelDBConfig() const;
 
     /// Turns all "touched" empty accounts into non-alive accounts.
     void removeEmptyAccounts();

--- a/libskale/State.h
+++ b/libskale/State.h
@@ -467,7 +467,7 @@ private:
     /// necessary.
     OverlayDB openDB( boost::filesystem::path const& _path, dev::h256 const& _genesisHash,
         dev::WithExisting _we = dev::WithExisting::Trust );
-    db::LevelDB::LevelDBOptions getLevelDBConfig() const;
+    dev::db::LevelDB::LevelDBOptions getLevelDBConfig() const;
 
     /// Turns all "touched" empty accounts into non-alive accounts.
     void removeEmptyAccounts();


### PR DESCRIPTION
## Description

This pull request updates the LevelDB configuration in State.cpp to reduce the number of compactions.

The goal is to minimize the likelihood of invalid state writes under high load. By increasing certain memory-related parameters, more data can be held in memory, resulting in less frequent flushes and compactions.

Key configuration changes:

`write_buffer_size` – Increases the size of the in-memory MemTable, allowing more state data to be buffered before flushing, thereby reducing flush frequency.

`max_file_size` – Raises the maximum size of SSTable files (starting from level 1), which helps reduce the number of compactions.

`max_open_files` – Allows LevelDB to keep more files open simultaneously (before it was 1,000), improving performance without significantly impacting the rest of the system.

`block_size` - Helps to reduce memory consumption by moving more data to cache.  

## Target issue 
Should be applied to fix https://github.com/skalenetwork/internal-support/issues/1247.

## Tests

- Tested on local network.
- Tested on mainnet indexer node (nebula).

## Performance 
- Memory consumption increased (~80Mb) , because more data holds in memory (`write_buffer_size` increased), but plot below shows similar behavior overall. 
- Catchup has similar performance. 
- Disk read performance behaves similarly.
- Disk write curve has higher peaks, but difference is around ~20Mb.

## Measurements 
### 4.0.2

#### Blocks

<img width="1071" height="476" alt="Pasted image 20251211170544" src="https://github.com/user-attachments/assets/5b769462-39d4-4073-bf5d-f9befb86551f" />

<img width="2270" height="1366" alt="Pasted image 20251211160214" src="https://github.com/user-attachments/assets/7e17934f-5687-4469-99e3-050a76473858" />

#### Leveldb 
<img width="1098" height="483" alt="Pasted image 20251211160250" src="https://github.com/user-attachments/assets/68a8126c-f31c-473a-bb6a-45de4334524e" />

#### OS

<img width="2270" height="1366" alt="Pasted image 20251211160516" src="https://github.com/user-attachments/assets/884502a7-61f3-4ce5-a0d6-2f6334e30e3e" />
<img width="2270" height="1366" alt="Pasted image 20251211160531" src="https://github.com/user-attachments/assets/5edb4980-ca89-419a-9d34-d82384f76b34" />
<img width="2270" height="1366" alt="Pasted image 20251211160601" src="https://github.com/user-attachments/assets/9a20cd97-9706-42b7-aee3-00cf65082555" />
<img width="2270" height="1366" alt="Pasted image 20251211160545" src="https://github.com/user-attachments/assets/6975e1ca-0902-4227-9edd-6c9d6b58ad84" />


### New version 

#### Blocks 
<img width="786" height="293" alt="block-per-second" src="https://github.com/user-attachments/assets/710af770-a575-47d7-8d84-c5e3e1a0e5f5" />

<img width="1601" height="783" alt="blocks-per-second" src="https://github.com/user-attachments/assets/a36bd5ea-8ebd-44f8-81de-49f036fc5965" />

#### LevelDB
<img width="781" height="289" alt="comp" src="https://github.com/user-attachments/assets/88b62335-8fdb-49ae-83a3-9eb4f96d40a1" />

#### OS
<img width="1589" height="773" alt="ram" src="https://github.com/user-attachments/assets/cf3a6eaf-45d1-495e-b4e0-b7dc906b6f70" />
<img width="1584" height="783" alt="reads" src="https://github.com/user-attachments/assets/e05d9d0a-e7b4-4db4-96c8-d267971ec0bc" />

<img width="1582" height="775" alt="writes" src="https://github.com/user-attachments/assets/1b199977-3c32-4b8c-980d-b17e07ac1545" />

<img width="1590" height="777" alt="cpu" src="https://github.com/user-attachments/assets/0373ede7-4fdc-4f75-a506-cb733fdab63b" />


### Steps to reproduce
The best way to reproduce the bug is to restore nebula indexer from snapshot.