### PR TITLE
Add encryptTE and encryptECIES precompiled SCs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,8 @@ if (BITE2)
 endif()
 
 if (FAIR)
+    set(BITE1 "1")
+    set(BITE2 "1")
     add_definitions(-DBITE=1)
     add_definitions(-DBITE2=1)
     add_definitions(-DFAIR=1)

--- a/libdevcrypto/Common.cpp
+++ b/libdevcrypto/Common.cpp
@@ -26,8 +26,10 @@
 #include "AES.h"
 #include "CryptoPP.h"
 #include "Exceptions.h"
+#include "Hash.h"
 
 #include <cryptopp/aes.h>
+#include <cryptopp/filters.h>
 #include <cryptopp/modes.h>
 #include <cryptopp/pwdbased.h>
 #include <cryptopp/sha.h>
@@ -409,5 +411,152 @@ SignatureStruct dev::makeSignature( const bytes& entropy, const dev::u256& txInd
     uint8_t parity = ( uint8_t )( ( uint64_t ) h3[0] & 0x01 );
 
     return SignatureStruct( h256( r ), h256( s ), parity );
+}
+
+bytes dev::compressPublicKey( Public const& _pub ) {
+    auto* ctx = getCtx();
+
+    // Build uncompressed format: 0x04 || x || y (65 bytes)
+    std::array<uint8_t, 65> uncompressedPubKey;
+    uncompressedPubKey[0] = 0x04;
+    memcpy( uncompressedPubKey.data() + 1, _pub.data(), 64 );
+
+    // Parse into secp256k1 internal format
+    secp256k1_pubkey parsedPubKey;
+    if ( !secp256k1_ec_pubkey_parse(
+             ctx, &parsedPubKey, uncompressedPubKey.data(), uncompressedPubKey.size() ) ) {
+        return {};  // Invalid public key
+    }
+
+    // Serialize to compressed format (33 bytes)
+    bytes result( 33 );
+    size_t outputLen = 33;
+    secp256k1_ec_pubkey_serialize(
+        ctx, result.data(), &outputLen, &parsedPubKey, SECP256K1_EC_COMPRESSED );
+
+    return result;
+}
+
+Public dev::decompressPublicKey( bytesConstRef _compressed ) {
+    if ( _compressed.size() != 33 )
+        return {};
+
+    auto* ctx = getCtx();
+
+    // Parse compressed public key
+    secp256k1_pubkey parsedPubKey;
+    if ( !secp256k1_ec_pubkey_parse( ctx, &parsedPubKey, _compressed.data(), _compressed.size() ) )
+        return {};
+
+    // Serialize to uncompressed format (65 bytes: 0x04 prefix + 64 bytes)
+    std::array<uint8_t, 65> uncompressedPubKey;
+    size_t outputLen = 65;
+    secp256k1_ec_pubkey_serialize(
+        ctx, uncompressedPubKey.data(), &outputLen, &parsedPubKey, SECP256K1_EC_UNCOMPRESSED );
+
+    // Return the 64 bytes (skip the 0x04 prefix)
+    return Public( &uncompressedPubKey[1], Public::ConstructFromPointer );
+}
+
+bool dev::isValidPublicKey( Public const& _pub ) {
+    if ( !_pub )
+        return false;
+
+    auto* ctx = getCtx();
+
+    // Build uncompressed format: 0x04 || x || y (65 bytes)
+    std::array<uint8_t, 65> uncompressedPubKey;
+    uncompressedPubKey[0] = 0x04;
+    memcpy( uncompressedPubKey.data() + 1, _pub.data(), 64 );
+
+    // Try to parse - this validates it's on the curve
+    secp256k1_pubkey parsedPubKey;
+    return secp256k1_ec_pubkey_parse(
+        ctx, &parsedPubKey, uncompressedPubKey.data(), uncompressedPubKey.size() );
+}
+
+bytes dev::encryptECIES_CBC( Public const& _recipientPubKey, bytesConstRef _plain ) {
+    if ( _plain.empty() )
+        return {};
+
+    // Generate ephemeral key pair
+    KeyPair ephemeralKeyPair = KeyPair::create();
+
+    // ECDH: shared secret = ephemeral_private * recipient_public
+    Secret sharedSecret;
+    if ( !crypto::ecdh::agree( ephemeralKeyPair.secret(), _recipientPubKey, sharedSecret ) )
+        return {};
+
+    // KDF: encryption_key = SHA-256(shared_secret)
+    h256 encryptionKey = sha256( sharedSecret.ref() );
+
+    // Generate random IV (16 bytes)
+    h128 iv = h128::random();
+
+    // AES-256-CBC encryption with PKCS7 padding
+    CryptoPP::CBC_Mode<CryptoPP::AES>::Encryption aesEncryptor;
+    aesEncryptor.SetKeyWithIV( encryptionKey.data(), encryptionKey.size, iv.data() );
+
+    std::string ciphertextStr;
+    CryptoPP::StreamTransformationFilter stfEncryptor(
+        aesEncryptor, new CryptoPP::StringSink( ciphertextStr ) );
+    stfEncryptor.Put( _plain.data(), _plain.size() );
+    stfEncryptor.MessageEnd();
+
+    // Compress ephemeral public key to 33 bytes
+    bytes compressedEphPubKey = compressPublicKey( ephemeralKeyPair.pub() );
+    if ( compressedEphPubKey.empty() )
+        return {};
+
+    // Output format: [IV(16)] [CompressedEphPubKey(33)] [Ciphertext]
+    bytes result;
+    result.reserve( 16 + 33 + ciphertextStr.size() );
+    result.insert( result.end(), iv.begin(), iv.end() );
+    result.insert( result.end(), compressedEphPubKey.begin(), compressedEphPubKey.end() );
+    result.insert( result.end(), ciphertextStr.begin(), ciphertextStr.end() );
+
+    return result;
+}
+
+bytes dev::decryptECIES_CBC( Secret const& _recipientPrivKey, bytesConstRef _cipher ) {
+    // Minimum size: IV(16) + CompressedPubKey(33) + at least 1 block(16)
+    static constexpr size_t MIN_CIPHER_SIZE = 16 + 33 + 16;
+    if ( _cipher.size() < MIN_CIPHER_SIZE )
+        return {};
+
+    // Parse input: [IV(16)] [CompressedEphPubKey(33)] [Ciphertext]
+    h128 iv( _cipher.cropped( 0, 16 ) );
+    bytesConstRef compressedEphPubKey = _cipher.cropped( 16, 33 );
+    bytesConstRef ciphertext = _cipher.cropped( 49 );
+
+    // Decompress ephemeral public key
+    Public ephemeralPubKey = decompressPublicKey( compressedEphPubKey );
+    if ( !ephemeralPubKey )
+        return {};
+
+    // ECDH: shared secret = recipient_private * ephemeral_public
+    Secret sharedSecret;
+    if ( !crypto::ecdh::agree( _recipientPrivKey, ephemeralPubKey, sharedSecret ) )
+        return {};
+
+    // KDF: encryption_key = SHA-256(shared_secret)
+    h256 encryptionKey = sha256( sharedSecret.ref() );
+
+    // AES-256-CBC decryption with PKCS7 unpadding
+    CryptoPP::CBC_Mode<CryptoPP::AES>::Decryption aesDecryptor;
+    aesDecryptor.SetKeyWithIV( encryptionKey.data(), encryptionKey.size, iv.data() );
+
+    std::string plaintextStr;
+    try {
+        CryptoPP::StreamTransformationFilter stfDecryptor(
+            aesDecryptor, new CryptoPP::StringSink( plaintextStr ),
+            CryptoPP::BlockPaddingSchemeDef::PKCS_PADDING );
+        stfDecryptor.Put( ciphertext.data(), ciphertext.size() );
+        stfDecryptor.MessageEnd();
+    } catch ( ... ) {
+        return {};  // Decryption or padding error
+    }
+
+    return bytes( plaintextStr.begin(), plaintextStr.end() );
 }
 #endif

--- a/libdevcrypto/Common.cpp
+++ b/libdevcrypto/Common.cpp
@@ -57,7 +57,7 @@ secp256k1_context const& getCtx() {
         &secp256k1_context_destroy
     };
 
-    if (!s_ctx) {
+    if ( !s_ctx ) {
         throw std::runtime_error( "Failed to create secp256k1 context" );
     }
 
@@ -222,7 +222,7 @@ static const u256 c_secp256k1n(
 Signature dev::sign( Secret const& _k, h256 const& _hash ) {
     auto& ctx = getCtx();
     secp256k1_ecdsa_recoverable_signature rawSig;
-    if ( !secp256k1_ecdsa_sign_recoverable( 
+    if ( !secp256k1_ecdsa_sign_recoverable(
              &ctx, &rawSig, _hash.data(), _k.data(), nullptr, nullptr ) )
         return {};
 

--- a/libdevcrypto/Common.cpp
+++ b/libdevcrypto/Common.cpp
@@ -51,12 +51,17 @@ using namespace dev::crypto;
 
 namespace {
 
-secp256k1_context const* getCtx() {
+secp256k1_context const& getCtx() {
     static std::unique_ptr< secp256k1_context, decltype( &secp256k1_context_destroy ) > s_ctx{
         secp256k1_context_create( SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY ),
         &secp256k1_context_destroy
     };
-    return s_ctx.get();
+
+    if (!s_ctx) {
+        throw std::runtime_error( "Failed to create secp256k1 context" );
+    }
+
+    return *s_ctx;
 }
 
 }  // namespace
@@ -69,14 +74,14 @@ bool dev::SignatureStruct::isValid() const noexcept {
 }
 
 Public dev::toPublic( Secret const& _secret ) {
-    auto* ctx = getCtx();
+    auto& ctx = getCtx();
     secp256k1_pubkey rawPubkey;
     // Creation will fail if the secret key is invalid.
-    if ( !secp256k1_ec_pubkey_create( ctx, &rawPubkey, _secret.data() ) )
+    if ( !secp256k1_ec_pubkey_create( &ctx, &rawPubkey, _secret.data() ) )
         return {};
     std::array< _byte_, 65 > serializedPubkey;
     size_t serializedPubkeySize = serializedPubkey.size();
-    secp256k1_ec_pubkey_serialize( ctx, serializedPubkey.data(), &serializedPubkeySize, &rawPubkey,
+    secp256k1_ec_pubkey_serialize( &ctx, serializedPubkey.data(), &serializedPubkeySize, &rawPubkey,
         SECP256K1_EC_UNCOMPRESSED );
     assert( serializedPubkeySize == serializedPubkey.size() );
     // Expect single byte header of value 0x04 -- uncompressed public key.
@@ -191,18 +196,18 @@ Public dev::recover( Signature const& _sig, h256 const& _message ) {
     if ( v > 3 )
         return {};
 
-    auto* ctx = getCtx();
+    auto& ctx = getCtx();
     secp256k1_ecdsa_recoverable_signature rawSig;
-    if ( !secp256k1_ecdsa_recoverable_signature_parse_compact( ctx, &rawSig, _sig.data(), v ) )
+    if ( !secp256k1_ecdsa_recoverable_signature_parse_compact( &ctx, &rawSig, _sig.data(), v ) )
         return {};
 
     secp256k1_pubkey rawPubkey;
-    if ( !secp256k1_ecdsa_recover( ctx, &rawPubkey, &rawSig, _message.data() ) )
+    if ( !secp256k1_ecdsa_recover( &ctx, &rawPubkey, &rawSig, _message.data() ) )
         return {};
 
     std::array< _byte_, 65 > serializedPubkey;
     size_t serializedPubkeySize = serializedPubkey.size();
-    secp256k1_ec_pubkey_serialize( ctx, serializedPubkey.data(), &serializedPubkeySize, &rawPubkey,
+    secp256k1_ec_pubkey_serialize( &ctx, serializedPubkey.data(), &serializedPubkeySize, &rawPubkey,
         SECP256K1_EC_UNCOMPRESSED );
     assert( serializedPubkeySize == serializedPubkey.size() );
     // Expect single byte header of value 0x04 -- uncompressed public key.
@@ -215,15 +220,15 @@ static const u256 c_secp256k1n(
     "115792089237316195423570985008687907852837564279074904382605163141518161494337" );
 
 Signature dev::sign( Secret const& _k, h256 const& _hash ) {
-    auto* ctx = getCtx();
+    auto& ctx = getCtx();
     secp256k1_ecdsa_recoverable_signature rawSig;
-    if ( !secp256k1_ecdsa_sign_recoverable(
-             ctx, &rawSig, _hash.data(), _k.data(), nullptr, nullptr ) )
+    if ( !secp256k1_ecdsa_sign_recoverable( 
+             &ctx, &rawSig, _hash.data(), _k.data(), nullptr, nullptr ) )
         return {};
 
     Signature s;
     int v = 0;
-    secp256k1_ecdsa_recoverable_signature_serialize_compact( ctx, s.data(), &v, &rawSig );
+    secp256k1_ecdsa_recoverable_signature_serialize_compact( &ctx, s.data(), &v, &rawSig );
 
     SignatureStruct& ss = *reinterpret_cast< SignatureStruct* >( &s );
     ss.v = static_cast< _byte_ >( v );
@@ -303,18 +308,18 @@ Secret Nonce::next() {
 }
 
 bool ecdh::agree( Secret const& _s, Public const& _r, Secret& o_s ) noexcept {
-    auto* ctx = getCtx();
+    auto& ctx = getCtx();
     static_assert( sizeof( Secret ) == 32, "Invalid Secret type size" );
     secp256k1_pubkey rawPubkey;
     std::array< _byte_, 65 > serializedPubKey{ { 0x04 } };
     std::copy( _r.asArray().begin(), _r.asArray().end(), serializedPubKey.begin() + 1 );
     if ( !secp256k1_ec_pubkey_parse(
-             ctx, &rawPubkey, serializedPubKey.data(), serializedPubKey.size() ) )
+             &ctx, &rawPubkey, serializedPubKey.data(), serializedPubKey.size() ) )
         return false;  // Invalid public key.
     // FIXME: We should verify the public key when constructed, maybe even keep
     //        secp256k1_pubkey as the internal data of Public.
     std::array< _byte_, 33 > compressedPoint;
-    if ( !secp256k1_ecdh_raw( ctx, compressedPoint.data(), &rawPubkey, _s.data() ) )
+    if ( !secp256k1_ecdh_raw( &ctx, compressedPoint.data(), &rawPubkey, _s.data() ) )
         return false;  // Invalid secret key.
     std::copy( compressedPoint.begin() + 1, compressedPoint.end(), o_s.writable().data() );
     return true;
@@ -414,7 +419,7 @@ SignatureStruct dev::makeSignature( const bytes& entropy, const dev::u256& txInd
 }
 
 bytes dev::compressPublicKey( Public const& _pub ) {
-    auto* ctx = getCtx();
+    auto& ctx = getCtx();
 
     // Build uncompressed format: 0x04 || x || y (65 bytes)
     std::array< uint8_t, 65 > uncompressedPubKey;
@@ -424,7 +429,7 @@ bytes dev::compressPublicKey( Public const& _pub ) {
     // Parse into secp256k1 internal format
     secp256k1_pubkey parsedPubKey;
     if ( !secp256k1_ec_pubkey_parse(
-             ctx, &parsedPubKey, uncompressedPubKey.data(), uncompressedPubKey.size() ) ) {
+             &ctx, &parsedPubKey, uncompressedPubKey.data(), uncompressedPubKey.size() ) ) {
         return {};  // Invalid public key
     }
 
@@ -432,7 +437,7 @@ bytes dev::compressPublicKey( Public const& _pub ) {
     bytes result( 33 );
     size_t outputLen = 33;
     secp256k1_ec_pubkey_serialize(
-        ctx, result.data(), &outputLen, &parsedPubKey, SECP256K1_EC_COMPRESSED );
+        &ctx, result.data(), &outputLen, &parsedPubKey, SECP256K1_EC_COMPRESSED );
 
     return result;
 }
@@ -441,18 +446,18 @@ Public dev::decompressPublicKey( bytesConstRef _compressed ) {
     if ( _compressed.size() != 33 )
         return {};
 
-    auto* ctx = getCtx();
+    auto& ctx = getCtx();
 
     // Parse compressed public key
     secp256k1_pubkey parsedPubKey;
-    if ( !secp256k1_ec_pubkey_parse( ctx, &parsedPubKey, _compressed.data(), _compressed.size() ) )
+    if ( !secp256k1_ec_pubkey_parse( &ctx, &parsedPubKey, _compressed.data(), _compressed.size() ) )
         return {};
 
     // Serialize to uncompressed format (65 bytes: 0x04 prefix + 64 bytes)
     std::array< uint8_t, 65 > uncompressedPubKey;
     size_t outputLen = 65;
     secp256k1_ec_pubkey_serialize(
-        ctx, uncompressedPubKey.data(), &outputLen, &parsedPubKey, SECP256K1_EC_UNCOMPRESSED );
+        &ctx, uncompressedPubKey.data(), &outputLen, &parsedPubKey, SECP256K1_EC_UNCOMPRESSED );
 
     // Return the 64 bytes (skip the 0x04 prefix)
     return Public( &uncompressedPubKey[1], Public::ConstructFromPointer );
@@ -462,7 +467,7 @@ bool dev::isValidPublicKey( Public const& _pub ) {
     if ( !_pub )
         return false;
 
-    auto* ctx = getCtx();
+    auto& ctx = getCtx();
 
     // Build uncompressed format: 0x04 || x || y (65 bytes)
     std::array< uint8_t, 65 > uncompressedPubKey;
@@ -472,7 +477,7 @@ bool dev::isValidPublicKey( Public const& _pub ) {
     // Try to parse - this validates it's on the curve
     secp256k1_pubkey parsedPubKey;
     return secp256k1_ec_pubkey_parse(
-        ctx, &parsedPubKey, uncompressedPubKey.data(), uncompressedPubKey.size() );
+        &ctx, &parsedPubKey, uncompressedPubKey.data(), uncompressedPubKey.size() );
 }
 
 bytes dev::encryptECIES_CBC( Public const& _recipientPubKey, bytesConstRef _plain ) {

--- a/libdevcrypto/Common.cpp
+++ b/libdevcrypto/Common.cpp
@@ -481,8 +481,8 @@ bool dev::isValidPublicKey( Public const& _pub ) {
 }
 
 bytes dev::encryptECIES_CBC( Public const& _recipientPubKey, bytesConstRef _plain ) {
-    if ( _plain.empty() )
-        return {};
+    // Note: Empty plaintext is allowed - with PKCS7 padding it produces a 16-byte padding block
+    // This prevents distinguishing between empty and non-empty encrypted payloads
 
     // Generate ephemeral key pair
     KeyPair ephemeralKeyPair = KeyPair::create();

--- a/libdevcrypto/Common.cpp
+++ b/libdevcrypto/Common.cpp
@@ -417,7 +417,7 @@ bytes dev::compressPublicKey( Public const& _pub ) {
     auto* ctx = getCtx();
 
     // Build uncompressed format: 0x04 || x || y (65 bytes)
-    std::array<uint8_t, 65> uncompressedPubKey;
+    std::array< uint8_t, 65 > uncompressedPubKey;
     uncompressedPubKey[0] = 0x04;
     memcpy( uncompressedPubKey.data() + 1, _pub.data(), 64 );
 
@@ -449,7 +449,7 @@ Public dev::decompressPublicKey( bytesConstRef _compressed ) {
         return {};
 
     // Serialize to uncompressed format (65 bytes: 0x04 prefix + 64 bytes)
-    std::array<uint8_t, 65> uncompressedPubKey;
+    std::array< uint8_t, 65 > uncompressedPubKey;
     size_t outputLen = 65;
     secp256k1_ec_pubkey_serialize(
         ctx, uncompressedPubKey.data(), &outputLen, &parsedPubKey, SECP256K1_EC_UNCOMPRESSED );
@@ -465,7 +465,7 @@ bool dev::isValidPublicKey( Public const& _pub ) {
     auto* ctx = getCtx();
 
     // Build uncompressed format: 0x04 || x || y (65 bytes)
-    std::array<uint8_t, 65> uncompressedPubKey;
+    std::array< uint8_t, 65 > uncompressedPubKey;
     uncompressedPubKey[0] = 0x04;
     memcpy( uncompressedPubKey.data() + 1, _pub.data(), 64 );
 
@@ -494,7 +494,7 @@ bytes dev::encryptECIES_CBC( Public const& _recipientPubKey, bytesConstRef _plai
     h128 iv = h128::random();
 
     // AES-256-CBC encryption with PKCS7 padding
-    CryptoPP::CBC_Mode<CryptoPP::AES>::Encryption aesEncryptor;
+    CryptoPP::CBC_Mode< CryptoPP::AES >::Encryption aesEncryptor;
     aesEncryptor.SetKeyWithIV( encryptionKey.data(), encryptionKey.size, iv.data() );
 
     std::string ciphertextStr;
@@ -543,13 +543,13 @@ bytes dev::decryptECIES_CBC( Secret const& _recipientPrivKey, bytesConstRef _cip
     h256 encryptionKey = sha256( sharedSecret.ref() );
 
     // AES-256-CBC decryption with PKCS7 unpadding
-    CryptoPP::CBC_Mode<CryptoPP::AES>::Decryption aesDecryptor;
+    CryptoPP::CBC_Mode< CryptoPP::AES >::Decryption aesDecryptor;
     aesDecryptor.SetKeyWithIV( encryptionKey.data(), encryptionKey.size, iv.data() );
 
     std::string plaintextStr;
     try {
-        CryptoPP::StreamTransformationFilter stfDecryptor(
-            aesDecryptor, new CryptoPP::StringSink( plaintextStr ),
+        CryptoPP::StreamTransformationFilter stfDecryptor( aesDecryptor,
+            new CryptoPP::StringSink( plaintextStr ),
             CryptoPP::BlockPaddingSchemeDef::PKCS_PADDING );
         stfDecryptor.Put( ciphertext.data(), ciphertext.size() );
         stfDecryptor.MessageEnd();

--- a/libdevcrypto/Common.h
+++ b/libdevcrypto/Common.h
@@ -154,6 +154,27 @@ bool isValidSecp256k1X( const u256& x );
 
 // Return (r,s,v) fabricated from entropy bytes and transaction index.
 SignatureStruct makeSignature( const bytes& entropy, const dev::u256& txIndex );
+
+// Compress a 64-byte public key to 33-byte compressed format.
+// Returns empty bytes on failure.
+bytes compressPublicKey( Public const& _pub );
+
+// Decompress a 33-byte compressed public key to 64-byte uncompressed format.
+// Returns null Public on failure.
+Public decompressPublicKey( bytesConstRef _compressed );
+
+// Check if a 64-byte public key is a valid point on the secp256k1 curve.
+bool isValidPublicKey( Public const& _pub );
+
+/// Encrypt using ECIES with AES-256-CBC and PKCS7 padding.
+/// Output format: [IV(16)] [CompressedEphPubKey(33)] [Ciphertext]
+/// Returns empty bytes on failure.
+bytes encryptECIES_CBC( Public const& _recipientPubKey, bytesConstRef _plain );
+
+/// Decrypt ECIES ciphertext encrypted with AES-256-CBC and PKCS7 padding.
+/// Input format: [IV(16)] [CompressedEphPubKey(33)] [Ciphertext]
+/// Returns empty bytes on failure.
+bytes decryptECIES_CBC( Secret const& _recipientPrivKey, bytesConstRef _cipher );
 #endif
 
 /// Simple class that represents a "key pair".

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -23,8 +23,11 @@
 
 #include "Precompiled.h"
 
+#include <cryptopp/aes.h>
 #include <cryptopp/files.h>
+#include <cryptopp/filters.h>
 #include <cryptopp/hex.h>
+#include <cryptopp/modes.h>
 #include <cryptopp/sha.h>
 #include <libdevcore/CommonJS.h>
 #include <libdevcore/FileSystem.h>
@@ -1168,12 +1171,52 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
             return { false, toBigEndian( dev::u256( 1 ) ) };  // error 1: input too large
         }
 
-        if ( _in.empty() ) {
-            return { false, toBigEndian( dev::u256( 2 ) ) };  // error 2: empty input
+        // Input format: abi.encode(address scAddress, bytes data)
+        // ABI encoding: [scAddress(20 bytes, left-padded to 32)] [offset_to_data(32)]
+        //               [data_length(32)] [data(N)]
+        // Minimum: 32 (address) + 32 (offset) + 32 (length) = 96 bytes
+        if ( _in.size() < 96 ) {
+            return { false, toBigEndian( dev::u256( 2 ) ) };  // error 2: input too small
         }
 
         if ( !g_skaleHost ) {
             throw std::runtime_error( "SkaleHost accessor was not initialized" );
+        }
+
+        int headFieldSizeBytes = 32;
+
+        // First 32 bytes: SC address (20 bytes, left-padded to 32)
+        // Skip the first 12 bytes (padding), extract the 20-byte address
+        auto scAddressBytes = _in.cropped( 12, 20 ).toBytes();
+
+        // Next 32 bytes: offset to data (should be 64 = 2 * 32)
+        bigint const dataOffset( parseBigEndianRightPadded( _in, 32, headFieldSizeBytes ) );
+        const int expectedDataOffset = 2 * 32;  // 64
+        if ( dataOffset != expectedDataOffset ) {
+            return { false, toBigEndian( dev::u256( 3 ) ) };  // error 3: invalid ABI encoding
+        }
+
+        // Read data length at the data offset (position 64)
+        if ( _in.size() < expectedDataOffset + headFieldSizeBytes ) {
+            return { false, toBigEndian( dev::u256( 4 ) ) };  // error 4: data length mismatch
+        }
+        bigint const dataLength(
+            parseBigEndianRightPadded( _in, expectedDataOffset, headFieldSizeBytes ) );
+
+        // Extract data bytes
+        size_t dataStart = expectedDataOffset + headFieldSizeBytes;
+        if ( dataLength < 0 || dataStart + static_cast< size_t >( dataLength ) > _in.size() ) {
+            return { false, toBigEndian( dev::u256( 4 ) ) };  // error 4: data length mismatch
+        }
+
+        std::vector< uint8_t > dataToEncrypt;
+        if ( dataLength > 0 ) {
+            dataToEncrypt =
+                _in.cropped( dataStart, static_cast< size_t >( dataLength ) ).toBytes();
+        }
+
+        if ( dataToEncrypt.empty() ) {
+            return { false, toBigEndian( dev::u256( 5 ) ) };  // error 5: empty data
         }
 
         // get network public key
@@ -1184,17 +1227,16 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
             libBLS::algebra::G2Point::fromString( blsPublicKeyArray, libBLS::Base::DEC );
         libBLS::TEPublicKey tePublicKey( publicKeyG2 );
 
-        // convert input to vector
-        std::vector< uint8_t > inputData( _in.begin(), _in.end() );
-
-        // encrypt using threshold encryption
+        // encrypt using threshold encryption with SC address as AAD
+        std::optional< std::vector< uint8_t > > aad =
+            std::vector< uint8_t >( scAddressBytes.begin(), scAddressBytes.end() );
         libBLS::Ciphertext ciphertext =
-            libBLS::ThresholdEncryption::encrypt( inputData, tePublicKey );
+            libBLS::ThresholdEncryption::encrypt( dataToEncrypt, tePublicKey, aad );
 
         // convert ciphertext to bytes
         bytes response = ciphertext.toBytes();
         return { true, response };
-        
+
     } catch ( std::exception& ex ) {
         std::string strError = ex.what();
         if ( strError.empty() )
@@ -1204,6 +1246,99 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
     } catch ( ... ) {
         BOOST_LOG( getLogger( VerbosityError ) )
             << "Unknown exception in precompiled/encryptTE()\n";
+    }
+
+    dev::u256 code = 0;
+    bytes response = toBigEndian( code );
+    return { false, response };
+}
+
+
+ETH_REGISTER_PRECOMPILED( encryptECIES )
+( bytesConstRef _in, const PrecompiledCallContext& ) {
+    try {
+        static constexpr size_t MAX_SIZE_BYTES = 64 * 1024;  // 64KB
+
+        if ( _in.size() > MAX_SIZE_BYTES ) {
+            return { false, toBigEndian( dev::u256( 1 ) ) };  // error 1: input too large
+        }
+
+        // Minimum input: at least public key coordinates (64 bytes)
+        // Input format: abi.encode(bytes data, bytes32 x, bytes32 y)
+        // ABI encoding: [offset_to_data(32)] [x(32)] [y(32)] [data_length(32)] [data(N)]
+        // So minimum is: 32 + 32 + 32 + 32 = 128 bytes for empty data
+        if ( _in.size() < 128 ) {
+            return { false, toBigEndian( dev::u256( 2 ) ) };  // error 2: input too small
+        }
+
+        int offset = 0;
+        int headFieldSizeBytes = 32;
+
+        // Parse ABI-encoded input
+        // First 32 bytes: offset to data
+        bigint const dataOffset( parseBigEndianRightPadded( _in, offset, headFieldSizeBytes ) );
+        // should be 3 * 32 = 96
+        const int expectedDataOffset = 3 * 32;
+        if ( dataOffset != expectedDataOffset ) {
+            return { false, toBigEndian( dev::u256( 3 ) ) };  // error 3: invalid ABI encoding
+        }
+
+        // Next 32 bytes: public key x-coordinate
+        offset += headFieldSizeBytes;
+        bytes pubKeyX = _in.cropped( offset, headFieldSizeBytes ).toBytes();
+        
+        // Next 32 bytes: public key y-coordinate  
+        offset += headFieldSizeBytes;
+        bytes pubKeyY = _in.cropped( offset, headFieldSizeBytes ).toBytes();
+
+        // Next 32 bytes: data length
+        offset += headFieldSizeBytes;
+        bigint const dataLength( parseBigEndianRightPadded( _in, offset, headFieldSizeBytes ) );
+        
+        // 3 head fields + data size field (also 32 bytes)
+        int totalMinSizeExceptData = 3 * headFieldSizeBytes + headFieldSizeBytes;
+        if ( dataLength < 0 || totalMinSizeExceptData + dataLength > _in.size() ) {
+            return { false, toBigEndian( dev::u256( 4 ) ) };  // error 4: data length mismatch
+        }
+
+        // Extract data to encrypt
+        offset += headFieldSizeBytes;
+        bytes dataToEncrypt;
+        if ( dataLength > 0 ) {
+            dataToEncrypt = _in.cropped( offset, static_cast<size_t>( dataLength ) ).toBytes();
+        }
+
+        if ( dataToEncrypt.empty() ) {
+            return { false, toBigEndian( dev::u256( 5 ) ) };  // error 5: empty data
+        }
+
+        // Construct user public key from x,y bytes
+        dev::Public userPubKey;
+        memcpy( userPubKey.data(), pubKeyX.data(), 32 );
+        memcpy( userPubKey.data() + 32, pubKeyY.data(), 32 );
+
+        // Validate public key is on the secp256k1 curve
+        if ( !dev::isValidPublicKey( userPubKey ) ) {
+            return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: invalid public key
+        }
+
+        // Encrypt using ECIES-CBC helper
+        bytes response = dev::encryptECIES_CBC( userPubKey, bytesConstRef( &dataToEncrypt ) );
+        if ( response.empty() ) {
+            return { false, toBigEndian( dev::u256( 7 ) ) };  // error 7: encryption failed
+        }
+
+        return { true, response };
+
+    } catch ( std::exception& ex ) {
+        std::string strError = ex.what();
+        if ( strError.empty() )
+            strError = "exception without description";
+        BOOST_LOG( getLogger( VerbosityError ) )
+            << "Exception in precompiled/encryptECIES(): " << strError << "\n";
+    } catch ( ... ) {
+        BOOST_LOG( getLogger( VerbosityError ) )
+            << "Unknown exception in precompiled/encryptECIES()\n";
     }
     dev::u256 code = 0;
     bytes response = toBigEndian( code );

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -1234,7 +1234,7 @@ ETH_REGISTER_PRECOMPILED( getRandomWalletAndSignatureForCTX )
 
 
 ETH_REGISTER_PRECOMPILED( encryptTE )
-( bytesConstRef _in, const PrecompiledCallContext& ) {
+( bytesConstRef _in, const PrecompiledCallContext& _ctx ) {
     try {
         static constexpr size_t MAX_SIZE_BYTES = 64 * 1024;  // 64KB
         if ( _in.size() > MAX_SIZE_BYTES ) {
@@ -1318,11 +1318,24 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
             libBLS::algebra::G2Point::fromString( blsPublicKeyArray, libBLS::Base::DEC );
         libBLS::TEPublicKey tePublicKey( publicKeyG2 );
 
-        // encrypt using threshold encryption with SC address as AAD
-        std::optional< std::vector< uint8_t > > aad =
-            std::vector< uint8_t >( scAddressBytes.begin(), scAddressBytes.end() );
+        // Get blockRandom to use as seed for deterministic encryption
+        // This ensures all nodes encrypt identically for consensus
+        unsigned blockNumberToCall = _ctx.blockNumber.convert_to< unsigned >();
+        dev::u256 blockRandomValue = g_skaleHost->getBlockRandom( blockNumberToCall, !_ctx.isReadOnly );
+        bytes blockRandomBytes = toBigEndian( blockRandomValue );
+
+        // Create seed array from blockRandom (32 bytes)
+        std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seed;
+        std::copy_n( blockRandomBytes.begin(), libBLS::AES_256_KEY_SIZE_BYTES, seed.begin() );
+
+        // Build EncryptMetaData with seed and SC address as TE AAD
+        libBLS::EncryptMetaData metaData;
+        metaData.seed = seed;
+        metaData.associatedDataTE = std::vector< uint8_t >( scAddressBytes.begin(), scAddressBytes.end() );
+
+        // encrypt using threshold encryption
         libBLS::Ciphertext ciphertext =
-            libBLS::ThresholdEncryption::encrypt( dataToEncrypt, tePublicKey, aad );
+            libBLS::ThresholdEncryption::encrypt( dataToEncrypt, tePublicKey, metaData );
 
         // convert ciphertext to bytes
         bytes response = ciphertext.toBytes();

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -1297,11 +1297,9 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
             return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: data length mismatch
         }
 
-        // Extract data bytes
-        std::vector< uint8_t > dataToEncrypt;
-        if ( dataLengthSafe > 0 ) {
-            dataToEncrypt = _in.cropped( dataStart, dataLengthSafe ).toBytes();
-        }
+        // Extract data bytes (empty data is allowed)
+        std::vector< uint8_t > dataToEncrypt =
+            _in.cropped( dataStart, dataLengthSafe ).toBytes();
 
         // Validate trailing padding bytes are all zeros (ABI compliance)
         size_t dataEnd = dataStart + dataLengthSafe;
@@ -1331,7 +1329,7 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
 
         // Build EncryptMetaData with seed and SC address as TE AAD
         libBLS::EncryptMetaData metaData;
-        metaData.seed = seed;
+        metaData.seed = libBLS::Seed256{ seed };
         metaData.associatedDataTE =
             std::vector< uint8_t >( scAddressBytes.begin(), scAddressBytes.end() );
 

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -1249,43 +1249,65 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
             return { false, toBigEndian( dev::u256( 2 ) ) };  // error 2: input too small
         }
 
+        // ABI encoding requires input to be a multiple of 32 bytes
+        if ( _in.size() % 32 != 0 ) {
+            return { false, toBigEndian( dev::u256( 3 ) ) };  // error 3: input not 32-byte aligned
+        }
+
         if ( !g_skaleHost ) {
             throw std::runtime_error( "SkaleHost accessor was not initialized" );
         }
 
-        int headFieldSizeBytes = 32;
+        size_t headFieldSizeBytes = 32;
 
         // First 32 bytes: SC address (20 bytes, left-padded to 32)
-        // Skip the first 12 bytes (padding), extract the 20-byte address
+        // Validate that the first 12 bytes are zeros (left-padding for 20-byte address)
+        if (! std::all_of( _in.data(), _in.data() + 12, []( uint8_t b ) { return b == 0; })) {
+            return { false, toBigEndian( dev::u256( 4 ) ) };  // error 4: address padding not zeros
+        }
+
+        // Extract the 20-byte address
         auto scAddressBytes = _in.cropped( 12, 20 ).toBytes();
 
         // Next 32 bytes: offset to data (should be 64 = 2 * 32)
         bigint const dataOffset( parseBigEndianRightPadded( _in, 32, headFieldSizeBytes ) );
-        const int expectedDataOffset = 2 * 32;  // 64
+        const size_t expectedDataOffset = 2 * 32;  // 64
         if ( dataOffset != expectedDataOffset ) {
-            return { false, toBigEndian( dev::u256( 3 ) ) };  // error 3: invalid ABI encoding
+            return { false, toBigEndian( dev::u256( 5 ) ) };  // error 5: invalid data offset
         }
 
         // Read data length at the data offset (position 64)
         if ( _in.size() < expectedDataOffset + headFieldSizeBytes ) {
-            return { false, toBigEndian( dev::u256( 4 ) ) };  // error 4: data length mismatch
+            return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: data length mismatch
         }
         bigint const dataLength(
             parseBigEndianRightPadded( _in, expectedDataOffset, headFieldSizeBytes ) );
 
-        // Extract data bytes
+        // Validate dataLength is non-negative and fits within reasonable bounds
+        // Header is 96 bytes (address + offset + length field), so max data = MAX_SIZE_BYTES - 96
+        static constexpr size_t HEADER_SIZE_BYTES = 96;
+        if ( dataLength < 0 || dataLength > MAX_SIZE_BYTES - HEADER_SIZE_BYTES ) {
+            return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: data length mismatch
+        }
+        size_t dataLengthSafe = static_cast< size_t >( dataLength );
+
+        // Calculate data start position and validate bounds
         size_t dataStart = expectedDataOffset + headFieldSizeBytes;
-        if ( dataLength < 0 || dataStart + static_cast< size_t >( dataLength ) > _in.size() ) {
-            return { false, toBigEndian( dev::u256( 4 ) ) };  // error 4: data length mismatch
+        if ( dataStart + dataLengthSafe > _in.size() ) {
+            return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: data length mismatch
         }
 
+        // Extract data bytes
         std::vector< uint8_t > dataToEncrypt;
-        if ( dataLength > 0 ) {
-            dataToEncrypt = _in.cropped( dataStart, static_cast< size_t >( dataLength ) ).toBytes();
+        if ( dataLengthSafe > 0 ) {
+            dataToEncrypt = _in.cropped( dataStart, dataLengthSafe ).toBytes();
         }
 
-        if ( dataToEncrypt.empty() ) {
-            return { false, toBigEndian( dev::u256( 5 ) ) };  // error 5: empty data
+        // Validate trailing padding bytes are all zeros (ABI compliance)
+        size_t dataEnd = dataStart + dataLengthSafe;
+        if ( !std::all_of( _in.data() + dataEnd, _in.data() + _in.size(),
+                 []( uint8_t b ) { return b == 0; } ) ) {
+            return { false, toBigEndian( dev::u256( 7 ) ) };  // error 7: trailing padding not zeros
         }
 
         // get network public key
@@ -1340,16 +1362,21 @@ ETH_REGISTER_PRECOMPILED( encryptECIES )
             return { false, toBigEndian( dev::u256( 2 ) ) };  // error 2: input too small
         }
 
-        int offset = 0;
-        int headFieldSizeBytes = 32;
+        // ABI encoding requires input to be a multiple of 32 bytes
+        if ( _in.size() % 32 != 0 ) {
+            return { false, toBigEndian( dev::u256( 3 ) ) };  // error 3: input not 32-byte aligned
+        }
+
+        size_t offset = 0;
+        size_t headFieldSizeBytes = 32;
 
         // Parse ABI-encoded input
         // First 32 bytes: offset to data
         bigint const dataOffset( parseBigEndianRightPadded( _in, offset, headFieldSizeBytes ) );
         // should be 3 * 32 = 96
-        const int expectedDataOffset = 3 * 32;
+        const size_t expectedDataOffset = 3 * 32;
         if ( dataOffset != expectedDataOffset ) {
-            return { false, toBigEndian( dev::u256( 3 ) ) };  // error 3: invalid ABI encoding
+            return { false, toBigEndian( dev::u256( 4 ) ) };  // error 4: invalid data offset
         }
 
         // Next 32 bytes: public key x-coordinate
@@ -1364,21 +1391,31 @@ ETH_REGISTER_PRECOMPILED( encryptECIES )
         offset += headFieldSizeBytes;
         bigint const dataLength( parseBigEndianRightPadded( _in, offset, headFieldSizeBytes ) );
 
-        // 3 head fields + data size field (also 32 bytes)
-        int totalMinSizeExceptData = 3 * headFieldSizeBytes + headFieldSizeBytes;
-        if ( dataLength < 0 || totalMinSizeExceptData + dataLength > _in.size() ) {
-            return { false, toBigEndian( dev::u256( 4 ) ) };  // error 4: data length mismatch
+        // Validate dataLength is non-negative and fits within reasonable bounds
+        // Header is 128 bytes (offset + x + y + length field), so max data = MAX_SIZE_BYTES - 128
+        static constexpr size_t HEADER_SIZE_BYTES = 128;
+        if ( dataLength < 0 || dataLength > MAX_SIZE_BYTES - HEADER_SIZE_BYTES ) {
+            return { false, toBigEndian( dev::u256( 5 ) ) };  // error 5: data length mismatch
+        }
+        size_t dataLengthSafe = static_cast< size_t >( dataLength );
+
+        // 4 header fields (offset, x, y, length) = 128 bytes
+        size_t dataStart = 4 * headFieldSizeBytes;
+        if ( dataStart + dataLengthSafe > _in.size() ) {
+            return { false, toBigEndian( dev::u256( 5 ) ) };  // error 5: data length mismatch
         }
 
         // Extract data to encrypt
-        offset += headFieldSizeBytes;
         bytes dataToEncrypt;
-        if ( dataLength > 0 ) {
-            dataToEncrypt = _in.cropped( offset, static_cast< size_t >( dataLength ) ).toBytes();
+        if ( dataLengthSafe > 0 ) {
+            dataToEncrypt = _in.cropped( dataStart, dataLengthSafe ).toBytes();
         }
 
-        if ( dataToEncrypt.empty() ) {
-            return { false, toBigEndian( dev::u256( 5 ) ) };  // error 5: empty data
+        // Validate trailing padding bytes are all zeros (ABI compliance)
+        size_t dataEnd = dataStart + dataLengthSafe;
+        if ( !std::all_of( _in.data() + dataEnd, _in.data() + _in.size(),
+                 []( uint8_t b ) { return b == 0; } ) ) {
+            return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: trailing padding not zeros
         }
 
         // Construct user public key from x,y bytes
@@ -1388,13 +1425,13 @@ ETH_REGISTER_PRECOMPILED( encryptECIES )
 
         // Validate public key is on the secp256k1 curve
         if ( !dev::isValidPublicKey( userPubKey ) ) {
-            return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: invalid public key
+            return { false, toBigEndian( dev::u256( 7 ) ) };  // error 7: invalid public key
         }
 
         // Encrypt using ECIES-CBC helper
         bytes response = dev::encryptECIES_CBC( userPubKey, bytesConstRef( &dataToEncrypt ) );
         if ( response.empty() ) {
-            return { false, toBigEndian( dev::u256( 7 ) ) };  // error 7: encryption failed
+            return { false, toBigEndian( dev::u256( 8 ) ) };  // error 8: encryption failed
         }
 
         return { true, response };

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -1321,7 +1321,8 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
         // Get blockRandom to use as seed for deterministic encryption
         // This ensures all nodes encrypt identically for consensus
         unsigned blockNumberToCall = _ctx.blockNumber.convert_to< unsigned >();
-        dev::u256 blockRandomValue = g_skaleHost->getBlockRandom( blockNumberToCall, !_ctx.isReadOnly );
+        dev::u256 blockRandomValue =
+            g_skaleHost->getBlockRandom( blockNumberToCall, !_ctx.isReadOnly );
         bytes blockRandomBytes = toBigEndian( blockRandomValue );
 
         // Create seed array from blockRandom (32 bytes)
@@ -1331,7 +1332,8 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
         // Build EncryptMetaData with seed and SC address as TE AAD
         libBLS::EncryptMetaData metaData;
         metaData.seed = seed;
-        metaData.associatedDataTE = std::vector< uint8_t >( scAddressBytes.begin(), scAddressBytes.end() );
+        metaData.associatedDataTE =
+            std::vector< uint8_t >( scAddressBytes.begin(), scAddressBytes.end() );
 
         // encrypt using threshold encryption
         libBLS::Ciphertext ciphertext =

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -55,6 +55,11 @@
 #include <sstream>
 #include <string>
 
+#ifdef BITE2
+#include <libconsensus/libBLS/threshold_encryption/TEPublicKey.h>
+#include <libconsensus/libBLS/threshold_encryption/ThresholdEncryption.h>
+#endif
+
 
 namespace dev {
 namespace eth {
@@ -1153,6 +1158,58 @@ ETH_REGISTER_PRECOMPILED( getRandomWalletForCTX )
     bytes response = toBigEndian( code );
     return { false, response };  // 1st false - means bad error occur
 }
+
+
+ETH_REGISTER_PRECOMPILED( encryptTE )
+( bytesConstRef _in, const PrecompiledCallContext& ) {
+    try {
+        static constexpr size_t MAX_SIZE_BYTES = 64 * 1024;  // 64KB
+        if ( _in.size() > MAX_SIZE_BYTES ) {
+            return { false, toBigEndian( dev::u256( 1 ) ) };  // error 1: input too large
+        }
+
+        if ( _in.empty() ) {
+            return { false, toBigEndian( dev::u256( 2 ) ) };  // error 2: empty input
+        }
+
+        if ( !g_skaleHost ) {
+            throw std::runtime_error( "SkaleHost accessor was not initialized" );
+        }
+
+        // get network public key
+        auto blsPublicKeyArray = g_skaleHost->getCurrentBLSPublicKey();
+
+        // convert BLS public key to TE public key
+        libBLS::algebra::G2Point publicKeyG2 =
+            libBLS::algebra::G2Point::fromString( blsPublicKeyArray, libBLS::Base::DEC );
+        libBLS::TEPublicKey tePublicKey( publicKeyG2 );
+
+        // convert input to vector
+        std::vector< uint8_t > inputData( _in.begin(), _in.end() );
+
+        // encrypt using threshold encryption
+        libBLS::Ciphertext ciphertext =
+            libBLS::ThresholdEncryption::encrypt( inputData, tePublicKey );
+
+        // convert ciphertext to bytes
+        bytes response = ciphertext.toBytes();
+        return { true, response };
+        
+    } catch ( std::exception& ex ) {
+        std::string strError = ex.what();
+        if ( strError.empty() )
+            strError = "exception without description";
+        BOOST_LOG( getLogger( VerbosityError ) )
+            << "Exception in precompiled/encryptTE(): " << strError << "\n";
+    } catch ( ... ) {
+        BOOST_LOG( getLogger( VerbosityError ) )
+            << "Unknown exception in precompiled/encryptTE()\n";
+    }
+    dev::u256 code = 0;
+    bytes response = toBigEndian( code );
+    return { false, response };  // 1st false - means bad error occur
+}
+
 #endif
 
 #ifndef FAIR

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -1211,8 +1211,7 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
 
         std::vector< uint8_t > dataToEncrypt;
         if ( dataLength > 0 ) {
-            dataToEncrypt =
-                _in.cropped( dataStart, static_cast< size_t >( dataLength ) ).toBytes();
+            dataToEncrypt = _in.cropped( dataStart, static_cast< size_t >( dataLength ) ).toBytes();
         }
 
         if ( dataToEncrypt.empty() ) {
@@ -1286,15 +1285,15 @@ ETH_REGISTER_PRECOMPILED( encryptECIES )
         // Next 32 bytes: public key x-coordinate
         offset += headFieldSizeBytes;
         bytes pubKeyX = _in.cropped( offset, headFieldSizeBytes ).toBytes();
-        
-        // Next 32 bytes: public key y-coordinate  
+
+        // Next 32 bytes: public key y-coordinate
         offset += headFieldSizeBytes;
         bytes pubKeyY = _in.cropped( offset, headFieldSizeBytes ).toBytes();
 
         // Next 32 bytes: data length
         offset += headFieldSizeBytes;
         bigint const dataLength( parseBigEndianRightPadded( _in, offset, headFieldSizeBytes ) );
-        
+
         // 3 head fields + data size field (also 32 bytes)
         int totalMinSizeExceptData = 3 * headFieldSizeBytes + headFieldSizeBytes;
         if ( dataLength < 0 || totalMinSizeExceptData + dataLength > _in.size() ) {
@@ -1305,7 +1304,7 @@ ETH_REGISTER_PRECOMPILED( encryptECIES )
         offset += headFieldSizeBytes;
         bytes dataToEncrypt;
         if ( dataLength > 0 ) {
-            dataToEncrypt = _in.cropped( offset, static_cast<size_t>( dataLength ) ).toBytes();
+            dataToEncrypt = _in.cropped( offset, static_cast< size_t >( dataLength ) ).toBytes();
         }
 
         if ( dataToEncrypt.empty() ) {

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -1262,7 +1262,7 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
 
         // First 32 bytes: SC address (20 bytes, left-padded to 32)
         // Validate that the first 12 bytes are zeros (left-padding for 20-byte address)
-        if (! std::all_of( _in.data(), _in.data() + 12, []( uint8_t b ) { return b == 0; })) {
+        if ( !std::all_of( _in.data(), _in.data() + 12, []( uint8_t b ) { return b == 0; } ) ) {
             return { false, toBigEndian( dev::u256( 4 ) ) };  // error 4: address padding not zeros
         }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,17 @@ find_library( YAML_CPP_LIBRARIES NAMES yaml-cpp HINTS "${DEPS_INSTALL_ROOT}/lib"
 
 add_executable(testeth ${sources} unittests/libethereum/InstanceMonitorTest.cpp)
 
+# Add libBLS test utils for BITE2 tests
+if(BITE2)
+    target_sources(testeth PRIVATE
+        ${CMAKE_SOURCE_DIR}/libconsensus/libBLS/test/utils.cpp
+    )
+    target_include_directories(testeth PRIVATE
+        ${CMAKE_SOURCE_DIR}/libconsensus/libBLS
+    )
+endif()
+
+
 target_compile_options( testeth PRIVATE
     -Wno-error=deprecated-copy -Wno-error=unused-result -Wno-unused-parameter -Wno-error=unused-variable -Wno-maybe-uninitialized
     -Wno-error=pessimizing-move
@@ -105,6 +116,9 @@ target_link_libraries(testeth PRIVATE
   $<$<BOOL:${HISTORIC_STATE}>:historic>
   $<$<BOOL:${CONSENSUS}>:consensus>
   $<$<BOOL:${BITE}>:te>
+  $<$<BOOL:${BITE2}>:te>
+
+
 
   "${DEPS_INSTALL_ROOT}/lib/libunwind.a"
 

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -1615,12 +1615,14 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
     dataLenBytes[31] = static_cast<uint8_t>( dataToEncrypt.size() );
     input.insert( input.end(), dataLenBytes.begin(), dataLenBytes.end() );
 
-    // data
+    // data (with ABI-compliant padding to 32-byte boundary)
     input.insert( input.end(), dataToEncrypt.begin(), dataToEncrypt.end() );
+    size_t paddingNeeded = 32 - ( dataToEncrypt.size() % 32 );
+    input.insert( input.end(), paddingNeeded, 0 );
 
     // Call the precompiled contract
     auto res = exec( bytesConstRef( input.data(), input.size() ),
-        { 1, 0, true } );
+        PrecompiledCallContext( 1, 0, 0, true ) );
 
     // Verify success
     BOOST_REQUIRE( res.first );
@@ -1648,21 +1650,6 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
     BOOST_REQUIRE( decryptedMessage == dataToEncrypt );    
 }
 
-BOOST_AUTO_TEST_CASE( encryptTE_inputTooSmall ) {
-    SkaleHostFixture fixture;
-
-    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
-
-    // Call with input smaller than minimum (96 bytes for ABI format)
-    bytes smallInput( 64, 0x42 );
-    auto res = exec( bytesConstRef( smallInput.data(), smallInput.size() ),
-        { 1, 0, true } );
-
-    // Verify failure with error code 2 (input too small)
-    BOOST_REQUIRE( !res.first );
-    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 2 ) ) );
-}
-
 BOOST_AUTO_TEST_CASE( encryptTE_inputTooLarge ) {
     SkaleHostFixture fixture;
 
@@ -1671,11 +1658,58 @@ BOOST_AUTO_TEST_CASE( encryptTE_inputTooLarge ) {
     // Create input larger than 64KB
     bytes largeInput( 65 * 1024, 0x42 );  // 65KB of 'B's
     auto res = exec( bytesConstRef( largeInput.data(), largeInput.size() ),
-        { 1, 0, true } );
+        PrecompiledCallContext( 1, 0, 0, true ) );
 
     // Verify failure with error code 1 (input too large)
     BOOST_REQUIRE( !res.first );
     BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 1 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptTE_inputTooSmall ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Call with input smaller than minimum (96 bytes for ABI format)
+    bytes smallInput( 64, 0x42 );
+    auto res = exec( bytesConstRef( smallInput.data(), smallInput.size() ),
+        PrecompiledCallContext( 1, 0, 0, true ) );
+
+    // Verify failure with error code 2 (input too small)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 2 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptTE_inputNotAligned ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Build input that is not a multiple of 32 bytes (97 bytes)
+    bytes input( 97, 0 );
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
+
+    // Verify failure with error code 3 (input not 32-byte aligned)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 3 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptTE_addressPaddingNotZeros ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Build input where the first 12 bytes (address padding) are not zeros
+    bytes input( 96, 0 );
+    input[0] = 0xFF;  // Non-zero byte in address padding
+    input[63] = 64;   // Correct data offset
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
+
+    // Verify failure with error code 4 (address padding not zeros)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 4 ) ) );
 }
 
 BOOST_AUTO_TEST_CASE( encryptTE_invalidABIEncoding ) {
@@ -1687,41 +1721,60 @@ BOOST_AUTO_TEST_CASE( encryptTE_invalidABIEncoding ) {
     bytes input( 96, 0 );
     input[63] = 32;  // Wrong data offset at position 32 (should be 64)
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ), { 1, 0, true } );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
 
-    // Verify failure with error code 3 (invalid ABI encoding)
+    // Verify failure with error code 5 (invalid data offset)
     BOOST_REQUIRE( !res.first );
-    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 3 ) ) );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 5 ) ) );
 }
 
-BOOST_AUTO_TEST_CASE( encryptTE_emptyData ) {
+BOOST_AUTO_TEST_CASE( encryptTE_dataLengthMismatch ) {
     SkaleHostFixture fixture;
 
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
 
-    // Build valid ABI input: abi.encode(address, bytes) but with data_length = 0
-    bytes input;
+    // Build valid ABI structure but claim more data than available
+    bytes input( 128, 0 );
+    // address padding (0-11): zeros
+    // address (12-31): some address
+    input[20] = 0x12;
+    // offset (32-63): 64
+    input[63] = 64;
+    // data_length (64-95): claim 100 bytes, but only 32 bytes total remain
+    input[95] = 100;
+    // actual data (96-127): only 32 bytes of zeros
 
-    // SC address (20 bytes, left-padded to 32)
-    bytes addressPadding( 12, 0 );
-    input.insert( input.end(), addressPadding.begin(), addressPadding.end() );
-    bytes scAddrData( 20, 0x12 );
-    input.insert( input.end(), scAddrData.begin(), scAddrData.end() );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
 
-    // Offset to data = 64
-    bytes offsetData( 32, 0 );
-    offsetData[31] = 64;
-    input.insert( input.end(), offsetData.begin(), offsetData.end() );
-
-    // data length = 0 (empty data)
-    bytes dataLenBytes( 32, 0 );
-    input.insert( input.end(), dataLenBytes.begin(), dataLenBytes.end() );
-
-    auto res = exec( bytesConstRef( input.data(), input.size() ), { 1, 0, true } );
-
-    // Verify failure with error code 5 (empty data)
+    // Verify failure with error code 6 (data length mismatch)
     BOOST_REQUIRE( !res.first );
-    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 5 ) ) );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 6 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptTE_trailingPaddingNotZeros ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Build valid ABI structure with 1 byte of data, but non-zero trailing padding
+    bytes input( 128, 0 );
+    // address padding (0-11): zeros
+    // address (12-31): some address
+    input[20] = 0x12;
+    // offset (32-63): 64
+    input[63] = 64;
+    // data_length (64-95): 1 byte
+    input[95] = 1;
+    // actual data (96): one byte of data
+    input[96] = 0xAB;
+    // trailing padding (97-127): should be zeros but we set one to non-zero
+    input[100] = 0xFF;
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
+
+    // Verify failure with error code 7 (trailing padding not zeros)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 7 ) ) );
 }
 
 BOOST_AUTO_TEST_CASE( encryptECIES_success ) {
@@ -1753,14 +1806,16 @@ BOOST_AUTO_TEST_CASE( encryptECIES_success ) {
     bytes lenBytes( 32, 0 );
     lenBytes[31] = static_cast<uint8_t>( dataToEncrypt.size() );
     input.insert( input.end(), lenBytes.begin(), lenBytes.end() );
-    // Data
+    // Data (with ABI-compliant padding to 32-byte boundary)
     input.insert( input.end(), dataToEncrypt.begin(), dataToEncrypt.end() );
+    size_t paddingNeeded = 32 - ( dataToEncrypt.size() % 32 );
+    input.insert( input.end(), paddingNeeded, 0 );
 
     // Get the executor for encryptECIES
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
 
     // Call the precompiled contract
-    auto res = exec( bytesConstRef( input.data(), input.size() ), { 1, 0, true } );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
 
     // Verify success
     BOOST_REQUIRE( res.first );
@@ -1789,7 +1844,7 @@ BOOST_AUTO_TEST_CASE( encryptECIES_inputTooLarge ) {
 
     // Input larger than 64KB
     bytes largeInput( 65 * 1024, 0x42 );
-    auto res = exec( bytesConstRef( largeInput.data(), largeInput.size() ), { 1, 0, true } );
+    auto res = exec( bytesConstRef( largeInput.data(), largeInput.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
 
     // Verify failure with error code 1 (input too large)
     BOOST_REQUIRE( !res.first );
@@ -1803,11 +1858,26 @@ BOOST_AUTO_TEST_CASE( encryptECIES_inputTooSmall ) {
 
     // Input smaller than 128 bytes
     bytes smallInput( 64, 0x42 );
-    auto res = exec( bytesConstRef( smallInput.data(), smallInput.size() ), { 1, 0, true } );
+    auto res = exec( bytesConstRef( smallInput.data(), smallInput.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
 
     // Verify failure with error code 2 (input too small)
     BOOST_REQUIRE( !res.first );
     BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 2 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_inputNotAligned ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Build input that is not a multiple of 32 bytes (129 bytes)
+    bytes input( 129, 0 );
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
+
+    // Verify failure with error code 3 (input not 32-byte aligned)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 3 ) ) );
 }
 
 BOOST_AUTO_TEST_CASE( encryptECIES_invalidABIOffset ) {
@@ -1819,11 +1889,11 @@ BOOST_AUTO_TEST_CASE( encryptECIES_invalidABIOffset ) {
     bytes input( 128, 0 );
     input[31] = 64;  // Wrong offset (should be 96)
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ), { 1, 0, true } );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
 
-    // Verify failure with error code 3 (invalid ABI encoding)
+    // Verify failure with error code 4 (invalid data offset)
     BOOST_REQUIRE( !res.first );
-    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 3 ) ) );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 4 ) ) );
 }
 
 BOOST_AUTO_TEST_CASE( encryptECIES_dataLengthMismatch ) {
@@ -1836,11 +1906,11 @@ BOOST_AUTO_TEST_CASE( encryptECIES_dataLengthMismatch ) {
     input[31] = 96;   // Correct offset
     input[127] = 100; // Claim 100 bytes of data, but none actually present
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ), { 1, 0, true } );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
 
-    // Verify failure with error code 4 (data length mismatch)
+    // Verify failure with error code 5 (data length mismatch)
     BOOST_REQUIRE( !res.first );
-    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 4 ) ) );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 5 ) ) );
 }
 
 BOOST_AUTO_TEST_CASE( encryptECIES_emptyData ) {
@@ -1853,11 +1923,36 @@ BOOST_AUTO_TEST_CASE( encryptECIES_emptyData ) {
     input[31] = 96;  // Correct offset
     // data_length at position [96..127] = 0 (already zeroed)
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ), { 1, 0, true } );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
 
-    // Verify failure with error code 5 (empty data)
+    // Verify failure with error code 6 (empty data)
     BOOST_REQUIRE( !res.first );
-    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 5 ) ) );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 6 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_trailingPaddingNotZeros ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Build valid ABI structure with 1 byte of data, but non-zero trailing padding
+    bytes input( 192, 0 );
+    // offset (0-31): 96
+    input[31] = 96;
+    // pubKeyX (32-63): zeros (valid x coordinate check happens later)
+    // pubKeyY (64-95): zeros
+    // data_length (96-127): 1 byte
+    input[127] = 1;
+    // actual data (128): one byte of data
+    input[128] = 0xAB;
+    // trailing padding (129-191): should be zeros but we set one to non-zero
+    input[150] = 0xFF;
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
+
+    // Verify failure with error code 7 (trailing padding not zeros)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 7 ) ) );
 }
 
 BOOST_AUTO_TEST_CASE( encryptECIES_invalidPublicKey ) {
@@ -1880,13 +1975,16 @@ BOOST_AUTO_TEST_CASE( encryptECIES_invalidPublicKey ) {
     lenBytes[31] = static_cast<uint8_t>( dataToEncrypt.size() );
     input.insert( input.end(), lenBytes.begin(), lenBytes.end() );
     input.insert( input.end(), dataToEncrypt.begin(), dataToEncrypt.end() );
+    // Add ABI-compliant padding to 32-byte boundary
+    size_t paddingNeeded = 32 - ( dataToEncrypt.size() % 32 );
+    input.insert( input.end(), paddingNeeded, 0 );
 
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
-    auto res = exec( bytesConstRef( input.data(), input.size() ), { 1, 0, true } );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
 
-    // Verify failure with error code 6 (invalid public key)
+    // Verify failure with error code 8 (invalid public key)
     BOOST_REQUIRE( !res.first );
-    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 6 ) ) );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 8 ) ) );
 }
 #endif  // BITE2
 

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -1632,6 +1632,11 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
     // Parse output as Ciphertext and validate
     libBLS::Ciphertext ciphertext = libBLS::Ciphertext::fromBytes( res.second, /* validate */ true );
 
+    // Validate the TE ciphertext with SC address as TE AAD
+    std::vector< uint8_t > scAddressVec( scAddressBytes.begin(), scAddressBytes.end() );
+    BOOST_REQUIRE_NO_THROW(
+        libBLS::ThresholdEncryption::validateEncryption( ciphertext.getTargetKey(), &scAddressVec ) );
+
     // decrypt & check if decrypted = original
     
     // 1. Create a decryption share from the single private key share
@@ -1643,10 +1648,9 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
     // 3. Combine shares → AES key
     libBLS::AES256Key aesKey = libBLS::ThresholdEncryption::combineShares( 
         ciphertext.getTargetKey(), decryptSet );
-    // 4. Decrypt using AES key with AAD
-    std::vector< uint8_t > scAddressVec( scAddressBytes.begin(), scAddressBytes.end() );
+    // 4. Decrypt using AES key (no AES AAD - we use TE AAD for validation instead)
     std::vector< uint8_t > decryptedMessage = 
-        libBLS::ThresholdEncryption::decrypt( ciphertext, aesKey, scAddressVec );
+        libBLS::ThresholdEncryption::decrypt( ciphertext, aesKey );
     // 5. Verify original message matches
     BOOST_REQUIRE( decryptedMessage == dataToEncrypt );    
 }
@@ -1917,18 +1921,40 @@ BOOST_AUTO_TEST_CASE( encryptECIES_dataLengthMismatch ) {
 BOOST_AUTO_TEST_CASE( encryptECIES_emptyData ) {
     SkaleHostFixture fixture;
 
+    // Generate a valid user keypair
+    dev::KeyPair userKeys = dev::KeyPair::create();
+    dev::Public userPublicKey = userKeys.pub();
+    dev::Secret userPrivateKey = userKeys.secret();
+
+    // Extract x and y coordinates from public key (64 bytes total)
+    bytes pubKeyX( userPublicKey.data(), userPublicKey.data() + 32 );
+    bytes pubKeyY( userPublicKey.data() + 32, userPublicKey.data() + 64 );
+
+    // Build ABI-encoded input with EMPTY data
+    // Format: [offset_to_data(32)] [x(32)] [y(32)] [data_length(32)] [no data]
+    bytes input;
+    // Offset to data = 96 (0x60) = 3 * 32
+    input.insert( input.end(), 32, 0 );
+    input[31] = 96;
+    // x-coordinate (32 bytes)
+    input.insert( input.end(), pubKeyX.begin(), pubKeyX.end() );
+    // y-coordinate (32 bytes)
+    input.insert( input.end(), pubKeyY.begin(), pubKeyY.end() );
+    // Data length = 0 (32 bytes of zeros)
+    input.insert( input.end(), 32, 0 );
+
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
 
-    // Build valid input but with data_length = 0
-    bytes input( 128, 0 );
-    input[31] = 96;  // Correct offset
-    // data_length at position [96..127] = 0 (already zeroed)
-
+    // Call the precompiled contract
     auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
 
-    // Verify failure with error code 6 (empty data)
-    BOOST_REQUIRE( !res.first );
-    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 6 ) ) );
+    // Verify success - empty data encryption should succeed
+    BOOST_REQUIRE( res.first );
+    BOOST_REQUIRE( !res.second.empty() );
+
+    // Verify we can decrypt back to empty data
+    auto decryptedBytes = dev::decryptECIES_CBC( userPrivateKey, &res.second );
+    BOOST_REQUIRE( decryptedBytes.empty() );
 }
 
 BOOST_AUTO_TEST_CASE( encryptECIES_trailingPaddingNotZeros ) {
@@ -1951,9 +1977,9 @@ BOOST_AUTO_TEST_CASE( encryptECIES_trailingPaddingNotZeros ) {
 
     auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
 
-    // Verify failure with error code 7 (trailing padding not zeros)
+    // Verify failure with error code 6 (trailing padding not zeros)
     BOOST_REQUIRE( !res.first );
-    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 7 ) ) );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 6 ) ) );
 }
 
 BOOST_AUTO_TEST_CASE( encryptECIES_invalidPublicKey ) {
@@ -1983,9 +2009,9 @@ BOOST_AUTO_TEST_CASE( encryptECIES_invalidPublicKey ) {
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
     auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, true ) );
 
-    // Verify failure with error code 8 (invalid public key)
+    // Verify failure with error code 7 (invalid public key)
     BOOST_REQUIRE( !res.first );
-    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 8 ) ) );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 7 ) ) );
 }
 #endif  // BITE2
 

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -5,6 +5,17 @@
 #ifdef BITE
 #include <libconsensus/libBLS/threshold_encryption/ThresholdEncryption.h>
 #endif
+#ifdef BITE2
+#include <libconsensus/libBLS/threshold_encryption/TEPrivateKey.h>
+#include <libconsensus/libBLS/threshold_encryption/TEPrivateKeyShare.h>
+#include <libconsensus/libBLS/threshold_encryption/TEPublicKeyShare.h>
+#include <libconsensus/libBLS/threshold_encryption/TEDecryptSet.h>
+#include <libconsensus/libBLS/threshold_encryption/ThresholdEncryption.h>
+#include <test/utils.h>
+#endif
+
+
+
 #include <libskale/ConsensusGasPricer.h>
 
 #include <test/tools/libtesteth/TestHelper.h>
@@ -223,6 +234,10 @@ struct SkaleHostFixture : public TestOutputHelperFixture {
     bytes bytes_from_json( const Json::Value& json ) {
         Transaction tx = tx_from_json( json );
         return tx.toBytes();
+    }
+
+    void setBlsPublicKey( const std::array< std::string, 4 >& _key ) {
+        chainParams->sChain.nodeGroups[0].blsPublicKey = _key;
     }
 
     TransactionQueue* tq;
@@ -1508,7 +1523,87 @@ BOOST_AUTO_TEST_CASE( biteTransactions ) {
 }
 #endif
 
+#ifdef BITE2
+BOOST_AUTO_TEST_CASE( encryptTE_success ) {
+    SkaleHostFixture fixture;
+
+    auto keys = generateKeys(1, 1);
+
+    // set test key
+    fixture.setBlsPublicKey(keys.commonPublic.getPublicKeyRaw().toStringArray(libBLS::Base::DEC));
+
+    // Get the executor for encryptTE
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Create test input data
+    std::string testMessage = "Hello, threshold encryption!";
+    bytes inputData( testMessage.begin(), testMessage.end() );
+
+    // Call the precompiled contract
+    auto res = exec( bytesConstRef( inputData.data(), inputData.size() ),
+        { 1, 0, true } );
+
+    // Verify success
+    BOOST_REQUIRE( res.first );
+    BOOST_REQUIRE( !res.second.empty() );
+
+    // Parse output as Ciphertext
+    libBLS::Ciphertext ciphertext = libBLS::Ciphertext::fromBytes( res.second, /* validate */ true );
+
+    // Verify ciphertext is valid
+    ciphertext.validate();
+
+    // decrypt & check if decrypted = original
+    
+    // 1. Create a decryption share from the single private key share
+    libBLS::TEDecryptionShare share = libBLS::ThresholdEncryption::partialDecrypt(
+        ciphertext.getTargetKey(), keys.secretKeys[0] );
+    // 2. Add to decrypt set
+    libBLS::TEDecryptSet decryptSet( 1, 1 );  // t=1, n=1
+    decryptSet.addDecryptShare( share );
+    // 3. Combine shares → AES key
+    libBLS::AES256Key aesKey = libBLS::ThresholdEncryption::combineShares( 
+        ciphertext.getTargetKey(), decryptSet );
+    // 4. Decrypt using AES key
+    std::vector< uint8_t > decryptedMessage = 
+        libBLS::ThresholdEncryption::decrypt( ciphertext, aesKey );
+    // 5. Verify original message matches
+    BOOST_REQUIRE( decryptedMessage == inputData );    
+}
+
+BOOST_AUTO_TEST_CASE( encryptTE_emptyInput ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Call with empty input
+    bytes emptyInput;
+    auto res = exec( bytesConstRef( emptyInput.data(), emptyInput.size() ),
+        { 1, 0, true } );
+
+    // Verify failure with error code 2 (empty input)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 2 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptTE_inputTooLarge ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Create input larger than 64KB
+    bytes largeInput( 65 * 1024, 0x42 );  // 65KB of 'B's
+    auto res = exec( bytesConstRef( largeInput.data(), largeInput.size() ),
+        { 1, 0, true } );
+
+    // Verify failure with error code 1 (input too large)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 1 ) ) );
+}
+#endif  // BITE2
+
 struct dummy {};
+
 
 // Test behavior of MTM if tx with big nonce was already mined as erroneous
 BOOST_FIXTURE_TEST_CASE(

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -12,6 +12,11 @@
 #include <libconsensus/libBLS/threshold_encryption/TEDecryptSet.h>
 #include <libconsensus/libBLS/threshold_encryption/ThresholdEncryption.h>
 #include <test/utils.h>
+#include <secp256k1.h>
+#include <secp256k1_ecdh.h>
+#include <secp256k1_sha256.h>
+#include <cryptopp/aes.h>
+#include <cryptopp/modes.h>
 #endif
 
 
@@ -1527,6 +1532,7 @@ BOOST_AUTO_TEST_CASE( biteTransactions ) {
 BOOST_AUTO_TEST_CASE( encryptTE_success ) {
     SkaleHostFixture fixture;
 
+    // TE helper from libBLS
     auto keys = generateKeys(1, 1);
 
     // set test key
@@ -1537,21 +1543,44 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
 
     // Create test input data
     std::string testMessage = "Hello, threshold encryption!";
-    bytes inputData( testMessage.begin(), testMessage.end() );
+    bytes dataToEncrypt( testMessage.begin(), testMessage.end() );
+
+    // Create a test SC address (20 bytes)
+    dev::Address testScAddress = dev::Address( "0x1234567890123456789012345678901234567890" );
+    bytes scAddressBytes = testScAddress.asBytes();
+
+    // Build ABI-encoded input: abi.encode(address scAddress, bytes data)
+    // Format: [scAddress(20 bytes, left-padded to 32)] [offset_to_data(32)] [data_length(32)] [data(N)]
+    bytes input;
+
+    // SC address (20 bytes, left-padded to 32)
+    bytes addressPadding( 12, 0 );  // 12 bytes of zero padding
+    input.insert( input.end(), addressPadding.begin(), addressPadding.end() );
+    input.insert( input.end(), scAddressBytes.begin(), scAddressBytes.end() );
+
+    // Offset to data = 64 (2 * 32, after address and offset fields)
+    bytes offsetData( 32, 0 );
+    offsetData[31] = 64;
+    input.insert( input.end(), offsetData.begin(), offsetData.end() );
+
+    // data length
+    bytes dataLenBytes( 32, 0 );
+    dataLenBytes[31] = static_cast<uint8_t>( dataToEncrypt.size() );
+    input.insert( input.end(), dataLenBytes.begin(), dataLenBytes.end() );
+
+    // data
+    input.insert( input.end(), dataToEncrypt.begin(), dataToEncrypt.end() );
 
     // Call the precompiled contract
-    auto res = exec( bytesConstRef( inputData.data(), inputData.size() ),
+    auto res = exec( bytesConstRef( input.data(), input.size() ),
         { 1, 0, true } );
 
     // Verify success
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( !res.second.empty() );
 
-    // Parse output as Ciphertext
+    // Parse output as Ciphertext and validate
     libBLS::Ciphertext ciphertext = libBLS::Ciphertext::fromBytes( res.second, /* validate */ true );
-
-    // Verify ciphertext is valid
-    ciphertext.validate();
 
     // decrypt & check if decrypted = original
     
@@ -1564,24 +1593,25 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
     // 3. Combine shares → AES key
     libBLS::AES256Key aesKey = libBLS::ThresholdEncryption::combineShares( 
         ciphertext.getTargetKey(), decryptSet );
-    // 4. Decrypt using AES key
+    // 4. Decrypt using AES key with AAD
+    std::vector< uint8_t > scAddressVec( scAddressBytes.begin(), scAddressBytes.end() );
     std::vector< uint8_t > decryptedMessage = 
-        libBLS::ThresholdEncryption::decrypt( ciphertext, aesKey );
+        libBLS::ThresholdEncryption::decrypt( ciphertext, aesKey, scAddressVec );
     // 5. Verify original message matches
-    BOOST_REQUIRE( decryptedMessage == inputData );    
+    BOOST_REQUIRE( decryptedMessage == dataToEncrypt );    
 }
 
-BOOST_AUTO_TEST_CASE( encryptTE_emptyInput ) {
+BOOST_AUTO_TEST_CASE( encryptTE_inputTooSmall ) {
     SkaleHostFixture fixture;
 
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
 
-    // Call with empty input
-    bytes emptyInput;
-    auto res = exec( bytesConstRef( emptyInput.data(), emptyInput.size() ),
+    // Call with input smaller than minimum (96 bytes for ABI format)
+    bytes smallInput( 64, 0x42 );
+    auto res = exec( bytesConstRef( smallInput.data(), smallInput.size() ),
         { 1, 0, true } );
 
-    // Verify failure with error code 2 (empty input)
+    // Verify failure with error code 2 (input too small)
     BOOST_REQUIRE( !res.first );
     BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 2 ) ) );
 }
@@ -1599,6 +1629,217 @@ BOOST_AUTO_TEST_CASE( encryptTE_inputTooLarge ) {
     // Verify failure with error code 1 (input too large)
     BOOST_REQUIRE( !res.first );
     BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 1 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptTE_invalidABIEncoding ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Build input with wrong data offset (at position 32, should be 64, we set 32)
+    bytes input( 96, 0 );
+    input[63] = 32;  // Wrong data offset at position 32 (should be 64)
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), { 1, 0, true } );
+
+    // Verify failure with error code 3 (invalid ABI encoding)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 3 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptTE_emptyData ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Build valid ABI input: abi.encode(address, bytes) but with data_length = 0
+    bytes input;
+
+    // SC address (20 bytes, left-padded to 32)
+    bytes addressPadding( 12, 0 );
+    input.insert( input.end(), addressPadding.begin(), addressPadding.end() );
+    bytes scAddrData( 20, 0x12 );
+    input.insert( input.end(), scAddrData.begin(), scAddrData.end() );
+
+    // Offset to data = 64
+    bytes offsetData( 32, 0 );
+    offsetData[31] = 64;
+    input.insert( input.end(), offsetData.begin(), offsetData.end() );
+
+    // data length = 0 (empty data)
+    bytes dataLenBytes( 32, 0 );
+    input.insert( input.end(), dataLenBytes.begin(), dataLenBytes.end() );
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), { 1, 0, true } );
+
+    // Verify failure with error code 5 (empty data)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 5 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_success ) {
+    SkaleHostFixture fixture;
+
+    // Generate a user keypair
+    dev::KeyPair userKeys = dev::KeyPair::create();
+    dev::Public userPublicKey = userKeys.pub();
+    dev::Secret userPrivateKey = userKeys.secret();
+
+    // Extract x and y coordinates from public key (64 bytes total)
+    bytes pubKeyX( userPublicKey.data(), userPublicKey.data() + 32 );
+    bytes pubKeyY( userPublicKey.data() + 32, userPublicKey.data() + 64 );
+
+    // Create test data to encrypt
+    std::string testMessage = "Hello, ECIES encryption!";
+    bytes dataToEncrypt( testMessage.begin(), testMessage.end() );
+
+    // Build ABI-encoded input: [offset_to_data(32)] [x(32)] [y(32)] [data_length(32)] [data(N)]
+    bytes input;
+    // Offset to data = 96 (0x60) = 3 * 32
+    input.insert( input.end(), 32, 0 );
+    input[31] = 96;
+    // x-coordinate (32 bytes)
+    input.insert( input.end(), pubKeyX.begin(), pubKeyX.end() );
+    // y-coordinate (32 bytes)
+    input.insert( input.end(), pubKeyY.begin(), pubKeyY.end() );
+    // Data length (32 bytes)
+    bytes lenBytes( 32, 0 );
+    lenBytes[31] = static_cast<uint8_t>( dataToEncrypt.size() );
+    input.insert( input.end(), lenBytes.begin(), lenBytes.end() );
+    // Data
+    input.insert( input.end(), dataToEncrypt.begin(), dataToEncrypt.end() );
+
+    // Get the executor for encryptECIES
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Call the precompiled contract
+    auto res = exec( bytesConstRef( input.data(), input.size() ), { 1, 0, true } );
+
+    // Verify success
+    BOOST_REQUIRE( res.first );
+    BOOST_REQUIRE( !res.second.empty() );
+
+    // Output format: [IV (16 bytes)] [Ephemeral Public Key (33 bytes)] [Ciphertext (N bytes)]
+    BOOST_REQUIRE( res.second.size() >= 16 + 33 + 16 );  // IV + pubkey + min ciphertext
+
+    // Parse output
+    bytes iv( res.second.begin(), res.second.begin() + 16 );
+    bytes ephemeralPubKeyCompressed( res.second.begin() + 16, res.second.begin() + 16 + 33 );
+
+    // Verify ephemeral public key prefix (0x02 or 0x03 for compressed format)
+    BOOST_REQUIRE( ephemeralPubKeyCompressed[0] == 0x02 || ephemeralPubKeyCompressed[0] == 0x03 );
+
+    auto decryptedBytes = dev::decryptECIES_CBC( userPrivateKey, &res.second );
+
+    // 7. Verify decrypted matches original
+    BOOST_REQUIRE( decryptedBytes == dataToEncrypt );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_inputTooLarge ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Input larger than 64KB
+    bytes largeInput( 65 * 1024, 0x42 );
+    auto res = exec( bytesConstRef( largeInput.data(), largeInput.size() ), { 1, 0, true } );
+
+    // Verify failure with error code 1 (input too large)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 1 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_inputTooSmall ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Input smaller than 128 bytes
+    bytes smallInput( 64, 0x42 );
+    auto res = exec( bytesConstRef( smallInput.data(), smallInput.size() ), { 1, 0, true } );
+
+    // Verify failure with error code 2 (input too small)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 2 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_invalidABIOffset ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Build input with wrong data offset (should be 96, we set 64)
+    bytes input( 128, 0 );
+    input[31] = 64;  // Wrong offset (should be 96)
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), { 1, 0, true } );
+
+    // Verify failure with error code 3 (invalid ABI encoding)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 3 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_dataLengthMismatch ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Build input where data_length claims more data than actually present
+    bytes input( 128, 0 );
+    input[31] = 96;   // Correct offset
+    input[127] = 100; // Claim 100 bytes of data, but none actually present
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), { 1, 0, true } );
+
+    // Verify failure with error code 4 (data length mismatch)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 4 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_emptyData ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Build valid input but with data_length = 0
+    bytes input( 128, 0 );
+    input[31] = 96;  // Correct offset
+    // data_length at position [96..127] = 0 (already zeroed)
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), { 1, 0, true } );
+
+    // Verify failure with error code 5 (empty data)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 5 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_invalidPublicKey ) {
+    SkaleHostFixture fixture;
+
+    // Create invalid public key (not on curve)
+    bytes invalidPubKeyX( 32, 0xFF );
+    bytes invalidPubKeyY( 32, 0xFF );
+
+    std::string testMessage = "Test";
+    bytes dataToEncrypt( testMessage.begin(), testMessage.end() );
+
+    // Build ABI-encoded input
+    bytes input;
+    input.insert( input.end(), 32, 0 );
+    input[31] = 96;  // offset
+    input.insert( input.end(), invalidPubKeyX.begin(), invalidPubKeyX.end() );
+    input.insert( input.end(), invalidPubKeyY.begin(), invalidPubKeyY.end() );
+    bytes lenBytes( 32, 0 );
+    lenBytes[31] = static_cast<uint8_t>( dataToEncrypt.size() );
+    input.insert( input.end(), lenBytes.begin(), lenBytes.end() );
+    input.insert( input.end(), dataToEncrypt.begin(), dataToEncrypt.end() );
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), { 1, 0, true } );
+
+    // Verify failure with error code 6 (invalid public key)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 6 ) ) );
 }
 #endif  // BITE2
 


### PR DESCRIPTION
## Add Encryption Precompiled Contracts

### Summary
Adds two new precompiled smart contracts for on-chain encryption capabilities.

### [encryptTE](cci:1://file:///workspace/skaled/libethereum/Precompiled.cpp:1165:0-1253:1) (Threshold Encryption)
Encrypts data using the network's BLS threshold encryption public key.

**Input:** `abi.encode(address scAddress, bytes data)`
- `scAddress` - Smart contract address used as Associated Data (AAD) to bind ciphertext to that contract
- `data` - Plaintext data to encrypt (max 64KB)

**Output:** Serialized `Ciphertext` bytes that can only be decrypted by the network's threshold signature holders

**Error Codes:**
| Code | Description |
|------|-------------|
| 1 | Input too large (>64KB) |
| 2 | Input too small (<96 bytes) |
| 3 | Input not 32-byte aligned |
| 4 | Address padding not 0's |
| 5 | Invalid data field offset |
| 6 | Data length mismatch |
| 7 | Trailing padding not 0's |

---

### [encryptECIES](cci:1://file:///workspace/skaled/libethereum/Precompiled.cpp:1256:0-1345:1) (ECIES-CBC Encryption)
Encrypts data for a specific recipient using their secp256k1 public key.

**Input:** `abi.encode(bytes data, bytes32 pubKeyX, bytes32 pubKeyY)`
- `data` - Plaintext data to encrypt (max 64KB)
- `pubKeyX`, `pubKeyY` - Recipient's uncompressed public key coordinates

**Output:** ECIES-encrypted ciphertext (AES-256-CBC with PKCS7 padding)

**Error Codes:**
| Code | Description |
|------|-------------|
| 1 | Input too large (>64KB) |
| 2 | Input too small (<128 bytes) |
| 3 | Input not 32-byte aligned |
| 4 | Invalid data field offset |
| 5 | Data length mismatch |
| 6 | Trailing padding not 0's |
| 7 | Invalid public key (not on secp256k1 curve) |
| 8 | Encryption failed |

---

### Notes
- Both contracts are guarded by `#ifdef BITE2`
- Unit tests added for all error paths

Fixes #2324 