### PR TITLE
Add precompiled contracts for ECIES and TE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,8 @@ if (BITE2)
 endif()
 
 if (FAIR)
+    set(BITE "1")
+    set(BITE2 "1")
     add_definitions(-DBITE=1)
     add_definitions(-DBITE2=1)
     add_definitions(-DFAIR=1)

--- a/libdevcrypto/Common.cpp
+++ b/libdevcrypto/Common.cpp
@@ -26,8 +26,10 @@
 #include "AES.h"
 #include "CryptoPP.h"
 #include "Exceptions.h"
+#include "Hash.h"
 
 #include <cryptopp/aes.h>
+#include <cryptopp/filters.h>
 #include <cryptopp/modes.h>
 #include <cryptopp/pwdbased.h>
 #include <cryptopp/sha.h>
@@ -410,4 +412,152 @@ SignatureStruct dev::makeSignature( const bytes& entropy, const dev::u256& txInd
 
     return SignatureStruct( h256( r ), h256( s ), parity );
 }
+
+bytes dev::compressPublicKey( Public const& _pub ) {
+    auto* ctx = getCtx();
+
+    // Build uncompressed format: 0x04 || x || y (65 bytes)
+    std::array< uint8_t, 65 > uncompressedPubKey;
+    uncompressedPubKey[0] = 0x04;
+    memcpy( uncompressedPubKey.data() + 1, _pub.data(), 64 );
+
+    // Parse into secp256k1 internal format
+    secp256k1_pubkey parsedPubKey;
+    if ( !secp256k1_ec_pubkey_parse(
+             ctx, &parsedPubKey, uncompressedPubKey.data(), uncompressedPubKey.size() ) ) {
+        return {};  // Invalid public key
+    }
+
+    // Serialize to compressed format (33 bytes)
+    bytes result( 33 );
+    size_t outputLen = 33;
+    secp256k1_ec_pubkey_serialize(
+        ctx, result.data(), &outputLen, &parsedPubKey, SECP256K1_EC_COMPRESSED );
+
+    return result;
+}
+
+Public dev::decompressPublicKey( bytesConstRef _compressed ) {
+    if ( _compressed.size() != 33 )
+        return {};
+
+    auto* ctx = getCtx();
+
+    // Parse compressed public key
+    secp256k1_pubkey parsedPubKey;
+    if ( !secp256k1_ec_pubkey_parse( ctx, &parsedPubKey, _compressed.data(), _compressed.size() ) )
+        return {};
+
+    // Serialize to uncompressed format (65 bytes: 0x04 prefix + 64 bytes)
+    std::array< uint8_t, 65 > uncompressedPubKey;
+    size_t outputLen = 65;
+    secp256k1_ec_pubkey_serialize(
+        ctx, uncompressedPubKey.data(), &outputLen, &parsedPubKey, SECP256K1_EC_UNCOMPRESSED );
+
+    // Return the 64 bytes (skip the 0x04 prefix)
+    return Public( &uncompressedPubKey[1], Public::ConstructFromPointer );
+}
+
+bool dev::isValidPublicKey( Public const& _pub ) {
+    if ( !_pub )
+        return false;
+
+    auto* ctx = getCtx();
+
+    // Build uncompressed format: 0x04 || x || y (65 bytes)
+    std::array< uint8_t, 65 > uncompressedPubKey;
+    uncompressedPubKey[0] = 0x04;
+    memcpy( uncompressedPubKey.data() + 1, _pub.data(), 64 );
+
+    // Try to parse - this validates it's on the curve
+    secp256k1_pubkey parsedPubKey;
+    return secp256k1_ec_pubkey_parse(
+        ctx, &parsedPubKey, uncompressedPubKey.data(), uncompressedPubKey.size() );
+}
+
+bytes dev::encryptECIES_CBC( Public const& _recipientPubKey, bytesConstRef _plain ) {
+    // Note: Empty plaintext is allowed - with PKCS7 padding it produces a 16-byte padding block
+    // This prevents distinguishing between empty and non-empty encrypted payloads
+
+    // Generate ephemeral key pair
+    KeyPair ephemeralKeyPair = KeyPair::create();
+
+    // ECDH: shared secret = ephemeral_private * recipient_public
+    Secret sharedSecret;
+    if ( !crypto::ecdh::agree( ephemeralKeyPair.secret(), _recipientPubKey, sharedSecret ) )
+        return {};
+
+    // KDF: encryption_key = SHA-256(shared_secret)
+    h256 encryptionKey = dev::sha256( sharedSecret.ref() );
+
+    // Generate random IV (16 bytes)
+    h128 iv = h128::random();
+
+    // AES-256-CBC encryption with PKCS7 padding
+    CryptoPP::CBC_Mode< CryptoPP::AES >::Encryption aesEncryptor;
+    aesEncryptor.SetKeyWithIV( encryptionKey.data(), encryptionKey.size, iv.data() );
+
+    std::string ciphertextStr;
+    CryptoPP::StreamTransformationFilter stfEncryptor(
+        aesEncryptor, new CryptoPP::StringSink( ciphertextStr ) );
+    stfEncryptor.Put( _plain.data(), _plain.size() );
+    stfEncryptor.MessageEnd();
+
+    // Compress ephemeral public key to 33 bytes
+    bytes compressedEphPubKey = compressPublicKey( ephemeralKeyPair.pub() );
+    if ( compressedEphPubKey.empty() )
+        return {};
+
+    // Output format: [IV(16)] [CompressedEphPubKey(33)] [Ciphertext]
+    bytes result;
+    result.reserve( 16 + 33 + ciphertextStr.size() );
+    result.insert( result.end(), iv.begin(), iv.end() );
+    result.insert( result.end(), compressedEphPubKey.begin(), compressedEphPubKey.end() );
+    result.insert( result.end(), ciphertextStr.begin(), ciphertextStr.end() );
+
+    return result;
+}
+
+bytes dev::decryptECIES_CBC( Secret const& _recipientPrivKey, bytesConstRef _cipher ) {
+    // Minimum size: IV(16) + CompressedPubKey(33) + at least 1 block(16)
+    static constexpr size_t MIN_CIPHER_SIZE = 16 + 33 + 16;
+    if ( _cipher.size() < MIN_CIPHER_SIZE )
+        return {};
+
+    // Parse input: [IV(16)] [CompressedEphPubKey(33)] [Ciphertext]
+    h128 iv( _cipher.cropped( 0, 16 ) );
+    bytesConstRef compressedEphPubKey = _cipher.cropped( 16, 33 );
+    bytesConstRef ciphertext = _cipher.cropped( 49 );
+
+    // Decompress ephemeral public key
+    Public ephemeralPubKey = decompressPublicKey( compressedEphPubKey );
+    if ( !ephemeralPubKey )
+        return {};
+
+    // ECDH: shared secret = recipient_private * ephemeral_public
+    Secret sharedSecret;
+    if ( !crypto::ecdh::agree( _recipientPrivKey, ephemeralPubKey, sharedSecret ) )
+        return {};
+
+    // KDF: encryption_key = SHA-256(shared_secret)
+    h256 encryptionKey = dev::sha256( sharedSecret.ref() );
+
+    // AES-256-CBC decryption with PKCS7 unpadding
+    CryptoPP::CBC_Mode< CryptoPP::AES >::Decryption aesDecryptor;
+    aesDecryptor.SetKeyWithIV( encryptionKey.data(), encryptionKey.size, iv.data() );
+
+    std::string plaintextStr;
+    try {
+        CryptoPP::StreamTransformationFilter stfDecryptor( aesDecryptor,
+            new CryptoPP::StringSink( plaintextStr ),
+            CryptoPP::BlockPaddingSchemeDef::PKCS_PADDING );
+        stfDecryptor.Put( ciphertext.data(), ciphertext.size() );
+        stfDecryptor.MessageEnd();
+    } catch ( ... ) {
+        return {};  // Decryption or padding error
+    }
+
+    return bytes( plaintextStr.begin(), plaintextStr.end() );
+}
+
 #endif

--- a/libdevcrypto/Common.h
+++ b/libdevcrypto/Common.h
@@ -155,6 +155,27 @@ bool isValidSecp256k1X( const u256& x );
 // Return (r,s,v) fabricated from entropy bytes and transaction index.
 SignatureStruct makeSignature( const bytes& entropy, const dev::u256& txIndex );
 
+// Compress a 64-byte public key to 33-byte compressed format.
+// Returns empty bytes on failure.
+bytes compressPublicKey( Public const& _pub );
+
+// Decompress a 33-byte compressed public key to 64-byte uncompressed format.
+// Returns null Public on failure.
+Public decompressPublicKey( bytesConstRef _compressed );
+
+// Check if a 64-byte public key is a valid point on the secp256k1 curve.
+bool isValidPublicKey( Public const& _pub );
+
+/// Encrypt using ECIES with AES-256-CBC and PKCS7 padding.
+/// Output format: [IV(16)] [CompressedEphPubKey(33)] [Ciphertext]
+/// Returns empty bytes on failure.
+bytes encryptECIES_CBC( Public const& _recipientPubKey, bytesConstRef _plain );
+
+/// Decrypt ECIES ciphertext encrypted with AES-256-CBC and PKCS7 padding.
+/// Input format: [IV(16)] [CompressedEphPubKey(33)] [Ciphertext]
+/// Returns empty bytes on failure.
+bytes decryptECIES_CBC( Secret const& _recipientPrivKey, bytesConstRef _cipher );
+
 inline bool operator==( const dev::SignatureStruct& lhs, const dev::SignatureStruct& rhs ) {
     return lhs.r == rhs.r && lhs.s == rhs.s && lhs.v == rhs.v;
 }

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -25,9 +25,9 @@
 
 #ifdef BITE2
 #include "BITEConstants.h"
-#include <libdevcore/RLP.h>
 #include <libconsensus/libBLS/threshold_encryption/TEPublicKey.h>
 #include <libconsensus/libBLS/threshold_encryption/ThresholdEncryption.h>
+#include <libdevcore/RLP.h>
 #endif
 
 #include "PrecompiledHelpers.h"
@@ -1258,8 +1258,7 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
         }
 
         // Extract data bytes (empty data is allowed)
-        std::vector< uint8_t > dataToEncrypt =
-            _in.cropped( dataStart, dataLengthSafe ).toBytes();
+        std::vector< uint8_t > dataToEncrypt = _in.cropped( dataStart, dataLengthSafe ).toBytes();
 
         // Validate trailing padding bytes are all zeros (ABI compliance)
         size_t dataEnd = dataStart + dataLengthSafe;

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -1201,11 +1201,10 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
             return { false, toBigEndian( dev::u256( 1 ) ) };  // error 1: input too large
         }
 
-        // Input format: abi.encode(address scAddress, bytes data)
-        // ABI encoding: [scAddress(20 bytes, left-padded to 32)] [offset_to_data(32)]
-        //               [data_length(32)] [data(N)]
-        // Minimum: 32 (address) + 32 (offset) + 32 (length) = 96 bytes
-        if ( _in.size() < 96 ) {
+        // Input format: abi.encode(bytes data)
+        // ABI encoding: [offset_to_data(32)] [data_length(32)] [data(N)]
+        // Minimum: 32 (offset) + 32 (length) = 64 bytes
+        if ( _in.size() < 64 ) {
             return { false, toBigEndian( dev::u256( 2 ) ) };  // error 2: input too small
         }
 
@@ -1220,23 +1219,14 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
 
         size_t headFieldSizeBytes = 32;
 
-        // First 32 bytes: SC address (20 bytes, left-padded to 32)
-        // Validate that the first 12 bytes are zeros (left-padding for 20-byte address)
-        if ( !std::all_of( _in.data(), _in.data() + 12, []( uint8_t b ) { return b == 0; } ) ) {
-            return { false, toBigEndian( dev::u256( 4 ) ) };  // error 4: address padding not zeros
-        }
-
-        // Extract the 20-byte address
-        auto scAddressBytes = _in.cropped( 12, 20 ).toBytes();
-
-        // Next 32 bytes: offset to data (should be 64 = 2 * 32)
-        bigint const dataOffset( parseBigEndianRightPadded( _in, 32, headFieldSizeBytes ) );
-        const size_t expectedDataOffset = 2 * 32;  // 64
+        // First 32 bytes: offset to data (should be 32)
+        bigint const dataOffset( parseBigEndianRightPadded( _in, 0, headFieldSizeBytes ) );
+        const size_t expectedDataOffset = 32;
         if ( dataOffset != expectedDataOffset ) {
             return { false, toBigEndian( dev::u256( 5 ) ) };  // error 5: invalid data offset
         }
 
-        // Read data length at the data offset (position 64)
+        // Read data length at the data offset (position 32)
         if ( _in.size() < expectedDataOffset + headFieldSizeBytes ) {
             return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: data length mismatch
         }
@@ -1244,8 +1234,8 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
             parseBigEndianRightPadded( _in, expectedDataOffset, headFieldSizeBytes ) );
 
         // Validate dataLength is non-negative and fits within reasonable bounds
-        // Header is 96 bytes (address + offset + length field), so max data = MAX_SIZE_BYTES - 96
-        static constexpr size_t HEADER_SIZE_BYTES = 96;
+        // Header is 64 bytes (offset + length field), so max data = MAX_SIZE_BYTES - 64
+        static constexpr size_t HEADER_SIZE_BYTES = 64;
         if ( dataLength < 0 || dataLength > MAX_SIZE_BYTES - HEADER_SIZE_BYTES ) {
             return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: data length mismatch
         }
@@ -1285,6 +1275,9 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
         // Create seed array from blockRandom (32 bytes)
         std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seed;
         std::copy_n( blockRandomBytes.begin(), libBLS::AES_256_KEY_SIZE_BYTES, seed.begin() );
+
+        // Use caller's address as the associated data for TE
+        auto scAddressBytes = _ctx.from.asBytes();
 
         // Build EncryptMetaData with seed and SC address as TE AAD
         libBLS::EncryptMetaData metaData;

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -22,9 +22,14 @@
  */
 
 #include "Precompiled.h"
+
 #ifdef BITE2
 #include "BITEConstants.h"
+#include <libdevcore/RLP.h>
+#include <libconsensus/libBLS/threshold_encryption/TEPublicKey.h>
+#include <libconsensus/libBLS/threshold_encryption/ThresholdEncryption.h>
 #endif
+
 #include "PrecompiledHelpers.h"
 
 #include <cryptopp/files.h>
@@ -33,9 +38,6 @@
 #include <libdevcore/CommonJS.h>
 #include <libdevcore/FileSystem.h>
 #include <libdevcore/Log.h>
-#ifdef BITE2
-#include <libdevcore/RLP.h>
-#endif
 #include <libdevcore/SHA3.h>
 #include <libdevcore/microprofile.h>
 #include <libdevcrypto/Common.h>
@@ -61,7 +63,6 @@
 #include <functional>
 #include <sstream>
 #include <string>
-
 
 namespace dev {
 namespace eth {
@@ -1191,6 +1192,238 @@ ETH_REGISTER_PRECOMPILED( getRandomWalletAndSignatureForCTX )
     bytes response = toBigEndian( code );
     return { false, response };  // 1st false - means bad error occur
 }
+
+ETH_REGISTER_PRECOMPILED( encryptTE )
+( bytesConstRef _in, const PrecompiledCallContext& _ctx ) {
+    try {
+        static constexpr size_t MAX_SIZE_BYTES = 64 * 1024;  // 64KB
+        if ( _in.size() > MAX_SIZE_BYTES ) {
+            return { false, toBigEndian( dev::u256( 1 ) ) };  // error 1: input too large
+        }
+
+        // Input format: abi.encode(address scAddress, bytes data)
+        // ABI encoding: [scAddress(20 bytes, left-padded to 32)] [offset_to_data(32)]
+        //               [data_length(32)] [data(N)]
+        // Minimum: 32 (address) + 32 (offset) + 32 (length) = 96 bytes
+        if ( _in.size() < 96 ) {
+            return { false, toBigEndian( dev::u256( 2 ) ) };  // error 2: input too small
+        }
+
+        // ABI encoding requires input to be a multiple of 32 bytes
+        if ( _in.size() % 32 != 0 ) {
+            return { false, toBigEndian( dev::u256( 3 ) ) };  // error 3: input not 32-byte aligned
+        }
+
+        if ( !g_skaleHost ) {
+            throw std::runtime_error( "SkaleHost accessor was not initialized" );
+        }
+
+        size_t headFieldSizeBytes = 32;
+
+        // First 32 bytes: SC address (20 bytes, left-padded to 32)
+        // Validate that the first 12 bytes are zeros (left-padding for 20-byte address)
+        if ( !std::all_of( _in.data(), _in.data() + 12, []( uint8_t b ) { return b == 0; } ) ) {
+            return { false, toBigEndian( dev::u256( 4 ) ) };  // error 4: address padding not zeros
+        }
+
+        // Extract the 20-byte address
+        auto scAddressBytes = _in.cropped( 12, 20 ).toBytes();
+
+        // Next 32 bytes: offset to data (should be 64 = 2 * 32)
+        bigint const dataOffset( parseBigEndianRightPadded( _in, 32, headFieldSizeBytes ) );
+        const size_t expectedDataOffset = 2 * 32;  // 64
+        if ( dataOffset != expectedDataOffset ) {
+            return { false, toBigEndian( dev::u256( 5 ) ) };  // error 5: invalid data offset
+        }
+
+        // Read data length at the data offset (position 64)
+        if ( _in.size() < expectedDataOffset + headFieldSizeBytes ) {
+            return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: data length mismatch
+        }
+        bigint const dataLength(
+            parseBigEndianRightPadded( _in, expectedDataOffset, headFieldSizeBytes ) );
+
+        // Validate dataLength is non-negative and fits within reasonable bounds
+        // Header is 96 bytes (address + offset + length field), so max data = MAX_SIZE_BYTES - 96
+        static constexpr size_t HEADER_SIZE_BYTES = 96;
+        if ( dataLength < 0 || dataLength > MAX_SIZE_BYTES - HEADER_SIZE_BYTES ) {
+            return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: data length mismatch
+        }
+        size_t dataLengthSafe = static_cast< size_t >( dataLength );
+
+        // Calculate data start position and validate bounds
+        size_t dataStart = expectedDataOffset + headFieldSizeBytes;
+        if ( dataStart + dataLengthSafe > _in.size() ) {
+            return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: data length mismatch
+        }
+
+        // Extract data bytes (empty data is allowed)
+        std::vector< uint8_t > dataToEncrypt =
+            _in.cropped( dataStart, dataLengthSafe ).toBytes();
+
+        // Validate trailing padding bytes are all zeros (ABI compliance)
+        size_t dataEnd = dataStart + dataLengthSafe;
+        if ( !std::all_of( _in.data() + dataEnd, _in.data() + _in.size(),
+                 []( uint8_t b ) { return b == 0; } ) ) {
+            return { false, toBigEndian( dev::u256( 7 ) ) };  // error 7: trailing padding not zeros
+        }
+
+        // get network public key
+        auto blsPublicKeyArray = g_skaleHost->getCurrentBLSPublicKey();
+
+        // convert BLS public key to TE public key
+        libBLS::algebra::G2Point publicKeyG2 =
+            libBLS::algebra::G2Point::fromString( blsPublicKeyArray, libBLS::Base::DEC );
+        libBLS::TEPublicKey tePublicKey( publicKeyG2 );
+
+        // Get blockRandom to use as seed for deterministic encryption
+        // This ensures all nodes encrypt identically for consensus
+        unsigned blockNumberToCall = _ctx.blockNumber.convert_to< unsigned >();
+        dev::u256 blockRandomValue =
+            g_skaleHost->getBlockRandom( blockNumberToCall, !_ctx.isReadOnly );
+        bytes blockRandomBytes = toBigEndian( blockRandomValue );
+
+        // Create seed array from blockRandom (32 bytes)
+        std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seed;
+        std::copy_n( blockRandomBytes.begin(), libBLS::AES_256_KEY_SIZE_BYTES, seed.begin() );
+
+        // Build EncryptMetaData with seed and SC address as TE AAD
+        libBLS::EncryptMetaData metaData;
+        metaData.seed = libBLS::Seed256{ seed };
+        metaData.associatedDataTE =
+            std::vector< uint8_t >( scAddressBytes.begin(), scAddressBytes.end() );
+
+        // encrypt using threshold encryption
+        libBLS::Ciphertext ciphertext =
+            libBLS::ThresholdEncryption::encrypt( dataToEncrypt, tePublicKey, metaData );
+
+        // convert ciphertext to bytes
+        bytes response = ciphertext.toBytes();
+        return { true, response };
+
+    } catch ( std::exception& ex ) {
+        std::string strError = ex.what();
+        if ( strError.empty() )
+            strError = "exception without description";
+        BOOST_LOG( getLogger( VerbosityError ) )
+            << "Exception in precompiled/encryptTE(): " << strError << "\n";
+    } catch ( ... ) {
+        BOOST_LOG( getLogger( VerbosityError ) )
+            << "Unknown exception in precompiled/encryptTE()\n";
+    }
+
+    dev::u256 code = 0;
+    bytes response = toBigEndian( code );
+    return { false, response };
+}
+
+
+ETH_REGISTER_PRECOMPILED( encryptECIES )
+( bytesConstRef _in, const PrecompiledCallContext& ) {
+    try {
+        static constexpr size_t MAX_SIZE_BYTES = 64 * 1024;  // 64KB
+
+        if ( _in.size() > MAX_SIZE_BYTES ) {
+            return { false, toBigEndian( dev::u256( 1 ) ) };  // error 1: input too large
+        }
+
+        // Minimum input: at least public key coordinates (64 bytes)
+        // Input format: abi.encode(bytes data, bytes32 x, bytes32 y)
+        // ABI encoding: [offset_to_data(32)] [x(32)] [y(32)] [data_length(32)] [data(N)]
+        // So minimum is: 32 + 32 + 32 + 32 = 128 bytes for empty data
+        if ( _in.size() < 128 ) {
+            return { false, toBigEndian( dev::u256( 2 ) ) };  // error 2: input too small
+        }
+
+        // ABI encoding requires input to be a multiple of 32 bytes
+        if ( _in.size() % 32 != 0 ) {
+            return { false, toBigEndian( dev::u256( 3 ) ) };  // error 3: input not 32-byte aligned
+        }
+
+        size_t offset = 0;
+        size_t headFieldSizeBytes = 32;
+
+        // Parse ABI-encoded input
+        // First 32 bytes: offset to data
+        bigint const dataOffset( parseBigEndianRightPadded( _in, offset, headFieldSizeBytes ) );
+        // should be 3 * 32 = 96
+        const size_t expectedDataOffset = 3 * 32;
+        if ( dataOffset != expectedDataOffset ) {
+            return { false, toBigEndian( dev::u256( 4 ) ) };  // error 4: invalid data offset
+        }
+
+        // Next 32 bytes: public key x-coordinate
+        offset += headFieldSizeBytes;
+        bytes pubKeyX = _in.cropped( offset, headFieldSizeBytes ).toBytes();
+
+        // Next 32 bytes: public key y-coordinate
+        offset += headFieldSizeBytes;
+        bytes pubKeyY = _in.cropped( offset, headFieldSizeBytes ).toBytes();
+
+        // Next 32 bytes: data length
+        offset += headFieldSizeBytes;
+        bigint const dataLength( parseBigEndianRightPadded( _in, offset, headFieldSizeBytes ) );
+
+        // Validate dataLength is non-negative and fits within reasonable bounds
+        // Header is 128 bytes (offset + x + y + length field), so max data = MAX_SIZE_BYTES - 128
+        static constexpr size_t HEADER_SIZE_BYTES = 128;
+        if ( dataLength < 0 || dataLength > MAX_SIZE_BYTES - HEADER_SIZE_BYTES ) {
+            return { false, toBigEndian( dev::u256( 5 ) ) };  // error 5: data length mismatch
+        }
+        size_t dataLengthSafe = static_cast< size_t >( dataLength );
+
+        // 4 header fields (offset, x, y, length) = 128 bytes
+        size_t dataStart = 4 * headFieldSizeBytes;
+        if ( dataStart + dataLengthSafe > _in.size() ) {
+            return { false, toBigEndian( dev::u256( 5 ) ) };  // error 5: data length mismatch
+        }
+
+        // Extract data to encrypt
+        bytes dataToEncrypt;
+        if ( dataLengthSafe > 0 ) {
+            dataToEncrypt = _in.cropped( dataStart, dataLengthSafe ).toBytes();
+        }
+
+        // Validate trailing padding bytes are all zeros (ABI compliance)
+        size_t dataEnd = dataStart + dataLengthSafe;
+        if ( !std::all_of( _in.data() + dataEnd, _in.data() + _in.size(),
+                 []( uint8_t b ) { return b == 0; } ) ) {
+            return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: trailing padding not zeros
+        }
+
+        // Construct user public key from x,y bytes
+        dev::Public userPubKey;
+        memcpy( userPubKey.data(), pubKeyX.data(), 32 );
+        memcpy( userPubKey.data() + 32, pubKeyY.data(), 32 );
+
+        // Validate public key is on the secp256k1 curve
+        if ( !dev::isValidPublicKey( userPubKey ) ) {
+            return { false, toBigEndian( dev::u256( 7 ) ) };  // error 7: invalid public key
+        }
+
+        // Encrypt using ECIES-CBC helper
+        bytes response = dev::encryptECIES_CBC( userPubKey, bytesConstRef( &dataToEncrypt ) );
+        if ( response.empty() ) {
+            return { false, toBigEndian( dev::u256( 8 ) ) };  // error 8: encryption failed
+        }
+
+        return { true, response };
+
+    } catch ( std::exception& ex ) {
+        std::string strError = ex.what();
+        if ( strError.empty() )
+            strError = "exception without description";
+        BOOST_LOG( getLogger( VerbosityError ) )
+            << "Exception in precompiled/encryptECIES(): " << strError << "\n";
+    } catch ( ... ) {
+        BOOST_LOG( getLogger( VerbosityError ) )
+            << "Unknown exception in precompiled/encryptECIES()\n";
+    }
+    dev::u256 code = 0;
+    bytes response = toBigEndian( code );
+    return { false, response };  // 1st false - means bad error occur
+}
+
 #endif
 
 #ifndef FAIR

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,16 @@ find_library( YAML_CPP_LIBRARIES NAMES yaml-cpp HINTS "${DEPS_INSTALL_ROOT}/lib"
 
 add_executable(testeth ${sources} unittests/libethereum/InstanceMonitorTest.cpp)
 
+# Add libBLS test utils for BITE2 tests
+if(BITE2)
+    target_sources(testeth PRIVATE
+        ${CMAKE_SOURCE_DIR}/libconsensus/libBLS/test/utils.cpp
+    )
+    target_include_directories(testeth PRIVATE
+        ${CMAKE_SOURCE_DIR}/libconsensus/libBLS
+    )
+endif()
+
 target_compile_options( testeth PRIVATE
     -Wno-error=deprecated-copy -Wno-error=unused-result -Wno-unused-parameter -Wno-error=unused-variable -Wno-maybe-uninitialized
     -Wno-error=pessimizing-move
@@ -105,6 +115,7 @@ target_link_libraries(testeth PRIVATE
   $<$<BOOL:${HISTORIC_STATE}>:historic>
   $<$<BOOL:${CONSENSUS}>:consensus>
   $<$<BOOL:${BITE}>:te>
+  $<$<BOOL:${BITE2}>:te>
 
   "${DEPS_INSTALL_ROOT}/lib/libunwind.a"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -115,7 +115,6 @@ target_link_libraries(testeth PRIVATE
   $<$<BOOL:${HISTORIC_STATE}>:historic>
   $<$<BOOL:${CONSENSUS}>:consensus>
   $<$<BOOL:${BITE}>:te>
-  $<$<BOOL:${BITE2}>:te>
 
   "${DEPS_INSTALL_ROOT}/lib/libunwind.a"
 

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -7,6 +7,20 @@
 #endif
 #include <libskale/ConsensusGasPricer.h>
 
+#ifdef BITE2
+#include <libconsensus/libBLS/threshold_encryption/TEPrivateKey.h>
+#include <libconsensus/libBLS/threshold_encryption/TEPrivateKeyShare.h>
+#include <libconsensus/libBLS/threshold_encryption/TEPublicKeyShare.h>
+#include <libconsensus/libBLS/threshold_encryption/TEDecryptSet.h>
+#include <libconsensus/libBLS/threshold_encryption/ThresholdEncryption.h>
+#include <test/utils.h>
+#include <secp256k1.h>
+#include <secp256k1_ecdh.h>
+#include <secp256k1_sha256.h>
+#include <cryptopp/aes.h>
+#include <cryptopp/modes.h>
+#endif
+
 #include <test/tools/libtesteth/TestHelper.h>
 #include <test/tools/libtesteth/TestOutputHelper.h>
 
@@ -266,6 +280,10 @@ struct SkaleHostFixture : public TestOutputHelperFixture {
     bytes bytes_from_json( const Json::Value& json ) {
         Transaction tx = tx_from_json( json );
         return tx.toBytes();
+    }
+
+    void setBlsPublicKey( const std::array< std::string, 4 >& _key ) {
+        chainParams->sChain.nodeGroups[0].blsPublicKey = _key;
     }
 
     TransactionQueue* tq;
@@ -1652,6 +1670,445 @@ BOOST_AUTO_TEST_CASE( getCurrentBLSPublicKey ) {
                                      toBigEndian( dev::u256( imaBLSPublicKey[3] ) ) );
 }
 #endif
+
+#ifdef BITE2
+BOOST_AUTO_TEST_CASE( encryptTE_success ) {
+    SkaleHostFixture fixture;
+
+    // TE helper from libBLS
+    auto keys = generateKeys(1, 1);
+
+    // set test key
+    fixture.setBlsPublicKey(keys.commonPublic.getPublicKeyRaw().toStringArray(libBLS::Base::DEC));
+
+    // Get the executor for encryptTE
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Create test input data
+    std::string testMessage = "Hello, threshold encryption!";
+    bytes dataToEncrypt( testMessage.begin(), testMessage.end() );
+
+    // Create a test SC address (20 bytes)
+    dev::Address testScAddress = dev::Address( "0x1234567890123456789012345678901234567890" );
+    bytes scAddressBytes = testScAddress.asBytes();
+
+    // Build ABI-encoded input: abi.encode(address scAddress, bytes data)
+    // Format: [scAddress(20 bytes, left-padded to 32)] [offset_to_data(32)] [data_length(32)] [data(N)]
+    bytes input;
+
+    // SC address (20 bytes, left-padded to 32)
+    bytes addressPadding( 12, 0 );  // 12 bytes of zero padding
+    input.insert( input.end(), addressPadding.begin(), addressPadding.end() );
+    input.insert( input.end(), scAddressBytes.begin(), scAddressBytes.end() );
+
+    // Offset to data = 64 (2 * 32, after address and offset fields)
+    bytes offsetData( 32, 0 );
+    offsetData[31] = 64;
+    input.insert( input.end(), offsetData.begin(), offsetData.end() );
+
+    // data length
+    bytes dataLenBytes( 32, 0 );
+    dataLenBytes[31] = static_cast<uint8_t>( dataToEncrypt.size() );
+    input.insert( input.end(), dataLenBytes.begin(), dataLenBytes.end() );
+
+    // data (with ABI-compliant padding to 32-byte boundary)
+    input.insert( input.end(), dataToEncrypt.begin(), dataToEncrypt.end() );
+    size_t paddingNeeded = 32 - ( dataToEncrypt.size() % 32 );
+    input.insert( input.end(), paddingNeeded, 0 );
+
+    // Call the precompiled contract
+    auto res = exec( bytesConstRef( input.data(), input.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify success
+    BOOST_REQUIRE( res.first );
+    BOOST_REQUIRE( !res.second.empty() );
+
+    // Parse output as Ciphertext and validate
+    libBLS::Ciphertext ciphertext = libBLS::Ciphertext::fromBytes( res.second, /* validate */ true );
+
+    // Validate the TE ciphertext with SC address as TE AAD
+    std::vector< uint8_t > scAddressVec( scAddressBytes.begin(), scAddressBytes.end() );
+    BOOST_REQUIRE_NO_THROW(
+        libBLS::ThresholdEncryption::validateEncryption( ciphertext.getTargetKey(), &scAddressVec ) );
+
+    // decrypt & check if decrypted = original
+    
+    // 1. Create a decryption share from the single private key share
+    libBLS::TEDecryptionShare share = libBLS::ThresholdEncryption::partialDecrypt(
+        ciphertext.getTargetKey(), keys.secretKeys[0] );
+    // 2. Add to decrypt set
+    libBLS::TEDecryptSet decryptSet( 1, 1 );  // t=1, n=1
+    decryptSet.addDecryptShare( share );
+    // 3. Combine shares → AES key
+    libBLS::AES256Key aesKey = libBLS::ThresholdEncryption::combineShares( 
+        ciphertext.getTargetKey(), decryptSet );
+    // 4. Decrypt using AES key (no AES AAD - we use TE AAD for validation instead)
+    std::vector< uint8_t > decryptedMessage = 
+        libBLS::ThresholdEncryption::decrypt( ciphertext, aesKey );
+    // 5. Verify original message matches
+    BOOST_REQUIRE( decryptedMessage == dataToEncrypt );    
+}
+
+BOOST_AUTO_TEST_CASE( encryptTE_inputTooLarge ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Create input larger than 64KB
+    bytes largeInput( 65 * 1024, 0x42 );  // 65KB of 'B's
+    auto res = exec( bytesConstRef( largeInput.data(), largeInput.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify failure with error code 1 (input too large)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 1 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptTE_inputTooSmall ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Call with input smaller than minimum (96 bytes for ABI format)
+    bytes smallInput( 64, 0x42 );
+    auto res = exec( bytesConstRef( smallInput.data(), smallInput.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify failure with error code 2 (input too small)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 2 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptTE_inputNotAligned ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Build input that is not a multiple of 32 bytes (97 bytes)
+    bytes input( 97, 0 );
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify failure with error code 3 (input not 32-byte aligned)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 3 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptTE_addressPaddingNotZeros ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Build input where the first 12 bytes (address padding) are not zeros
+    bytes input( 96, 0 );
+    input[0] = 0xFF;  // Non-zero byte in address padding
+    input[63] = 64;   // Correct data offset
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify failure with error code 4 (address padding not zeros)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 4 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptTE_invalidABIEncoding ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Build input with wrong data offset (at position 32, should be 64, we set 32)
+    bytes input( 96, 0 );
+    input[63] = 32;  // Wrong data offset at position 32 (should be 64)
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify failure with error code 5 (invalid data offset)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 5 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptTE_dataLengthMismatch ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Build valid ABI structure but claim more data than available
+    bytes input( 128, 0 );
+    // address padding (0-11): zeros
+    // address (12-31): some address
+    input[20] = 0x12;
+    // offset (32-63): 64
+    input[63] = 64;
+    // data_length (64-95): claim 100 bytes, but only 32 bytes total remain
+    input[95] = 100;
+    // actual data (96-127): only 32 bytes of zeros
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify failure with error code 6 (data length mismatch)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 6 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptTE_trailingPaddingNotZeros ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
+
+    // Build valid ABI structure with 1 byte of data, but non-zero trailing padding
+    bytes input( 128, 0 );
+    // address padding (0-11): zeros
+    // address (12-31): some address
+    input[20] = 0x12;
+    // offset (32-63): 64
+    input[63] = 64;
+    // data_length (64-95): 1 byte
+    input[95] = 1;
+    // actual data (96): one byte of data
+    input[96] = 0xAB;
+    // trailing padding (97-127): should be zeros but we set one to non-zero
+    input[100] = 0xFF;
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify failure with error code 7 (trailing padding not zeros)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 7 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_success ) {
+    SkaleHostFixture fixture;
+
+    // Generate a user keypair
+    dev::KeyPair userKeys = dev::KeyPair::create();
+    dev::Public userPublicKey = userKeys.pub();
+    dev::Secret userPrivateKey = userKeys.secret();
+
+    // Extract x and y coordinates from public key (64 bytes total)
+    bytes pubKeyX( userPublicKey.data(), userPublicKey.data() + 32 );
+    bytes pubKeyY( userPublicKey.data() + 32, userPublicKey.data() + 64 );
+
+    // Create test data to encrypt
+    std::string testMessage = "Hello, ECIES encryption!";
+    bytes dataToEncrypt( testMessage.begin(), testMessage.end() );
+
+    // Build ABI-encoded input: [offset_to_data(32)] [x(32)] [y(32)] [data_length(32)] [data(N)]
+    bytes input;
+    // Offset to data = 96 (0x60) = 3 * 32
+    input.insert( input.end(), 32, 0 );
+    input[31] = 96;
+    // x-coordinate (32 bytes)
+    input.insert( input.end(), pubKeyX.begin(), pubKeyX.end() );
+    // y-coordinate (32 bytes)
+    input.insert( input.end(), pubKeyY.begin(), pubKeyY.end() );
+    // Data length (32 bytes)
+    bytes lenBytes( 32, 0 );
+    lenBytes[31] = static_cast<uint8_t>( dataToEncrypt.size() );
+    input.insert( input.end(), lenBytes.begin(), lenBytes.end() );
+    // Data (with ABI-compliant padding to 32-byte boundary)
+    input.insert( input.end(), dataToEncrypt.begin(), dataToEncrypt.end() );
+    size_t paddingNeeded = 32 - ( dataToEncrypt.size() % 32 );
+    input.insert( input.end(), paddingNeeded, 0 );
+
+    // Get the executor for encryptECIES
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Call the precompiled contract
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify success
+    BOOST_REQUIRE( res.first );
+    BOOST_REQUIRE( !res.second.empty() );
+
+    // Output format: [IV (16 bytes)] [Ephemeral Public Key (33 bytes)] [Ciphertext (N bytes)]
+    BOOST_REQUIRE( res.second.size() >= 16 + 33 + 16 );  // IV + pubkey + min ciphertext
+
+    // Parse output
+    bytes iv( res.second.begin(), res.second.begin() + 16 );
+    bytes ephemeralPubKeyCompressed( res.second.begin() + 16, res.second.begin() + 16 + 33 );
+
+    // Verify ephemeral public key prefix (0x02 or 0x03 for compressed format)
+    BOOST_REQUIRE( ephemeralPubKeyCompressed[0] == 0x02 || ephemeralPubKeyCompressed[0] == 0x03 );
+
+    auto decryptedBytes = dev::decryptECIES_CBC( userPrivateKey, &res.second );
+
+    // 7. Verify decrypted matches original
+    BOOST_REQUIRE( decryptedBytes == dataToEncrypt );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_inputTooLarge ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Input larger than 64KB
+    bytes largeInput( 65 * 1024, 0x42 );
+    auto res = exec( bytesConstRef( largeInput.data(), largeInput.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify failure with error code 1 (input too large)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 1 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_inputTooSmall ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Input smaller than 128 bytes
+    bytes smallInput( 64, 0x42 );
+    auto res = exec( bytesConstRef( smallInput.data(), smallInput.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify failure with error code 2 (input too small)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 2 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_inputNotAligned ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Build input that is not a multiple of 32 bytes (129 bytes)
+    bytes input( 129, 0 );
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify failure with error code 3 (input not 32-byte aligned)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 3 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_invalidABIOffset ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Build input with wrong data offset (should be 96, we set 64)
+    bytes input( 128, 0 );
+    input[31] = 64;  // Wrong offset (should be 96)
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify failure with error code 4 (invalid data offset)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 4 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_dataLengthMismatch ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Build input where data_length claims more data than actually present
+    bytes input( 128, 0 );
+    input[31] = 96;   // Correct offset
+    input[127] = 100; // Claim 100 bytes of data, but none actually present
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify failure with error code 5 (data length mismatch)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 5 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_emptyData ) {
+    SkaleHostFixture fixture;
+
+    // Generate a valid user keypair
+    dev::KeyPair userKeys = dev::KeyPair::create();
+    dev::Public userPublicKey = userKeys.pub();
+    dev::Secret userPrivateKey = userKeys.secret();
+
+    // Extract x and y coordinates from public key (64 bytes total)
+    bytes pubKeyX( userPublicKey.data(), userPublicKey.data() + 32 );
+    bytes pubKeyY( userPublicKey.data() + 32, userPublicKey.data() + 64 );
+
+    // Build ABI-encoded input with EMPTY data
+    // Format: [offset_to_data(32)] [x(32)] [y(32)] [data_length(32)] [no data]
+    bytes input;
+    // Offset to data = 96 (0x60) = 3 * 32
+    input.insert( input.end(), 32, 0 );
+    input[31] = 96;
+    // x-coordinate (32 bytes)
+    input.insert( input.end(), pubKeyX.begin(), pubKeyX.end() );
+    // y-coordinate (32 bytes)
+    input.insert( input.end(), pubKeyY.begin(), pubKeyY.end() );
+    // Data length = 0 (32 bytes of zeros)
+    input.insert( input.end(), 32, 0 );
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Call the precompiled contract
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify success - empty data encryption should succeed
+    BOOST_REQUIRE( res.first );
+    BOOST_REQUIRE( !res.second.empty() );
+
+    // Verify we can decrypt back to empty data
+    auto decryptedBytes = dev::decryptECIES_CBC( userPrivateKey, &res.second );
+    BOOST_REQUIRE( decryptedBytes.empty() );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_trailingPaddingNotZeros ) {
+    SkaleHostFixture fixture;
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+
+    // Build valid ABI structure with 1 byte of data, but non-zero trailing padding
+    bytes input( 192, 0 );
+    // offset (0-31): 96
+    input[31] = 96;
+    // pubKeyX (32-63): zeros (valid x coordinate check happens later)
+    // pubKeyY (64-95): zeros
+    // data_length (96-127): 1 byte
+    input[127] = 1;
+    // actual data (128): one byte of data
+    input[128] = 0xAB;
+    // trailing padding (129-191): should be zeros but we set one to non-zero
+    input[150] = 0xFF;
+
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify failure with error code 6 (trailing padding not zeros)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 6 ) ) );
+}
+
+BOOST_AUTO_TEST_CASE( encryptECIES_invalidPublicKey ) {
+    SkaleHostFixture fixture;
+
+    // Create invalid public key (not on curve)
+    bytes invalidPubKeyX( 32, 0xFF );
+    bytes invalidPubKeyY( 32, 0xFF );
+
+    std::string testMessage = "Test";
+    bytes dataToEncrypt( testMessage.begin(), testMessage.end() );
+
+    // Build ABI-encoded input
+    bytes input;
+    input.insert( input.end(), 32, 0 );
+    input[31] = 96;  // offset
+    input.insert( input.end(), invalidPubKeyX.begin(), invalidPubKeyX.end() );
+    input.insert( input.end(), invalidPubKeyY.begin(), invalidPubKeyY.end() );
+    bytes lenBytes( 32, 0 );
+    lenBytes[31] = static_cast<uint8_t>( dataToEncrypt.size() );
+    input.insert( input.end(), lenBytes.begin(), lenBytes.end() );
+    input.insert( input.end(), dataToEncrypt.begin(), dataToEncrypt.end() );
+    // Add ABI-compliant padding to 32-byte boundary
+    size_t paddingNeeded = 32 - ( dataToEncrypt.size() % 32 );
+    input.insert( input.end(), paddingNeeded, 0 );
+
+    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+
+    // Verify failure with error code 7 (invalid public key)
+    BOOST_REQUIRE( !res.first );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 7 ) ) );
+}
+#endif  // BITE2
 
 #ifdef BITE
 BOOST_AUTO_TEST_CASE( biteTransactions ) {

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -12,7 +12,6 @@
 #include <libconsensus/libBLS/threshold_encryption/TEPrivateKeyShare.h>
 #include <libconsensus/libBLS/threshold_encryption/TEPublicKeyShare.h>
 #include <libconsensus/libBLS/threshold_encryption/TEDecryptSet.h>
-#include <libconsensus/libBLS/threshold_encryption/ThresholdEncryption.h>
 #include <test/utils.h>
 #include <secp256k1.h>
 #include <secp256k1_ecdh.h>

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -8,16 +8,16 @@
 #include <libskale/ConsensusGasPricer.h>
 
 #ifdef BITE2
-#include <cryptopp/aes.h>
-#include <cryptopp/modes.h>
-#include <libconsensus/libBLS/threshold_encryption/TEDecryptSet.h>
 #include <libconsensus/libBLS/threshold_encryption/TEPrivateKey.h>
 #include <libconsensus/libBLS/threshold_encryption/TEPrivateKeyShare.h>
 #include <libconsensus/libBLS/threshold_encryption/TEPublicKeyShare.h>
+#include <libconsensus/libBLS/threshold_encryption/TEDecryptSet.h>
+#include <test/utils.h>
 #include <secp256k1.h>
 #include <secp256k1_ecdh.h>
 #include <secp256k1_sha256.h>
-#include <test/utils.h>
+#include <cryptopp/aes.h>
+#include <cryptopp/modes.h>
 #endif
 
 #include <test/tools/libtesteth/TestHelper.h>
@@ -42,9 +42,9 @@
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <memory>
 #include <atomic>
 #include <limits>
-#include <memory>
 
 using namespace dev;
 using namespace dev::eth;
@@ -63,7 +63,7 @@ public:
 
     void runCommitteeRotationForConsensus() override { ++rotationCallCount; }
 
-    std::atomic< uint32_t > rotationCallCount{ 0 };
+    std::atomic< uint32_t > rotationCallCount{0};
 };
 #endif
 
@@ -165,8 +165,8 @@ public:
 
 // TODO Do not copy&paste from JsonRpcFixture
 struct SkaleHostFixture : public TestOutputHelperFixture {
-    SkaleHostFixture(
-        const std::map< std::string, std::string >& params = std::map< std::string, std::string >(),
+    SkaleHostFixture( const std::map< std::string, std::string >& params =
+                          std::map< std::string, std::string >(),
         bool mockCommitteeRotation = false ) {
         dev::p2p::NetworkPreferences nprefs;
         libBLS::init();
@@ -230,8 +230,7 @@ struct SkaleHostFixture : public TestOutputHelperFixture {
         ConsensusTestStubFactory test_stub_factory;
 #ifdef FAIR
         if ( mockCommitteeRotation ) {
-            auto mockHost =
-                std::make_shared< MockRotationSkaleHost >( *client, &test_stub_factory );
+            auto mockHost = std::make_shared< MockRotationSkaleHost >( *client, &test_stub_factory );
             skaleHost = mockHost;
             mockRotationHost = mockHost;
         } else
@@ -390,15 +389,17 @@ BOOST_DATA_TEST_CASE(
 
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx.toBytes() );
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( txns,
 #ifdef BITE
-        DecryptedTransactions{
+                           DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                   std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                   std::make_shared< DecryptedRegularTxsMap >()
+                               },
 #endif
-        utcTime(), 1U ) );
+            utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
     REQUIRE_BLOCK_SIZE( 1, 1 );
@@ -445,13 +446,15 @@ BOOST_DATA_TEST_CASE(
     blockTxns.pushBackRegular( bad_tx1 );
     blockTxns.pushBackRegular( bad_tx2 );
 
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( blockTxns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock(
+        blockTxns,
 #ifdef BITE
-        DecryptedTransactions{
+                                DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                        std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                        std::make_shared< DecryptedRegularTxsMap >()
+                                    },
 #endif
         utcTime(), 1U ) );
 
@@ -547,15 +550,17 @@ BOOST_DATA_TEST_CASE(
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW(
+            stub->createBlock( txns,
 #ifdef BITE
-        DecryptedTransactions{
+                               DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                       std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                       std::make_shared< DecryptedRegularTxsMap >()
+                                   },
 #endif
-        utcTime(), 1U ) );
+            utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
 
@@ -623,11 +628,12 @@ BOOST_DATA_TEST_CASE(
 
     BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
 #ifdef BITE
-        DecryptedTransactions{
+                                               DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                                       std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                                       std::make_shared< DecryptedRegularTxsMap >()
+                                                   },
 #endif
         utcTime(), 1U ) );
 
@@ -684,15 +690,17 @@ BOOST_DATA_TEST_CASE(
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( txns,
 #ifdef BITE
-        DecryptedTransactions{
+                           DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                   std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                   std::make_shared< DecryptedRegularTxsMap >()
+                               },
 #endif
-        utcTime(), 1U ) );
+            utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
 
@@ -762,15 +770,17 @@ BOOST_DATA_TEST_CASE(
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( txns,
 #ifdef BITE
-        DecryptedTransactions{
+                           DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                   std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                   std::make_shared< DecryptedRegularTxsMap >()
+                               },
 #endif
-        utcTime(), 1U ) );
+            utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
     REQUIRE_BLOCK_SIZE( 1, 1 );
@@ -817,15 +827,17 @@ BOOST_DATA_TEST_CASE(
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( txns,
 #ifdef BITE
-        DecryptedTransactions{
+                           DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                   std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                   std::make_shared< DecryptedRegularTxsMap >()
+                               },
 #endif
-        utcTime(), 1U ) );
+            utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
 
@@ -873,15 +885,17 @@ BOOST_DATA_TEST_CASE(
     block1Txns.pushBackRegular( tx1.toBytes() );
 
     // create 1 txns in 1 block
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( block1Txns,
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( block1Txns,
 #ifdef BITE
-        DecryptedTransactions{
+                           DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                   std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                   std::make_shared< DecryptedRegularTxsMap >()
+                               },
 #endif
-        utcTime(), 1U ) );
+            utcTime(), 1U ) );
 
     // now our test txn
     json["value"] = jsToDecimal( toJS( 9000 * dev::eth::szabo ) );
@@ -899,15 +913,17 @@ BOOST_DATA_TEST_CASE(
     ConsensusExtFace::Transactions block2Txns;
     block2Txns.pushBackRegular( tx2.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( block2Txns,
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( block2Txns,
 #ifdef BITE
-        DecryptedTransactions{
+                           DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                   std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                   std::make_shared< DecryptedRegularTxsMap >()
+                               },
 #endif
-        utcTime(), 2U ) );
+            utcTime(), 2U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
 
@@ -966,15 +982,17 @@ BOOST_DATA_TEST_CASE(
     ConsensusExtFace::Transactions block1Txns;
     block1Txns.pushBackRegular( tx.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( block1Txns,
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( block1Txns,
 #ifdef BITE
-        DecryptedTransactions{
+                           DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                   std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                   std::make_shared< DecryptedRegularTxsMap >()
+                               },
 #endif
-        utcTime(), 1U ) );
+            utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
 
@@ -1007,11 +1025,12 @@ BOOST_DATA_TEST_CASE(
 
     stub->createBlock( block2Txns,
 #ifdef BITE
-        DecryptedTransactions{
+                       DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                               std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                               std::make_shared< DecryptedRegularTxsMap >()
+                           },
 #endif
         utcTime(), 2U );
 
@@ -1073,15 +1092,17 @@ BOOST_DATA_TEST_CASE(
     txns.pushBackRegular( tx1.toBytes() );
     txns.pushBackRegular( tx2.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( txns,
 #ifdef BITE
-        DecryptedTransactions{
+                           DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                   std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                   std::make_shared< DecryptedRegularTxsMap >()
+                               },
 #endif
-        utcTime(), 1U ) );
+            utcTime(), 1U ) );
     BOOST_REQUIRE_EQUAL( client->number(), 1 );
 
     REQUIRE_BLOCK_INCREASE( 1 );
@@ -1206,11 +1227,12 @@ BOOST_AUTO_TEST_CASE( transactionDropReceive
 
     BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
 #ifdef BITE
-        DecryptedTransactions{
-#ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
-#endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                               DecryptedTransactions{
+        #ifdef BITE2
+                                                       std::make_shared< DecryptedCATxsMap >(),
+        #endif  // BITE2
+                                                       std::make_shared< DecryptedRegularTxsMap >()
+                                                   },
 #endif
         utcTime(), 1U ) );
     stub->setPriceForBlockId( 1, 1000 );
@@ -1275,15 +1297,17 @@ BOOST_AUTO_TEST_CASE(
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx2.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( txns,
 #ifdef BITE
-        DecryptedTransactions{
+                           DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                   std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                   std::make_shared< DecryptedRegularTxsMap >()
+                               },
 #endif
-        utcTime(), 1U ) );
+            utcTime(), 1U ) );
     stub->setPriceForBlockId( 1, 1000 );
 
     REQUIRE_BLOCK_INCREASE( 1 );
@@ -1349,15 +1373,17 @@ BOOST_AUTO_TEST_CASE( transactionDropByGasPrice
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx2.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( txns,
 #ifdef BITE
-        DecryptedTransactions{
+                           DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                   std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                   std::make_shared< DecryptedRegularTxsMap >()
+                               },
 #endif
-        utcTime(), 1U, 1000 ) );
+            utcTime(), 1U, 1000 ) );
     stub->setPriceForBlockId( 1, 1100 );
 
     REQUIRE_BLOCK_INCREASE( 1 );
@@ -1432,15 +1458,17 @@ BOOST_AUTO_TEST_CASE( transactionDropByGasPriceReceive
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx2.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( txns,
 #ifdef BITE
-        DecryptedTransactions{
+                           DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                   std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                   std::make_shared< DecryptedRegularTxsMap >()
+                               },
 #endif
-        utcTime(), 1U, 1000 ) );
+            utcTime(), 1U, 1000 ) );
     stub->setPriceForBlockId( 1, 1100 );
 
     REQUIRE_BLOCK_INCREASE( 1 );
@@ -1489,15 +1517,17 @@ BOOST_AUTO_TEST_CASE( transactionRace
     txns.pushBackRegular( tx.toBytes() );
 
     // 2 get it from consensus
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( txns,
 #ifdef BITE
-        DecryptedTransactions{
+                           DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                   std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                   std::make_shared< DecryptedRegularTxsMap >()
+                               },
 #endif
-        utcTime(), 1U ) );
+            utcTime(), 1U ) );
     stub->setPriceForBlockId( 1, 1000 );
 
     REQUIRE_BLOCK_INCREASE( 1 );
@@ -1546,15 +1576,17 @@ BOOST_AUTO_TEST_CASE( partialCatchUp
     block1txns.pushBackRegular( tx1.toBytes() );
 
     // create 1 txns in 1 block
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( block1txns,
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( block1txns,
 #ifdef BITE
-        DecryptedTransactions{
+                           DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                   std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                   std::make_shared< DecryptedRegularTxsMap >()
+                               },
 #endif
-        utcTime(), 1U ) );
+            utcTime(), 1U ) );
 
     // now 2 txns
     json["value"] = jsToDecimal( toJS( 9000 * dev::eth::szabo ) );
@@ -1575,15 +1607,17 @@ BOOST_AUTO_TEST_CASE( partialCatchUp
     block2Txns.pushBackRegular( tx1.toBytes() );
     block2Txns.pushBackRegular( tx2.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( block2Txns,
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( block2Txns,
 #ifdef BITE
-        DecryptedTransactions{
+                           DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                   std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                   std::make_shared< DecryptedRegularTxsMap >()
+                               },
 #endif
-        utcTime(), 2U ) );
+            utcTime(), 2U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
 #ifndef FAIR
@@ -1604,9 +1638,11 @@ BOOST_AUTO_TEST_CASE( getBlockRandom ) {
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "getBlockRandom" );
     auto res = exec( bytesConstRef(), { 1,
 #ifdef BITE2
-                                          { 0 }, 1, dev::ZeroAddress,
+                                        { 0 },
+                                        1,
+                                        dev::ZeroAddress,
 #endif
-                                          true } );
+                                        true } );
     u256 blockRandom = skaleHost->getBlockRandom( 0, false );
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( res.second == toBigEndian( static_cast< u256 >( blockRandom ) ) );
@@ -1620,9 +1656,11 @@ BOOST_AUTO_TEST_CASE( getCurrentBLSPublicKey ) {
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "getIMABLSPublicKey" );
     auto res = exec( bytesConstRef(), { 1,
 #ifdef BITE2
-                                          { -1 }, 0, dev::ZeroAddress,
+                                        { -1 },
+                                        0,
+                                        dev::ZeroAddress,
 #endif
-                                          true } );
+                                        true } );
     std::array< std::string, 4 > imaBLSPublicKey = skaleHost->getCurrentBLSPublicKey();
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( res.second == toBigEndian( dev::u256( imaBLSPublicKey[0] ) ) +
@@ -1637,11 +1675,10 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
     SkaleHostFixture fixture;
 
     // TE helper from libBLS
-    auto keys = generateKeys( 1, 1 );
+    auto keys = generateKeys(1, 1);
 
     // set test key
-    fixture.setBlsPublicKey(
-        keys.commonPublic.getPublicKeyRaw().toStringArray( libBLS::Base::DEC ) );
+    fixture.setBlsPublicKey(keys.commonPublic.getPublicKeyRaw().toStringArray(libBLS::Base::DEC));
 
     // Get the executor for encryptTE
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
@@ -1656,7 +1693,6 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
 
     // Build ABI-encoded input: abi.encode(bytes data)
     // Format: [offset_to_data(32)] [data_length(32)] [data(N)]
-    // Minimum: 32 (offset) + 32 (length) = 64 bytes
     bytes input;
 
     // Offset to data = 32 (after offset field itself)
@@ -1666,7 +1702,7 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
 
     // data length
     bytes dataLenBytes( 32, 0 );
-    dataLenBytes[31] = static_cast< uint8_t >( dataToEncrypt.size() );
+    dataLenBytes[31] = static_cast<uint8_t>( dataToEncrypt.size() );
     input.insert( input.end(), dataLenBytes.begin(), dataLenBytes.end() );
 
     // data (with ABI-compliant padding to 32-byte boundary)
@@ -1674,7 +1710,7 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
     size_t paddingNeeded = 32 - ( dataToEncrypt.size() % 32 );
     input.insert( input.end(), paddingNeeded, 0 );
 
-    // Call the precompiled contract
+    // Call the precompiled contract - pass testScAddress via context.from
     auto res = exec( bytesConstRef( input.data(), input.size() ),
         PrecompiledCallContext( 1, 0, 0, testScAddress, true ) );
 
@@ -1683,16 +1719,15 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
     BOOST_REQUIRE( !res.second.empty() );
 
     // Parse output as Ciphertext and validate
-    libBLS::Ciphertext ciphertext =
-        libBLS::Ciphertext::fromBytes( res.second, /* validate */ true );
+    libBLS::Ciphertext ciphertext = libBLS::Ciphertext::fromBytes( res.second, /* validate */ true );
 
     // Validate the TE ciphertext with SC address as TE AAD
     std::vector< uint8_t > scAddressVec( scAddressBytes.begin(), scAddressBytes.end() );
-    BOOST_REQUIRE_NO_THROW( libBLS::ThresholdEncryption::validateEncryption(
-        ciphertext.getTargetKey(), &scAddressVec ) );
+    BOOST_REQUIRE_NO_THROW(
+        libBLS::ThresholdEncryption::validateEncryption( ciphertext.getTargetKey(), &scAddressVec ) );
 
     // decrypt & check if decrypted = original
-
+    
     // 1. Create a decryption share from the single private key share
     libBLS::TEDecryptionShare share = libBLS::ThresholdEncryption::partialDecrypt(
         ciphertext.getTargetKey(), keys.secretKeys[0] );
@@ -1700,13 +1735,13 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
     libBLS::TEDecryptSet decryptSet( 1, 1 );  // t=1, n=1
     decryptSet.addDecryptShare( share );
     // 3. Combine shares → AES key
-    libBLS::AES256Key aesKey =
-        libBLS::ThresholdEncryption::combineShares( ciphertext.getTargetKey(), decryptSet );
+    libBLS::AES256Key aesKey = libBLS::ThresholdEncryption::combineShares( 
+        ciphertext.getTargetKey(), decryptSet );
     // 4. Decrypt using AES key (no AES AAD - we use TE AAD for validation instead)
-    std::vector< uint8_t > decryptedMessage =
+    std::vector< uint8_t > decryptedMessage = 
         libBLS::ThresholdEncryption::decrypt( ciphertext, aesKey );
     // 5. Verify original message matches
-    BOOST_REQUIRE( decryptedMessage == dataToEncrypt );
+    BOOST_REQUIRE( decryptedMessage == dataToEncrypt );    
 }
 
 BOOST_AUTO_TEST_CASE( encryptTE_inputTooLarge ) {
@@ -1747,26 +1782,23 @@ BOOST_AUTO_TEST_CASE( encryptTE_inputNotAligned ) {
     // Build input that is not a multiple of 32 bytes (65 bytes)
     bytes input( 65, 0 );
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ),
-        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 3 (input not 32-byte aligned)
     BOOST_REQUIRE( !res.first );
     BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 3 ) ) );
 }
 
-
 BOOST_AUTO_TEST_CASE( encryptTE_invalidABIEncoding ) {
     SkaleHostFixture fixture;
 
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
 
-    // Build input with wrong data offset (at position 0, should be 32, we set 64)
+    // Build input with wrong data offset (should be 32, we set 64)
     bytes input( 64, 0 );
-    input[31] = 64;  // Wrong data offset at position 32 (should be 32)
+    input[31] = 64;  // Wrong data offset (should be 32)
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ),
-        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 5 (invalid data offset)
     BOOST_REQUIRE( !res.first );
@@ -1786,8 +1818,7 @@ BOOST_AUTO_TEST_CASE( encryptTE_dataLengthMismatch ) {
     input[63] = 100;
     // actual data (64-95): only 32 bytes of zeros
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ),
-        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 6 (data length mismatch)
     BOOST_REQUIRE( !res.first );
@@ -1810,8 +1841,7 @@ BOOST_AUTO_TEST_CASE( encryptTE_trailingPaddingNotZeros ) {
     // trailing padding (65-95): should be zeros but we set one to non-zero
     input[95] = 0xFF;
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ),
-        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 7 (trailing padding not zeros)
     BOOST_REQUIRE( !res.first );
@@ -1845,7 +1875,7 @@ BOOST_AUTO_TEST_CASE( encryptECIES_success ) {
     input.insert( input.end(), pubKeyY.begin(), pubKeyY.end() );
     // Data length (32 bytes)
     bytes lenBytes( 32, 0 );
-    lenBytes[31] = static_cast< uint8_t >( dataToEncrypt.size() );
+    lenBytes[31] = static_cast<uint8_t>( dataToEncrypt.size() );
     input.insert( input.end(), lenBytes.begin(), lenBytes.end() );
     // Data (with ABI-compliant padding to 32-byte boundary)
     input.insert( input.end(), dataToEncrypt.begin(), dataToEncrypt.end() );
@@ -1856,8 +1886,7 @@ BOOST_AUTO_TEST_CASE( encryptECIES_success ) {
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
 
     // Call the precompiled contract
-    auto res = exec( bytesConstRef( input.data(), input.size() ),
-        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify success
     BOOST_REQUIRE( res.first );
@@ -1886,8 +1915,7 @@ BOOST_AUTO_TEST_CASE( encryptECIES_inputTooLarge ) {
 
     // Input larger than 64KB
     bytes largeInput( 65 * 1024, 0x42 );
-    auto res = exec( bytesConstRef( largeInput.data(), largeInput.size() ),
-        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( largeInput.data(), largeInput.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 1 (input too large)
     BOOST_REQUIRE( !res.first );
@@ -1901,8 +1929,7 @@ BOOST_AUTO_TEST_CASE( encryptECIES_inputTooSmall ) {
 
     // Input smaller than 128 bytes
     bytes smallInput( 64, 0x42 );
-    auto res = exec( bytesConstRef( smallInput.data(), smallInput.size() ),
-        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( smallInput.data(), smallInput.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 2 (input too small)
     BOOST_REQUIRE( !res.first );
@@ -1917,8 +1944,7 @@ BOOST_AUTO_TEST_CASE( encryptECIES_inputNotAligned ) {
     // Build input that is not a multiple of 32 bytes (129 bytes)
     bytes input( 129, 0 );
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ),
-        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 3 (input not 32-byte aligned)
     BOOST_REQUIRE( !res.first );
@@ -1934,8 +1960,7 @@ BOOST_AUTO_TEST_CASE( encryptECIES_invalidABIOffset ) {
     bytes input( 128, 0 );
     input[31] = 64;  // Wrong offset (should be 96)
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ),
-        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 4 (invalid data offset)
     BOOST_REQUIRE( !res.first );
@@ -1949,11 +1974,10 @@ BOOST_AUTO_TEST_CASE( encryptECIES_dataLengthMismatch ) {
 
     // Build input where data_length claims more data than actually present
     bytes input( 128, 0 );
-    input[31] = 96;    // Correct offset
-    input[127] = 100;  // Claim 100 bytes of data, but none actually present
+    input[31] = 96;   // Correct offset
+    input[127] = 100; // Claim 100 bytes of data, but none actually present
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ),
-        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 5 (data length mismatch)
     BOOST_REQUIRE( !res.first );
@@ -1988,8 +2012,7 @@ BOOST_AUTO_TEST_CASE( encryptECIES_emptyData ) {
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
 
     // Call the precompiled contract
-    auto res = exec( bytesConstRef( input.data(), input.size() ),
-        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify success - empty data encryption should succeed
     BOOST_REQUIRE( res.first );
@@ -2018,8 +2041,7 @@ BOOST_AUTO_TEST_CASE( encryptECIES_trailingPaddingNotZeros ) {
     // trailing padding (129-191): should be zeros but we set one to non-zero
     input[150] = 0xFF;
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ),
-        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 6 (trailing padding not zeros)
     BOOST_REQUIRE( !res.first );
@@ -2043,7 +2065,7 @@ BOOST_AUTO_TEST_CASE( encryptECIES_invalidPublicKey ) {
     input.insert( input.end(), invalidPubKeyX.begin(), invalidPubKeyX.end() );
     input.insert( input.end(), invalidPubKeyY.begin(), invalidPubKeyY.end() );
     bytes lenBytes( 32, 0 );
-    lenBytes[31] = static_cast< uint8_t >( dataToEncrypt.size() );
+    lenBytes[31] = static_cast<uint8_t>( dataToEncrypt.size() );
     input.insert( input.end(), lenBytes.begin(), lenBytes.end() );
     input.insert( input.end(), dataToEncrypt.begin(), dataToEncrypt.end() );
     // Add ABI-compliant padding to 32-byte boundary
@@ -2051,8 +2073,7 @@ BOOST_AUTO_TEST_CASE( encryptECIES_invalidPublicKey ) {
     input.insert( input.end(), paddingNeeded, 0 );
 
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
-    auto res = exec( bytesConstRef( input.data(), input.size() ),
-        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 7 (invalid public key)
     BOOST_REQUIRE( !res.first );
@@ -2107,19 +2128,22 @@ BOOST_AUTO_TEST_CASE( biteTransactions ) {
     DecryptedRegularTxFields txFields{ messageToEncrypt, receiver.address().asArray() };
     std::shared_ptr< DecryptedRegularTxsMap > regularTxsMap =
         std::make_shared< DecryptedRegularTxsMap >(
-            DecryptedRegularTxsMap{ { 0, std::make_optional( txFields ) } } );
+            DecryptedRegularTxsMap{ { 0, std::make_optional( txFields ) } }
+        );
 
     DecryptedTransactions decryptedTxnDataMap(
 #ifdef BITE2
-        std::make_shared< DecryptedCATxsMap >(),
+                std::make_shared< DecryptedCATxsMap >(),
 #endif
-        regularTxsMap );
+                regularTxsMap
+                );
 
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( txEncrypted.toBytes() );
 
     // simulate new block
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns, decryptedTxnDataMap, utcTime(), 1U ) );
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( txns, decryptedTxnDataMap, utcTime(), 1U ) );
 
     BOOST_REQUIRE( client->transaction( encryptedTxHash ).toBytes() == txEncrypted.toBytes() );
     BOOST_REQUIRE(
@@ -2129,7 +2153,7 @@ BOOST_AUTO_TEST_CASE( biteTransactions ) {
 #endif
 
 #ifdef FAIR
-BOOST_AUTO_TEST_CASE( syncNodeGroupsUpdatesEpochIdWithoutRotation ) {
+BOOST_AUTO_TEST_CASE(syncNodeGroupsUpdatesEpochIdWithoutRotation) {
     SkaleHostFixture fixture( {}, true );
 
     auto& client = fixture.client;
@@ -2137,42 +2161,55 @@ BOOST_AUTO_TEST_CASE( syncNodeGroupsUpdatesEpochIdWithoutRotation ) {
 
     uint64_t currentTimestamp = static_cast< uint64_t >( utcTime() );
 
-    fixture.overwriteHistoricNodeGroups(
-        { { { GroupNode{ u256( 0 ), u256( 8 ),
-                "0xf925c203a30ec6cad5a263db3efab7ed4c1fd74c8688167e10a5a22e15ab5018d8553df0ac54ea"
-                "10"
-                "5a3d21845e5660bc3d4e7c82e7af1daa3baad393b1521467",
-                Address( "0x08151B8F80bfa7dEa760e461412AF24348224edf" ) } },
-              currentTimestamp,
-              { "15959969554621958245201075983340071881770733084910870228938077786643587385029",
-                  "7970122607051572307517094692346020360016825923464107614135327251488152616550",
-                  "3371162264373897025322009434717052197952692496405149486989861571246537813591",
-                  "1367862575151550440111063536979078771674468649843121371391160175980955991969"
-                  "3" } },
-            { { GroupNode{ u256( 0 ), u256( 8 ),
-                  "0xf925c203a30ec6cad5a263db3efab7ed4c1fd74c8688167e10a5a22e15ab5018d8553df0ac54ea"
-                  "10"
-                  "5a3d21845e5660bc3d4e7c82e7af1daa3baad393b1521467",
-                  Address( "0x08151B8F80bfa7dEa760e461412AF24348224edf" ) } },
-                std::numeric_limits< uint64_t >::max(),
-                { "3842742177969966091367527274107524613106077736353521259727282251005583743182",
-                    "3497912824016228906558906422247670474553186446469877598411863912329082553081",
-                    "8173996886448941320370434854289578123609627835954133538412363037981850950343",
-                    "2097937072068947534867058237502694910549764272699286393231551752400480478415"
-                    "5" } } } );
+    fixture.overwriteHistoricNodeGroups( {
+        {
+         {
+          GroupNode{ u256( 0 ), u256( 8 ),
+            "0xf925c203a30ec6cad5a263db3efab7ed4c1fd74c8688167e10a5a22e15ab5018d8553df0ac54ea"
+            "10"
+            "5a3d21845e5660bc3d4e7c82e7af1daa3baad393b1521467",
+            Address( "0x08151B8F80bfa7dEa760e461412AF24348224edf" )
+         }
+        },
+        currentTimestamp,
+        {
+            "15959969554621958245201075983340071881770733084910870228938077786643587385029",
+            "7970122607051572307517094692346020360016825923464107614135327251488152616550",
+            "3371162264373897025322009434717052197952692496405149486989861571246537813591",
+            "13678625751515504401110635369790787716744686498431213713911601759809559919693" }
+        },
+        {
+        {
+             GroupNode{ u256( 0 ), u256( 8 ),
+                 "0xf925c203a30ec6cad5a263db3efab7ed4c1fd74c8688167e10a5a22e15ab5018d8553df0ac54ea"
+                 "10"
+                 "5a3d21845e5660bc3d4e7c82e7af1daa3baad393b1521467",
+                 Address( "0x08151B8F80bfa7dEa760e461412AF24348224edf" )
+             }
+         },
+         std::numeric_limits<uint64_t>::max(), {
+                "3842742177969966091367527274107524613106077736353521259727282251005583743182",
+                "3497912824016228906558906422247670474553186446469877598411863912329082553081",
+                "8173996886448941320370434854289578123609627835954133538412363037981850950343",
+                "20979370720689475348670582375026949105497642726992863932315517524004804784155"
+        }
+        }
+    });
 
     BOOST_REQUIRE_EQUAL( client->getCurrentEpochId(), 0 );
 
     uint64_t blockTimestamp = currentTimestamp + 1;
     uint64_t blockId = client->number() + 1;
 
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( ConsensusExtFace::Transactions{},
+    BOOST_REQUIRE_NO_THROW( stub->createBlock(
+        ConsensusExtFace::Transactions{},
 #ifdef BITE
-        DecryptedTransactions{
+                                DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                        std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                        std::make_shared< DecryptedRegularTxsMap >()
+                                    },
 #endif
         blockTimestamp, blockId ) );
 
@@ -2227,15 +2264,17 @@ BOOST_FIXTURE_TEST_CASE(
     block1Txns.pushBackRegular( tx1.toBytes() );
 
     // simulate it coming from another node
-    BOOST_REQUIRE_NO_THROW( stub->createBlock( block1Txns,
+    BOOST_REQUIRE_NO_THROW(
+        stub->createBlock( block1Txns,
 #ifdef BITE
-        DecryptedTransactions{
+                           DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                   std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                   std::make_shared< DecryptedRegularTxsMap >()
+                               },
 #endif
-        utcTime(), 1U ) );
+            utcTime(), 1U ) );
 
 #ifndef FAIR
     REQUIRE_BLOCK_SIZE( 1, 1 );
@@ -2266,11 +2305,12 @@ BOOST_FIXTURE_TEST_CASE(
 
     BOOST_REQUIRE_NO_THROW( stub->createBlock( block2Txns,
 #ifdef BITE
-        DecryptedTransactions{
+                                               DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                                       std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                                       std::make_shared< DecryptedRegularTxsMap >()
+                                                   },
 #endif
         utcTime(), 2U ) );
 
@@ -2294,11 +2334,12 @@ BOOST_FIXTURE_TEST_CASE(
     // submit it for sure
     BOOST_REQUIRE_NO_THROW( stub->createBlock( block3Txns,
 #ifdef BITE
-        DecryptedTransactions{
+                                               DecryptedTransactions{
 #ifdef BITE2
-            std::make_shared< DecryptedCATxsMap >(),
+                                                       std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-            std::make_shared< DecryptedRegularTxsMap >() },
+                                                       std::make_shared< DecryptedRegularTxsMap >()
+                                                   },
 #endif
         utcTime(), 3U ) );
 }

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -8,16 +8,16 @@
 #include <libskale/ConsensusGasPricer.h>
 
 #ifdef BITE2
+#include <cryptopp/aes.h>
+#include <cryptopp/modes.h>
+#include <libconsensus/libBLS/threshold_encryption/TEDecryptSet.h>
 #include <libconsensus/libBLS/threshold_encryption/TEPrivateKey.h>
 #include <libconsensus/libBLS/threshold_encryption/TEPrivateKeyShare.h>
 #include <libconsensus/libBLS/threshold_encryption/TEPublicKeyShare.h>
-#include <libconsensus/libBLS/threshold_encryption/TEDecryptSet.h>
-#include <test/utils.h>
 #include <secp256k1.h>
 #include <secp256k1_ecdh.h>
 #include <secp256k1_sha256.h>
-#include <cryptopp/aes.h>
-#include <cryptopp/modes.h>
+#include <test/utils.h>
 #endif
 
 #include <test/tools/libtesteth/TestHelper.h>
@@ -42,9 +42,9 @@
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
 
-#include <memory>
 #include <atomic>
 #include <limits>
+#include <memory>
 
 using namespace dev;
 using namespace dev::eth;
@@ -63,7 +63,7 @@ public:
 
     void runCommitteeRotationForConsensus() override { ++rotationCallCount; }
 
-    std::atomic< uint32_t > rotationCallCount{0};
+    std::atomic< uint32_t > rotationCallCount{ 0 };
 };
 #endif
 
@@ -165,8 +165,8 @@ public:
 
 // TODO Do not copy&paste from JsonRpcFixture
 struct SkaleHostFixture : public TestOutputHelperFixture {
-    SkaleHostFixture( const std::map< std::string, std::string >& params =
-                          std::map< std::string, std::string >(),
+    SkaleHostFixture(
+        const std::map< std::string, std::string >& params = std::map< std::string, std::string >(),
         bool mockCommitteeRotation = false ) {
         dev::p2p::NetworkPreferences nprefs;
         libBLS::init();
@@ -230,7 +230,8 @@ struct SkaleHostFixture : public TestOutputHelperFixture {
         ConsensusTestStubFactory test_stub_factory;
 #ifdef FAIR
         if ( mockCommitteeRotation ) {
-            auto mockHost = std::make_shared< MockRotationSkaleHost >( *client, &test_stub_factory );
+            auto mockHost =
+                std::make_shared< MockRotationSkaleHost >( *client, &test_stub_factory );
             skaleHost = mockHost;
             mockRotationHost = mockHost;
         } else
@@ -389,17 +390,15 @@ BOOST_DATA_TEST_CASE(
 
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx.toBytes() );
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
 #ifdef BITE
-                           DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                   std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                   std::make_shared< DecryptedRegularTxsMap >()
-                               },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 1U ) );
+        utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
     REQUIRE_BLOCK_SIZE( 1, 1 );
@@ -446,15 +445,13 @@ BOOST_DATA_TEST_CASE(
     blockTxns.pushBackRegular( bad_tx1 );
     blockTxns.pushBackRegular( bad_tx2 );
 
-    BOOST_REQUIRE_NO_THROW( stub->createBlock(
-        blockTxns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( blockTxns,
 #ifdef BITE
-                                DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                        std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                        std::make_shared< DecryptedRegularTxsMap >()
-                                    },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
         utcTime(), 1U ) );
 
@@ -550,17 +547,15 @@ BOOST_DATA_TEST_CASE(
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW(
-            stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
 #ifdef BITE
-                               DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                       std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                       std::make_shared< DecryptedRegularTxsMap >()
-                                   },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 1U ) );
+        utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
 
@@ -628,12 +623,11 @@ BOOST_DATA_TEST_CASE(
 
     BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
 #ifdef BITE
-                                               DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                                       std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                                       std::make_shared< DecryptedRegularTxsMap >()
-                                                   },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
         utcTime(), 1U ) );
 
@@ -690,17 +684,15 @@ BOOST_DATA_TEST_CASE(
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
 #ifdef BITE
-                           DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                   std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                   std::make_shared< DecryptedRegularTxsMap >()
-                               },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 1U ) );
+        utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
 
@@ -770,17 +762,15 @@ BOOST_DATA_TEST_CASE(
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
 #ifdef BITE
-                           DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                   std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                   std::make_shared< DecryptedRegularTxsMap >()
-                               },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 1U ) );
+        utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
     REQUIRE_BLOCK_SIZE( 1, 1 );
@@ -827,17 +817,15 @@ BOOST_DATA_TEST_CASE(
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
 #ifdef BITE
-                           DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                   std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                   std::make_shared< DecryptedRegularTxsMap >()
-                               },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 1U ) );
+        utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
 
@@ -885,17 +873,15 @@ BOOST_DATA_TEST_CASE(
     block1Txns.pushBackRegular( tx1.toBytes() );
 
     // create 1 txns in 1 block
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( block1Txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( block1Txns,
 #ifdef BITE
-                           DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                   std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                   std::make_shared< DecryptedRegularTxsMap >()
-                               },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 1U ) );
+        utcTime(), 1U ) );
 
     // now our test txn
     json["value"] = jsToDecimal( toJS( 9000 * dev::eth::szabo ) );
@@ -913,17 +899,15 @@ BOOST_DATA_TEST_CASE(
     ConsensusExtFace::Transactions block2Txns;
     block2Txns.pushBackRegular( tx2.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( block2Txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( block2Txns,
 #ifdef BITE
-                           DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                   std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                   std::make_shared< DecryptedRegularTxsMap >()
-                               },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 2U ) );
+        utcTime(), 2U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
 
@@ -982,17 +966,15 @@ BOOST_DATA_TEST_CASE(
     ConsensusExtFace::Transactions block1Txns;
     block1Txns.pushBackRegular( tx.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( block1Txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( block1Txns,
 #ifdef BITE
-                           DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                   std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                   std::make_shared< DecryptedRegularTxsMap >()
-                               },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 1U ) );
+        utcTime(), 1U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
 
@@ -1025,12 +1007,11 @@ BOOST_DATA_TEST_CASE(
 
     stub->createBlock( block2Txns,
 #ifdef BITE
-                       DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                               std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                               std::make_shared< DecryptedRegularTxsMap >()
-                           },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
         utcTime(), 2U );
 
@@ -1092,17 +1073,15 @@ BOOST_DATA_TEST_CASE(
     txns.pushBackRegular( tx1.toBytes() );
     txns.pushBackRegular( tx2.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
 #ifdef BITE
-                           DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                   std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                   std::make_shared< DecryptedRegularTxsMap >()
-                               },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 1U ) );
+        utcTime(), 1U ) );
     BOOST_REQUIRE_EQUAL( client->number(), 1 );
 
     REQUIRE_BLOCK_INCREASE( 1 );
@@ -1227,12 +1206,11 @@ BOOST_AUTO_TEST_CASE( transactionDropReceive
 
     BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
 #ifdef BITE
-                                               DecryptedTransactions{
-        #ifdef BITE2
-                                                       std::make_shared< DecryptedCATxsMap >(),
-        #endif  // BITE2
-                                                       std::make_shared< DecryptedRegularTxsMap >()
-                                                   },
+        DecryptedTransactions{
+#ifdef BITE2
+            std::make_shared< DecryptedCATxsMap >(),
+#endif  // BITE2
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
         utcTime(), 1U ) );
     stub->setPriceForBlockId( 1, 1000 );
@@ -1297,17 +1275,15 @@ BOOST_AUTO_TEST_CASE(
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx2.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
 #ifdef BITE
-                           DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                   std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                   std::make_shared< DecryptedRegularTxsMap >()
-                               },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 1U ) );
+        utcTime(), 1U ) );
     stub->setPriceForBlockId( 1, 1000 );
 
     REQUIRE_BLOCK_INCREASE( 1 );
@@ -1373,17 +1349,15 @@ BOOST_AUTO_TEST_CASE( transactionDropByGasPrice
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx2.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
 #ifdef BITE
-                           DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                   std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                   std::make_shared< DecryptedRegularTxsMap >()
-                               },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 1U, 1000 ) );
+        utcTime(), 1U, 1000 ) );
     stub->setPriceForBlockId( 1, 1100 );
 
     REQUIRE_BLOCK_INCREASE( 1 );
@@ -1458,17 +1432,15 @@ BOOST_AUTO_TEST_CASE( transactionDropByGasPriceReceive
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( tx2.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
 #ifdef BITE
-                           DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                   std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                   std::make_shared< DecryptedRegularTxsMap >()
-                               },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 1U, 1000 ) );
+        utcTime(), 1U, 1000 ) );
     stub->setPriceForBlockId( 1, 1100 );
 
     REQUIRE_BLOCK_INCREASE( 1 );
@@ -1517,17 +1489,15 @@ BOOST_AUTO_TEST_CASE( transactionRace
     txns.pushBackRegular( tx.toBytes() );
 
     // 2 get it from consensus
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns,
 #ifdef BITE
-                           DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                   std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                   std::make_shared< DecryptedRegularTxsMap >()
-                               },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 1U ) );
+        utcTime(), 1U ) );
     stub->setPriceForBlockId( 1, 1000 );
 
     REQUIRE_BLOCK_INCREASE( 1 );
@@ -1576,17 +1546,15 @@ BOOST_AUTO_TEST_CASE( partialCatchUp
     block1txns.pushBackRegular( tx1.toBytes() );
 
     // create 1 txns in 1 block
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( block1txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( block1txns,
 #ifdef BITE
-                           DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                   std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                   std::make_shared< DecryptedRegularTxsMap >()
-                               },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 1U ) );
+        utcTime(), 1U ) );
 
     // now 2 txns
     json["value"] = jsToDecimal( toJS( 9000 * dev::eth::szabo ) );
@@ -1607,17 +1575,15 @@ BOOST_AUTO_TEST_CASE( partialCatchUp
     block2Txns.pushBackRegular( tx1.toBytes() );
     block2Txns.pushBackRegular( tx2.toBytes() );
 
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( block2Txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( block2Txns,
 #ifdef BITE
-                           DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                   std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                   std::make_shared< DecryptedRegularTxsMap >()
-                               },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 2U ) );
+        utcTime(), 2U ) );
 
     REQUIRE_BLOCK_INCREASE( 1 );
 #ifndef FAIR
@@ -1638,11 +1604,9 @@ BOOST_AUTO_TEST_CASE( getBlockRandom ) {
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "getBlockRandom" );
     auto res = exec( bytesConstRef(), { 1,
 #ifdef BITE2
-                                        { 0 },
-                                        1,
-                                        dev::ZeroAddress,
+                                          { 0 }, 1, dev::ZeroAddress,
 #endif
-                                        true } );
+                                          true } );
     u256 blockRandom = skaleHost->getBlockRandom( 0, false );
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( res.second == toBigEndian( static_cast< u256 >( blockRandom ) ) );
@@ -1656,11 +1620,9 @@ BOOST_AUTO_TEST_CASE( getCurrentBLSPublicKey ) {
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "getIMABLSPublicKey" );
     auto res = exec( bytesConstRef(), { 1,
 #ifdef BITE2
-                                        { -1 },
-                                        0,
-                                        dev::ZeroAddress,
+                                          { -1 }, 0, dev::ZeroAddress,
 #endif
-                                        true } );
+                                          true } );
     std::array< std::string, 4 > imaBLSPublicKey = skaleHost->getCurrentBLSPublicKey();
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( res.second == toBigEndian( dev::u256( imaBLSPublicKey[0] ) ) +
@@ -1675,10 +1637,11 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
     SkaleHostFixture fixture;
 
     // TE helper from libBLS
-    auto keys = generateKeys(1, 1);
+    auto keys = generateKeys( 1, 1 );
 
     // set test key
-    fixture.setBlsPublicKey(keys.commonPublic.getPublicKeyRaw().toStringArray(libBLS::Base::DEC));
+    fixture.setBlsPublicKey(
+        keys.commonPublic.getPublicKeyRaw().toStringArray( libBLS::Base::DEC ) );
 
     // Get the executor for encryptTE
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
@@ -1691,23 +1654,19 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
     dev::Address testScAddress = dev::Address( "0x1234567890123456789012345678901234567890" );
     bytes scAddressBytes = testScAddress.asBytes();
 
-    // Build ABI-encoded input: abi.encode(address scAddress, bytes data)
-    // Format: [scAddress(20 bytes, left-padded to 32)] [offset_to_data(32)] [data_length(32)] [data(N)]
+    // Build ABI-encoded input: abi.encode(bytes data)
+    // Format: [offset_to_data(32)] [data_length(32)] [data(N)]
+    // Minimum: 32 (offset) + 32 (length) = 64 bytes
     bytes input;
 
-    // SC address (20 bytes, left-padded to 32)
-    bytes addressPadding( 12, 0 );  // 12 bytes of zero padding
-    input.insert( input.end(), addressPadding.begin(), addressPadding.end() );
-    input.insert( input.end(), scAddressBytes.begin(), scAddressBytes.end() );
-
-    // Offset to data = 64 (2 * 32, after address and offset fields)
+    // Offset to data = 32 (after offset field itself)
     bytes offsetData( 32, 0 );
-    offsetData[31] = 64;
+    offsetData[31] = 32;
     input.insert( input.end(), offsetData.begin(), offsetData.end() );
 
     // data length
     bytes dataLenBytes( 32, 0 );
-    dataLenBytes[31] = static_cast<uint8_t>( dataToEncrypt.size() );
+    dataLenBytes[31] = static_cast< uint8_t >( dataToEncrypt.size() );
     input.insert( input.end(), dataLenBytes.begin(), dataLenBytes.end() );
 
     // data (with ABI-compliant padding to 32-byte boundary)
@@ -1717,22 +1676,23 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
 
     // Call the precompiled contract
     auto res = exec( bytesConstRef( input.data(), input.size() ),
-        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+        PrecompiledCallContext( 1, 0, 0, testScAddress, true ) );
 
     // Verify success
     BOOST_REQUIRE( res.first );
     BOOST_REQUIRE( !res.second.empty() );
 
     // Parse output as Ciphertext and validate
-    libBLS::Ciphertext ciphertext = libBLS::Ciphertext::fromBytes( res.second, /* validate */ true );
+    libBLS::Ciphertext ciphertext =
+        libBLS::Ciphertext::fromBytes( res.second, /* validate */ true );
 
     // Validate the TE ciphertext with SC address as TE AAD
     std::vector< uint8_t > scAddressVec( scAddressBytes.begin(), scAddressBytes.end() );
-    BOOST_REQUIRE_NO_THROW(
-        libBLS::ThresholdEncryption::validateEncryption( ciphertext.getTargetKey(), &scAddressVec ) );
+    BOOST_REQUIRE_NO_THROW( libBLS::ThresholdEncryption::validateEncryption(
+        ciphertext.getTargetKey(), &scAddressVec ) );
 
     // decrypt & check if decrypted = original
-    
+
     // 1. Create a decryption share from the single private key share
     libBLS::TEDecryptionShare share = libBLS::ThresholdEncryption::partialDecrypt(
         ciphertext.getTargetKey(), keys.secretKeys[0] );
@@ -1740,13 +1700,13 @@ BOOST_AUTO_TEST_CASE( encryptTE_success ) {
     libBLS::TEDecryptSet decryptSet( 1, 1 );  // t=1, n=1
     decryptSet.addDecryptShare( share );
     // 3. Combine shares → AES key
-    libBLS::AES256Key aesKey = libBLS::ThresholdEncryption::combineShares( 
-        ciphertext.getTargetKey(), decryptSet );
+    libBLS::AES256Key aesKey =
+        libBLS::ThresholdEncryption::combineShares( ciphertext.getTargetKey(), decryptSet );
     // 4. Decrypt using AES key (no AES AAD - we use TE AAD for validation instead)
-    std::vector< uint8_t > decryptedMessage = 
+    std::vector< uint8_t > decryptedMessage =
         libBLS::ThresholdEncryption::decrypt( ciphertext, aesKey );
     // 5. Verify original message matches
-    BOOST_REQUIRE( decryptedMessage == dataToEncrypt );    
+    BOOST_REQUIRE( decryptedMessage == dataToEncrypt );
 }
 
 BOOST_AUTO_TEST_CASE( encryptTE_inputTooLarge ) {
@@ -1769,8 +1729,8 @@ BOOST_AUTO_TEST_CASE( encryptTE_inputTooSmall ) {
 
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
 
-    // Call with input smaller than minimum (96 bytes for ABI format)
-    bytes smallInput( 64, 0x42 );
+    // Call with input smaller than minimum (64 bytes for ABI format)
+    bytes smallInput( 63, 0x42 );
     auto res = exec( bytesConstRef( smallInput.data(), smallInput.size() ),
         PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
@@ -1784,43 +1744,29 @@ BOOST_AUTO_TEST_CASE( encryptTE_inputNotAligned ) {
 
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
 
-    // Build input that is not a multiple of 32 bytes (97 bytes)
-    bytes input( 97, 0 );
+    // Build input that is not a multiple of 32 bytes (65 bytes)
+    bytes input( 65, 0 );
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 3 (input not 32-byte aligned)
     BOOST_REQUIRE( !res.first );
     BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 3 ) ) );
 }
 
-BOOST_AUTO_TEST_CASE( encryptTE_addressPaddingNotZeros ) {
-    SkaleHostFixture fixture;
-
-    PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
-
-    // Build input where the first 12 bytes (address padding) are not zeros
-    bytes input( 96, 0 );
-    input[0] = 0xFF;  // Non-zero byte in address padding
-    input[63] = 64;   // Correct data offset
-
-    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
-
-    // Verify failure with error code 4 (address padding not zeros)
-    BOOST_REQUIRE( !res.first );
-    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 4 ) ) );
-}
 
 BOOST_AUTO_TEST_CASE( encryptTE_invalidABIEncoding ) {
     SkaleHostFixture fixture;
 
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
 
-    // Build input with wrong data offset (at position 32, should be 64, we set 32)
-    bytes input( 96, 0 );
-    input[63] = 32;  // Wrong data offset at position 32 (should be 64)
+    // Build input with wrong data offset (at position 0, should be 32, we set 64)
+    bytes input( 64, 0 );
+    input[31] = 64;  // Wrong data offset at position 32 (should be 32)
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 5 (invalid data offset)
     BOOST_REQUIRE( !res.first );
@@ -1833,17 +1779,15 @@ BOOST_AUTO_TEST_CASE( encryptTE_dataLengthMismatch ) {
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
 
     // Build valid ABI structure but claim more data than available
-    bytes input( 128, 0 );
-    // address padding (0-11): zeros
-    // address (12-31): some address
-    input[20] = 0x12;
-    // offset (32-63): 64
-    input[63] = 64;
-    // data_length (64-95): claim 100 bytes, but only 32 bytes total remain
-    input[95] = 100;
-    // actual data (96-127): only 32 bytes of zeros
+    bytes input( 96, 0 );
+    // offset (0-31): 32
+    input[31] = 32;
+    // data_length (32-63): claim 100 bytes, but only 32 bytes total remain
+    input[63] = 100;
+    // actual data (64-95): only 32 bytes of zeros
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 6 (data length mismatch)
     BOOST_REQUIRE( !res.first );
@@ -1856,20 +1800,18 @@ BOOST_AUTO_TEST_CASE( encryptTE_trailingPaddingNotZeros ) {
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptTE" );
 
     // Build valid ABI structure with 1 byte of data, but non-zero trailing padding
-    bytes input( 128, 0 );
-    // address padding (0-11): zeros
-    // address (12-31): some address
-    input[20] = 0x12;
-    // offset (32-63): 64
-    input[63] = 64;
-    // data_length (64-95): 1 byte
-    input[95] = 1;
-    // actual data (96): one byte of data
-    input[96] = 0xAB;
-    // trailing padding (97-127): should be zeros but we set one to non-zero
-    input[100] = 0xFF;
+    bytes input( 96, 0 );
+    // offset (0-31): 32
+    input[31] = 32;
+    // data_length (32-63): 1 byte
+    input[63] = 1;
+    // actual data (64): one byte of data
+    input[64] = 0xAB;
+    // trailing padding (65-95): should be zeros but we set one to non-zero
+    input[95] = 0xFF;
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 7 (trailing padding not zeros)
     BOOST_REQUIRE( !res.first );
@@ -1903,7 +1845,7 @@ BOOST_AUTO_TEST_CASE( encryptECIES_success ) {
     input.insert( input.end(), pubKeyY.begin(), pubKeyY.end() );
     // Data length (32 bytes)
     bytes lenBytes( 32, 0 );
-    lenBytes[31] = static_cast<uint8_t>( dataToEncrypt.size() );
+    lenBytes[31] = static_cast< uint8_t >( dataToEncrypt.size() );
     input.insert( input.end(), lenBytes.begin(), lenBytes.end() );
     // Data (with ABI-compliant padding to 32-byte boundary)
     input.insert( input.end(), dataToEncrypt.begin(), dataToEncrypt.end() );
@@ -1914,7 +1856,8 @@ BOOST_AUTO_TEST_CASE( encryptECIES_success ) {
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
 
     // Call the precompiled contract
-    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify success
     BOOST_REQUIRE( res.first );
@@ -1943,7 +1886,8 @@ BOOST_AUTO_TEST_CASE( encryptECIES_inputTooLarge ) {
 
     // Input larger than 64KB
     bytes largeInput( 65 * 1024, 0x42 );
-    auto res = exec( bytesConstRef( largeInput.data(), largeInput.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( largeInput.data(), largeInput.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 1 (input too large)
     BOOST_REQUIRE( !res.first );
@@ -1957,7 +1901,8 @@ BOOST_AUTO_TEST_CASE( encryptECIES_inputTooSmall ) {
 
     // Input smaller than 128 bytes
     bytes smallInput( 64, 0x42 );
-    auto res = exec( bytesConstRef( smallInput.data(), smallInput.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( smallInput.data(), smallInput.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 2 (input too small)
     BOOST_REQUIRE( !res.first );
@@ -1972,7 +1917,8 @@ BOOST_AUTO_TEST_CASE( encryptECIES_inputNotAligned ) {
     // Build input that is not a multiple of 32 bytes (129 bytes)
     bytes input( 129, 0 );
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 3 (input not 32-byte aligned)
     BOOST_REQUIRE( !res.first );
@@ -1988,7 +1934,8 @@ BOOST_AUTO_TEST_CASE( encryptECIES_invalidABIOffset ) {
     bytes input( 128, 0 );
     input[31] = 64;  // Wrong offset (should be 96)
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 4 (invalid data offset)
     BOOST_REQUIRE( !res.first );
@@ -2002,10 +1949,11 @@ BOOST_AUTO_TEST_CASE( encryptECIES_dataLengthMismatch ) {
 
     // Build input where data_length claims more data than actually present
     bytes input( 128, 0 );
-    input[31] = 96;   // Correct offset
-    input[127] = 100; // Claim 100 bytes of data, but none actually present
+    input[31] = 96;    // Correct offset
+    input[127] = 100;  // Claim 100 bytes of data, but none actually present
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 5 (data length mismatch)
     BOOST_REQUIRE( !res.first );
@@ -2040,7 +1988,8 @@ BOOST_AUTO_TEST_CASE( encryptECIES_emptyData ) {
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
 
     // Call the precompiled contract
-    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify success - empty data encryption should succeed
     BOOST_REQUIRE( res.first );
@@ -2069,7 +2018,8 @@ BOOST_AUTO_TEST_CASE( encryptECIES_trailingPaddingNotZeros ) {
     // trailing padding (129-191): should be zeros but we set one to non-zero
     input[150] = 0xFF;
 
-    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 6 (trailing padding not zeros)
     BOOST_REQUIRE( !res.first );
@@ -2093,7 +2043,7 @@ BOOST_AUTO_TEST_CASE( encryptECIES_invalidPublicKey ) {
     input.insert( input.end(), invalidPubKeyX.begin(), invalidPubKeyX.end() );
     input.insert( input.end(), invalidPubKeyY.begin(), invalidPubKeyY.end() );
     bytes lenBytes( 32, 0 );
-    lenBytes[31] = static_cast<uint8_t>( dataToEncrypt.size() );
+    lenBytes[31] = static_cast< uint8_t >( dataToEncrypt.size() );
     input.insert( input.end(), lenBytes.begin(), lenBytes.end() );
     input.insert( input.end(), dataToEncrypt.begin(), dataToEncrypt.end() );
     // Add ABI-compliant padding to 32-byte boundary
@@ -2101,7 +2051,8 @@ BOOST_AUTO_TEST_CASE( encryptECIES_invalidPublicKey ) {
     input.insert( input.end(), paddingNeeded, 0 );
 
     PrecompiledExecutor exec = PrecompiledRegistrar::executor( "encryptECIES" );
-    auto res = exec( bytesConstRef( input.data(), input.size() ), PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
+    auto res = exec( bytesConstRef( input.data(), input.size() ),
+        PrecompiledCallContext( 1, 0, 0, dev::ZeroAddress, true ) );
 
     // Verify failure with error code 7 (invalid public key)
     BOOST_REQUIRE( !res.first );
@@ -2156,22 +2107,19 @@ BOOST_AUTO_TEST_CASE( biteTransactions ) {
     DecryptedRegularTxFields txFields{ messageToEncrypt, receiver.address().asArray() };
     std::shared_ptr< DecryptedRegularTxsMap > regularTxsMap =
         std::make_shared< DecryptedRegularTxsMap >(
-            DecryptedRegularTxsMap{ { 0, std::make_optional( txFields ) } }
-        );
+            DecryptedRegularTxsMap{ { 0, std::make_optional( txFields ) } } );
 
     DecryptedTransactions decryptedTxnDataMap(
 #ifdef BITE2
-                std::make_shared< DecryptedCATxsMap >(),
+        std::make_shared< DecryptedCATxsMap >(),
 #endif
-                regularTxsMap
-                );
+        regularTxsMap );
 
     ConsensusExtFace::Transactions txns;
     txns.pushBackRegular( txEncrypted.toBytes() );
 
     // simulate new block
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( txns, decryptedTxnDataMap, utcTime(), 1U ) );
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( txns, decryptedTxnDataMap, utcTime(), 1U ) );
 
     BOOST_REQUIRE( client->transaction( encryptedTxHash ).toBytes() == txEncrypted.toBytes() );
     BOOST_REQUIRE(
@@ -2181,7 +2129,7 @@ BOOST_AUTO_TEST_CASE( biteTransactions ) {
 #endif
 
 #ifdef FAIR
-BOOST_AUTO_TEST_CASE(syncNodeGroupsUpdatesEpochIdWithoutRotation) {
+BOOST_AUTO_TEST_CASE( syncNodeGroupsUpdatesEpochIdWithoutRotation ) {
     SkaleHostFixture fixture( {}, true );
 
     auto& client = fixture.client;
@@ -2189,55 +2137,42 @@ BOOST_AUTO_TEST_CASE(syncNodeGroupsUpdatesEpochIdWithoutRotation) {
 
     uint64_t currentTimestamp = static_cast< uint64_t >( utcTime() );
 
-    fixture.overwriteHistoricNodeGroups( {
-        {
-         {
-          GroupNode{ u256( 0 ), u256( 8 ),
-            "0xf925c203a30ec6cad5a263db3efab7ed4c1fd74c8688167e10a5a22e15ab5018d8553df0ac54ea"
-            "10"
-            "5a3d21845e5660bc3d4e7c82e7af1daa3baad393b1521467",
-            Address( "0x08151B8F80bfa7dEa760e461412AF24348224edf" )
-         }
-        },
-        currentTimestamp,
-        {
-            "15959969554621958245201075983340071881770733084910870228938077786643587385029",
-            "7970122607051572307517094692346020360016825923464107614135327251488152616550",
-            "3371162264373897025322009434717052197952692496405149486989861571246537813591",
-            "13678625751515504401110635369790787716744686498431213713911601759809559919693" }
-        },
-        {
-        {
-             GroupNode{ u256( 0 ), u256( 8 ),
-                 "0xf925c203a30ec6cad5a263db3efab7ed4c1fd74c8688167e10a5a22e15ab5018d8553df0ac54ea"
-                 "10"
-                 "5a3d21845e5660bc3d4e7c82e7af1daa3baad393b1521467",
-                 Address( "0x08151B8F80bfa7dEa760e461412AF24348224edf" )
-             }
-         },
-         std::numeric_limits<uint64_t>::max(), {
-                "3842742177969966091367527274107524613106077736353521259727282251005583743182",
-                "3497912824016228906558906422247670474553186446469877598411863912329082553081",
-                "8173996886448941320370434854289578123609627835954133538412363037981850950343",
-                "20979370720689475348670582375026949105497642726992863932315517524004804784155"
-        }
-        }
-    });
+    fixture.overwriteHistoricNodeGroups(
+        { { { GroupNode{ u256( 0 ), u256( 8 ),
+                "0xf925c203a30ec6cad5a263db3efab7ed4c1fd74c8688167e10a5a22e15ab5018d8553df0ac54ea"
+                "10"
+                "5a3d21845e5660bc3d4e7c82e7af1daa3baad393b1521467",
+                Address( "0x08151B8F80bfa7dEa760e461412AF24348224edf" ) } },
+              currentTimestamp,
+              { "15959969554621958245201075983340071881770733084910870228938077786643587385029",
+                  "7970122607051572307517094692346020360016825923464107614135327251488152616550",
+                  "3371162264373897025322009434717052197952692496405149486989861571246537813591",
+                  "1367862575151550440111063536979078771674468649843121371391160175980955991969"
+                  "3" } },
+            { { GroupNode{ u256( 0 ), u256( 8 ),
+                  "0xf925c203a30ec6cad5a263db3efab7ed4c1fd74c8688167e10a5a22e15ab5018d8553df0ac54ea"
+                  "10"
+                  "5a3d21845e5660bc3d4e7c82e7af1daa3baad393b1521467",
+                  Address( "0x08151B8F80bfa7dEa760e461412AF24348224edf" ) } },
+                std::numeric_limits< uint64_t >::max(),
+                { "3842742177969966091367527274107524613106077736353521259727282251005583743182",
+                    "3497912824016228906558906422247670474553186446469877598411863912329082553081",
+                    "8173996886448941320370434854289578123609627835954133538412363037981850950343",
+                    "2097937072068947534867058237502694910549764272699286393231551752400480478415"
+                    "5" } } } );
 
     BOOST_REQUIRE_EQUAL( client->getCurrentEpochId(), 0 );
 
     uint64_t blockTimestamp = currentTimestamp + 1;
     uint64_t blockId = client->number() + 1;
 
-    BOOST_REQUIRE_NO_THROW( stub->createBlock(
-        ConsensusExtFace::Transactions{},
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( ConsensusExtFace::Transactions{},
 #ifdef BITE
-                                DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                        std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                        std::make_shared< DecryptedRegularTxsMap >()
-                                    },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
         blockTimestamp, blockId ) );
 
@@ -2292,17 +2227,15 @@ BOOST_FIXTURE_TEST_CASE(
     block1Txns.pushBackRegular( tx1.toBytes() );
 
     // simulate it coming from another node
-    BOOST_REQUIRE_NO_THROW(
-        stub->createBlock( block1Txns,
+    BOOST_REQUIRE_NO_THROW( stub->createBlock( block1Txns,
 #ifdef BITE
-                           DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                   std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                   std::make_shared< DecryptedRegularTxsMap >()
-                               },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
-            utcTime(), 1U ) );
+        utcTime(), 1U ) );
 
 #ifndef FAIR
     REQUIRE_BLOCK_SIZE( 1, 1 );
@@ -2333,12 +2266,11 @@ BOOST_FIXTURE_TEST_CASE(
 
     BOOST_REQUIRE_NO_THROW( stub->createBlock( block2Txns,
 #ifdef BITE
-                                               DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                                       std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                                       std::make_shared< DecryptedRegularTxsMap >()
-                                                   },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
         utcTime(), 2U ) );
 
@@ -2362,12 +2294,11 @@ BOOST_FIXTURE_TEST_CASE(
     // submit it for sure
     BOOST_REQUIRE_NO_THROW( stub->createBlock( block3Txns,
 #ifdef BITE
-                                               DecryptedTransactions{
+        DecryptedTransactions{
 #ifdef BITE2
-                                                       std::make_shared< DecryptedCATxsMap >(),
+            std::make_shared< DecryptedCATxsMap >(),
 #endif  // BITE2
-                                                       std::make_shared< DecryptedRegularTxsMap >()
-                                                   },
+            std::make_shared< DecryptedRegularTxsMap >() },
 #endif
         utcTime(), 3U ) );
 }


### PR DESCRIPTION
## Description
This PR introduces two new precompiled contracts to `skaled` to support encryption operations, along with necessary cryptographic primitives and comprehensive tests.

## Key Changes

### New Precompiled Contracts
* **`encryptTE` (Threshold Encryption):** 
    - Implements threshold encryption using the network's BLS public key. Features deterministic seeding via block randomness and full ABI-encoded input validation.
    - Current version using block random is insecure
* **`encryptECIES`:** 
    - Implements ECIES encryption (using AES-256-CBC with PKCS7 padding) to facilitate secure message passing.
    
    Follows the provided specification [here](https://forum.skale.network/t/metamask-friendly-machinepay-balance-encryption/756#h-3-mathematical-model-2)

### Crypto Utilities (`libdevcrypto`)
* Added `encryptECIES_CBC` / `decryptECIES_CBC` helper functions.
* Added `compressPublicKey` / `decompressPublicKey` and validation utilities for secp256k1 keys.

### Tests
* Added extensive unit tests (`SkaleHost.cpp`) for both precompiles, covering:
    * Success scenarios.
    * Input validation (size, alignment, padding).
    * Edge cases (e.g., empty data).
    
Fixes #2324