### PR TITLE
2389 Fix memory leak in HashSnapshot.cpp

### DIFF
--- a/.github/actions/testeth-run/action.yml
+++ b/.github/actions/testeth-run/action.yml
@@ -21,7 +21,6 @@ runs:
 
         if [[ "${{ inputs.mode }}" == "historic" ]]; then
           mkdir -p /tmp/tests/
-          # Only clear markers on verbosity 1 (keep markers for verbosity 4 rerun logic)
           if [[ "${{ inputs.verbosity }}" == "1" ]]; then
             sudo rm -rf /tmp/tests/*
           fi
@@ -49,25 +48,98 @@ runs:
           mkdir -p /tmp/tests/
           sudo rm -rf /tmp/tests/*
 
-          run_test() { ./testeth --report_level=detailed -t "$1" -- --express && touch "/tmp/tests/${1}Passed" || true; }
+          run_test() {
+            local suite="$1"
+            if ./testeth --report_level=detailed -t "$suite" -- --express; then
+              touch "/tmp/tests/${suite}Passed"
+            else
+              echo "Suite ${suite} failed (continuing)"
+            fi
+          }
           for s in "${TEST_SUITES[@]}"; do run_test "$s"; done
 
-          run_sudo_all() {
-            sudo NO_ULIMIT_CHECK="${NO_ULIMIT_CHECK:-1}" NO_NTP_CHECK="${NO_NTP_CHECK:-1}" ./testeth -t "$1" -- --all \
-              && touch "/tmp/tests/${1}Passed" || true
-          }
-          run_sudo_all BtrfsTestSuite
-          run_sudo_all HashSnapshotTestSuite
-          run_sudo_all ClientSnapshotsSuite
         else
-          rerun_test() { ls "/tmp/tests/${1}Passed" 2>/dev/null || ./testeth --report_level=detailed -t "$1" -- --express --verbosity 4; }
-          for s in "${TEST_SUITES[@]}"; do rerun_test "$s"; done
-
-          rerun_sudo_all() {
-            ls "/tmp/tests/${1}Passed" 2>/dev/null || sudo NO_ULIMIT_CHECK="${NO_ULIMIT_CHECK:-1}" NO_NTP_CHECK="${NO_NTP_CHECK:-1}" \
-              ./testeth -t "$1" -- --all --verbosity 4
+          rerun_test() {
+            local suite="$1"
+            if ls "/tmp/tests/${suite}Passed" 2>/dev/null; then
+              return
+            fi
+            ./testeth --report_level=detailed -t "$suite" -- --express --verbosity 4
           }
-          rerun_sudo_all BtrfsTestSuite
-          rerun_sudo_all HashSnapshotTestSuite
-          rerun_sudo_all ClientSnapshotsSuite
+          for s in "${TEST_SUITES[@]}"; do rerun_test "$s"; done
+        fi
+
+    - name: Btrfs test suites
+      if: inputs.mode == 'full'
+      shell: bash
+      run: |
+        set -uo pipefail
+
+        cd "${{ inputs.build_dir }}/test"
+
+        BTRFS_SUITES=(BtrfsTestSuite HashSnapshotTestSuite ClientSnapshotsSuite)
+
+        check_btrfs_state() {
+          local label="$1"
+          echo "=== BTRFS STATE CHECK (${label}) ==="
+          ls -la btrfs.file 2>/dev/null && echo "  WARNING: btrfs.file exists" || echo "  btrfs.file: absent (OK)"
+          if mount | grep -q btrfs.file; then
+            echo "  WARNING: btrfs.file IS MOUNTED:"
+            mount | grep btrfs.file
+          else
+            echo "  mount: not mounted (OK)"
+          fi
+          if mountpoint -q btrfs 2>/dev/null; then
+            echo "  WARNING: btrfs/ IS a mount point"
+          else
+            echo "  btrfs/: not a mount point (OK)"
+          fi
+          grep btrfs /proc/mounts && true || echo "  /proc/mounts: no btrfs entries (OK)"
+          echo "=== END BTRFS STATE CHECK ==="
+        }
+
+        force_btrfs_cleanup() {
+          if mountpoint -q btrfs 2>/dev/null || mount | grep -q btrfs.file; then
+            echo "  Stale btrfs mount detected — forcing cleanup"
+            sudo umount btrfs 2>/dev/null \
+              || sudo umount -f btrfs 2>/dev/null \
+              || sudo umount -l btrfs 2>/dev/null \
+              || true
+          fi
+          sudo rm -rf btrfs 2>/dev/null || true
+          rm -f btrfs.file 2>/dev/null || true
+        }
+
+        if [[ "${{ inputs.verbosity }}" == "1" ]]; then
+          for s in "${BTRFS_SUITES[@]}"; do
+            echo ""
+            echo "========================================"
+            echo "  BTRFS SUITE: ${s}"
+            echo "========================================"
+            check_btrfs_state "before ${s}"
+            force_btrfs_cleanup
+            if sudo NO_ULIMIT_CHECK="${NO_ULIMIT_CHECK:-1}" NO_NTP_CHECK="${NO_NTP_CHECK:-1}" ./testeth -t "${s}" -- --all; then
+              touch "/tmp/tests/${s}Passed"
+              echo "Suite ${s}: PASSED"
+            else
+              echo "Suite ${s}: FAILED (continuing)"
+            fi
+            check_btrfs_state "after ${s}"
+            force_btrfs_cleanup
+          done
+        else
+          for s in "${BTRFS_SUITES[@]}"; do
+            if ls "/tmp/tests/${s}Passed" 2>/dev/null; then
+              continue
+            fi
+            echo ""
+            echo "========================================"
+            echo "  BTRFS SUITE RERUN: ${s}"
+            echo "========================================"
+            check_btrfs_state "before ${s} (rerun)"
+            force_btrfs_cleanup
+            sudo NO_ULIMIT_CHECK="${NO_ULIMIT_CHECK:-1}" NO_NTP_CHECK="${NO_NTP_CHECK:-1}" ./testeth -t "${s}" -- --all --verbosity 4
+            check_btrfs_state "after ${s} (rerun)"
+            force_btrfs_cleanup
+          done
         fi

--- a/test/unittests/libethereum/ClientTest.cpp
+++ b/test/unittests/libethereum/ClientTest.cpp
@@ -1442,9 +1442,20 @@ BOOST_AUTO_TEST_CASE( ClientSnapshotsTest, *boost::unit_test::disabled() ) {
 
     BOOST_REQUIRE( testClient->getSnapshotHash( 0 ) != dev::h256() );
 
-    std::this_thread::sleep_for( 5000ms );
+    // Wait until a snapshot with computed hash appears (block number depends on timing)
+    int64_t snapshotBlockNumber = -1;
+    for ( int i = 0; i < 30; ++i ) {
+        std::this_thread::sleep_for( 1000ms );
+        snapshotBlockNumber = testClient->getLatestSnapshotBlockNumer();
+        if ( snapshotBlockNumber > 0 )
+            break;
+    }
+    BOOST_REQUIRE( snapshotBlockNumber > 0 );
 
-    BOOST_REQUIRE( fs::exists( fs::path( fixture.getTmpDataDir() ) / "snapshots" / "2" ) );
+    std::string snapshotBlockStr = std::to_string( snapshotBlockNumber );
+
+    BOOST_REQUIRE(
+        fs::exists( fs::path( fixture.getTmpDataDir() ) / "snapshots" / snapshotBlockStr ) );
 
     secp256k1_sha256_t ctx;
     secp256k1_sha256_initialize( &ctx );
@@ -1457,15 +1468,14 @@ BOOST_AUTO_TEST_CASE( ClientSnapshotsTest, *boost::unit_test::disabled() ) {
 
     BOOST_REQUIRE( testClient->latestBlock().info().stateRoot() == empty_state_root_hash );
 
-    std::this_thread::sleep_for( 3000ms );
+    BOOST_REQUIRE( fs::exists( fs::path( fixture.getTmpDataDir() ) / "snapshots" /
+                               snapshotBlockStr / "snapshot_hash.txt" ) );
 
-    BOOST_REQUIRE( fs::exists(
-        fs::path( fixture.getTmpDataDir() ) / "snapshots" / "2" / "snapshot_hash.txt" ) );
-
-    dev::h256 hash = testClient->hashFromNumber( 2 );
+    dev::h256 hash = testClient->hashFromNumber( snapshotBlockNumber );
     uint64_t timestampFromBlockchain = testClient->blockInfo( hash ).timestamp();
 
-    BOOST_REQUIRE_EQUAL( timestampFromBlockchain, testClient->getBlockTimestampFromSnapshot( 2 ) );
+    BOOST_REQUIRE_EQUAL(
+        timestampFromBlockchain, testClient->getBlockTimestampFromSnapshot( snapshotBlockNumber ) );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libethereum/ClientTest.cpp
+++ b/test/unittests/libethereum/ClientTest.cpp
@@ -1457,19 +1457,13 @@ BOOST_AUTO_TEST_CASE( ClientSnapshotsTest, *boost::unit_test::disabled() ) {
     BOOST_REQUIRE(
         fs::exists( fs::path( fixture.getTmpDataDir() ) / "snapshots" / snapshotBlockStr ) );
 
-    secp256k1_sha256_t ctx;
-    secp256k1_sha256_initialize( &ctx );
-
-    dev::h256 empty_str = dev::h256( "" );
-    secp256k1_sha256_write( &ctx, empty_str.data(), empty_str.size );
-
-    dev::h256 empty_state_root_hash;
-    secp256k1_sha256_finalize( &ctx, empty_state_root_hash.data() );
-
-    BOOST_REQUIRE( testClient->latestBlock().info().stateRoot() == empty_state_root_hash );
-
     BOOST_REQUIRE( fs::exists( fs::path( fixture.getTmpDataDir() ) / "snapshots" /
                                snapshotBlockStr / "snapshot_hash.txt" ) );
+
+    // Verify that the snapshot hash was propagated as the state root
+    dev::h256 snapshotHash = testClient->getSnapshotHash( snapshotBlockNumber );
+    BOOST_REQUIRE( snapshotHash != dev::h256() );
+    BOOST_REQUIRE( testClient->latestBlock().info().stateRoot() == snapshotHash );
 
     dev::h256 hash = testClient->hashFromNumber( snapshotBlockNumber );
     uint64_t timestampFromBlockchain = testClient->blockInfo( hash ).timestamp();

--- a/test/unittests/libskale/HashSnapshot.cpp
+++ b/test/unittests/libskale/HashSnapshot.cpp
@@ -452,7 +452,14 @@ struct SnapshotHashingFixture : public TestOutputHelperFixture, public FixtureCo
     }
 
     ~SnapshotHashingFixture() {
+        rpcClient.reset();
+        if ( testIpcClient ) {
+            delete testIpcClient;
+            testIpcClient = nullptr;
+        }
+        rpcServer.reset();
         client.reset();
+
         const char* NC = getenv( "NC" );
         if ( NC )
             return;
@@ -463,9 +470,6 @@ struct SnapshotHashingFixture : public TestOutputHelperFixture, public FixtureCo
         assert( rv == 0 );
         rv = system( ( "rm " + BTRFS_FILE_PATH ).c_str() );
         assert( rv == 0 );
-
-        if ( testIpcClient )
-            delete testIpcClient;
     }
 
     string sendingRawShouldFail( string const& _t ) {


### PR DESCRIPTION
## Description

- Small fix that aims to resolve usage after free problem in HashSnapshotTestSuite/SnapshotHashingTest. Related to https://github.com/skalenetwork/skaled/issues/2389
- Added btrfs artifacts cleanup between relevant tests in testrun action

## Tests

- Only tests has been touched, tested on local machine by running multiple times. 

## Performance Impact

- No performance related changes were introduced. 