### PR TITLE
#2229 fix heap use after free on exit

### DIFF
--- a/libskale/httpserveroverride.cpp
+++ b/libskale/httpserveroverride.cpp
@@ -1563,23 +1563,6 @@ SkaleServerOverride::SkaleServerOverride(
         dev::Logger logger{ createLogger( dev::VerbosityError, "SkaleServerOverride" ) };
         BOOST_LOG( logger ) << "CRITICAL ERROR: Proxygen abort handler called.";
     } );
-
-    {  // block
-        std::function< void( const unsigned& iw, const dev::eth::Block& block ) >
-            fnOnSunscriptionEvent =
-                [this]( const unsigned& /*iw*/, const dev::eth::Block& block ) -> void {
-            dev::h256 h = block.info().hash();
-            dev::eth::TransactionHashes arrTxHashes = ethereum()->transactionHashes( h );
-        };
-        iwBlockStats_ = ethereum()->installNewBlockWatch( fnOnSunscriptionEvent );
-    }
-    {
-        std::function< void( const unsigned& iw, const dev::eth::Transaction& tx ) >
-            fnOnSunscriptionEvent =
-                [this]( const unsigned& /*iw*/, const dev::eth::Transaction& /*tx*/ ) -> void {};
-        iwPendingTransactionStats_ =
-            ethereum()->installNewPendingTransactionWatch( fnOnSunscriptionEvent );
-    }
 }
 
 SkaleServerOverride::~SkaleServerOverride() {}

--- a/libskale/httpserveroverride.h
+++ b/libskale/httpserveroverride.h
@@ -601,7 +601,6 @@ protected:
     void eth_getFilterLogs( const string& strOrigin, const rapidjson::Document& joRequest,
         rapidjson::Document& joResponse );
 
-    unsigned iwBlockStats_ = unsigned( -1 ), iwPendingTransactionStats_ = unsigned( -1 );
     mutex_type mtxStats_;
     nlohmann::json generateBlocksStats();
 


### PR DESCRIPTION
fixes #2229 
fix `heap-use-after-free` error

`SkaleServerOverride` installed callbacks to `Client` which were never used nor uninstalled, causing `heap-use-after-free` after `SkaleServerOverride` is destroyed but before `Client` is destroyed.
there are no other watches in `SkaleServerOverride`
watches in `SkaleWSPeer` are proparly uninstalled in `~SkaleWSPeer`

verified locally by running skaled built wth `-fsanitize=address` 