### PR TITLE
IS-1321 Increase write buffer size (beta)

### DIFF
--- a/libskale/State.cpp
+++ b/libskale/State.cpp
@@ -266,8 +266,8 @@ skale::OverlayDB State::openDB(
 
 db::LevelDB::LevelDBOptions State::getLevelDBConfig() const {
     db::LevelDB::LevelDBOptions levelDbOptions;
-    levelDbOptions.dbOptions.write_buffer_size = 64 * 1024 * 1024;
-    levelDbOptions.dbOptions.max_file_size = 16 * 1024 * 1024;
+    levelDbOptions.dbOptions.write_buffer_size = 128 * 1024 * 1024;
+    levelDbOptions.dbOptions.max_file_size = 32 * 1024 * 1024;
     levelDbOptions.dbOptions.max_open_files = 2000;
     levelDbOptions.dbOptions.block_size = 32 * 1024;
     return levelDbOptions;


### PR DESCRIPTION
## Description

It seems that values that were changed in https://github.com/skalenetwork/skaled/pull/2329 are enough to solve the problem https://github.com/skalenetwork/internal-support/issues/1247, but not https://github.com/skalenetwork/internal-support/issues/1321.
With new `write_buffer_size` the later issue is hardly reproduced and only on relatively big amount of state with 1 hour snapshot  interval. 

## Tests

- Tested extensively on local network with up to 1.5BG of state. 

## Performance Impact

- Since with new configuration MemTable is growing higher memory consumption expected (additional ~64MB). 
- In additional noticed slightly longer start up time. 
- In general no noticeable performance decrease reported from QA team. 

## Note
- Since even go-ethereum migrated to pebble by default, probably we should prioritize migration to RocksDB or ther alternatives. 