### PR TITLE
2394 Fix eth_call for contract deployment

### DIFF
--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -1244,8 +1244,9 @@ ExecutionResult Client::call( Address const& _from, u256 _value, Address _dest, 
     ExecutionResult ret;
     try {
         auto buildTransaction = [&]( u256 gasLimit, u256 gasPrice, u256 nonce ) {
-            Transaction t = _isCreation ? Transaction( _value, gasPrice, gasLimit, _data, nonce ) :
-                                         Transaction( _value, gasPrice, gasLimit, _dest, _data, nonce );
+            Transaction t = _isCreation ?
+                                Transaction( _value, gasPrice, gasLimit, _data, nonce ) :
+                                Transaction( _value, gasPrice, gasLimit, _dest, _data, nonce );
             t.forceSender( _from );
             t.forceChainId( chainParams().getChainId() );
 #ifndef FAIR

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -1240,9 +1240,19 @@ ExecutionResult Client::call( Address const& _from, u256 _value, Address _dest, 
 #ifdef HISTORIC_STATE
     BlockNumber _blockNumber,
 #endif
-    FudgeFactor _ff ) {
+    bool _isCreation, FudgeFactor _ff ) {
     ExecutionResult ret;
     try {
+        auto buildTransaction = [&]( u256 gasLimit, u256 gasPrice, u256 nonce ) {
+            Transaction t = _isCreation ? Transaction( _value, gasPrice, gasLimit, _data, nonce ) :
+                                         Transaction( _value, gasPrice, gasLimit, _dest, _data, nonce );
+            t.forceSender( _from );
+            t.forceChainId( chainParams().getChainId() );
+#ifndef FAIR
+            t.ignoreExternalGas();
+#endif
+            return t;
+        };
 #ifdef HISTORIC_STATE
 
         if ( _blockNumber < bc().number() ) {
@@ -1254,13 +1264,7 @@ ExecutionResult Client::call( Address const& _from, u256 _value, Address _dest, 
                 // limit of gas
                 u256 gasLimit = _gasLimit == Invalid256 ? historicBlock.gasLimit() : _gasLimit;
                 u256 gasPrice = _gasPrice == Invalid256 ? gasBidPrice() : _gasPrice;
-                Transaction t( _value, gasPrice, gasLimit, _dest, _data, nonce );
-                t.forceSender( _from );
-
-                t.forceChainId( chainParams().getChainId() );
-#ifndef FAIR
-                t.ignoreExternalGas();
-#endif
+                Transaction t = buildTransaction( gasLimit, gasPrice, nonce );
                 // if we are in a call, we add to the balance of the account
                 // value needed for the call to guaranteed pass
                 // geth does a similar thing, we need to check whether it is fully compatible with
@@ -1283,12 +1287,7 @@ ExecutionResult Client::call( Address const& _from, u256 _value, Address _dest, 
         // limit of gas
         u256 gasLimit = _gasLimit == Invalid256 ? temp.gasLimit() : _gasLimit;
         u256 gasPrice = _gasPrice == Invalid256 ? gasBidPrice() : _gasPrice;
-        Transaction t( _value, gasPrice, gasLimit, _dest, _data, nonce );
-        t.forceSender( _from );
-        t.forceChainId( chainParams().getChainId() );
-#ifndef FAIR
-        t.ignoreExternalGas();
-#endif
+        Transaction t = buildTransaction( gasLimit, gasPrice, nonce );
         if ( _ff == FudgeFactor::Lenient )
             temp.mutableState().addBalance( _from, ( u256 )( t.gas() * t.gasPrice() + t.value() ) );
         ret = temp.execute( bc().lastBlockHashes(), t, skale::Permanence::Reverted );

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -130,7 +130,7 @@ public:
 #ifdef HISTORIC_STATE
         BlockNumber _blockNumber,
 #endif
-        FudgeFactor _ff = FudgeFactor::Strict ) override;
+        bool _isCreation = false, FudgeFactor _ff = FudgeFactor::Strict ) override;
 
 #ifdef HISTORIC_STATE
     Json::Value traceCall( Address const& _from, u256 _value, Address _to, bytes const& _data,

--- a/libethereum/Interface.h
+++ b/libethereum/Interface.h
@@ -106,8 +106,7 @@ public:
 #ifdef HISTORIC_STATE
             _blockNumber,
 #endif
-            _isCreation,
-            _ff );
+            _isCreation, _ff );
     }
 
     /// Injects the RLP-encoded block given by the _rlp into the block queue directly.

--- a/libethereum/Interface.h
+++ b/libethereum/Interface.h
@@ -95,17 +95,18 @@ public:
 #ifdef HISTORIC_STATE
         BlockNumber _blockNumber,
 #endif
-        FudgeFactor _ff = FudgeFactor::Strict ) = 0;
+        bool _isCreation = false, FudgeFactor _ff = FudgeFactor::Strict ) = 0;
     ExecutionResult call( Secret const& _secret, u256 _value, Address _dest, bytes const& _data,
         u256 _gas, u256 _gasPrice,
 #ifdef HISTORIC_STATE
         BlockNumber _blockNumber,
 #endif
-        FudgeFactor _ff = FudgeFactor::Strict ) {
+        bool _isCreation = false, FudgeFactor _ff = FudgeFactor::Strict ) {
         return call( toAddress( _secret ), _value, _dest, _data, _gas, _gasPrice,
 #ifdef HISTORIC_STATE
             _blockNumber,
 #endif
+            _isCreation,
             _ff );
     }
 

--- a/libskale/httpserveroverride.cpp
+++ b/libskale/httpserveroverride.cpp
@@ -2663,7 +2663,7 @@ void SkaleServerOverride::informational_eth_getBalance( const json& joRequest, j
 #ifdef HISTORIC_STATE
                 bNumber,
 #endif
-                dev::eth::FudgeFactor::Lenient );
+                false, dev::eth::FudgeFactor::Lenient );
 
         string strRevertReason;
         if ( er.excepted == dev::eth::TransactionException::RevertInstruction ) {

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -480,7 +480,7 @@ string Eth::eth_call( TransactionSkeleton& t, string const&
 #ifdef HISTORIC_STATE
         bN,
 #endif
-        FudgeFactor::Lenient );
+        t.creation, FudgeFactor::Lenient );
 
     std::string strRevertReason;
     if ( er.excepted == dev::eth::TransactionException::RevertInstruction ) {

--- a/test/tools/libtestutils/FixedClient.h
+++ b/test/tools/libtestutils/FixedClient.h
@@ -75,7 +75,7 @@ public:
 #ifdef HISTORIC_STATE
                                   BlockNumber,
 #endif
-eth::FudgeFactor ) override {
+        bool, eth::FudgeFactor ) override {
         return {};
     };
     eth::TransactionSkeleton populateTransactionWithDefaults(

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -2036,6 +2036,61 @@ BOOST_AUTO_TEST_CASE( call_with_error ) {
     }
 }
 
+BOOST_AUTO_TEST_CASE( eth_call_create ) {
+    JsonRpcFixture fixture;
+    dev::eth::simulateMining( *( fixture.client ), 1 );
+
+    auto senderAddress = fixture.coinbase.address();
+
+    // contract test {
+    //   function f(uint a) returns(uint d) { return a * 7; }
+    // }
+    string compiled =
+        "6080604052348015600f57600080fd5b5060b98061001d6000396000f300"
+        "608060405260043610603f576000357c01000000000000000000000000"
+        "00000000000000000000000000000000900463ffffffff168063b3de64"
+        "8b146044575b600080fd5b3415604e57600080fd5b606a600480360381"
+        "019080803590602001909291905050506080565b604051808281526020"
+        "0191505060405180910390f35b60006007820290509190505600a16562"
+        "7a7a72305820f294e834212334e2978c6dd090355312a3f0f9476b8eb9"
+        "8fb480406fc2728a960029";
+
+    // eth_call with no "to" field triggers creation transaction
+    Json::Value callObject;
+    callObject["from"] = toJS( senderAddress );
+    callObject["data"] = "0x" + compiled;
+    callObject["gas"] = "1000000";
+    callObject["gasPrice"] = "0";
+
+    string callResult = fixture.rpcClient->eth_call( callObject, "latest" );
+    // creation via eth_call should return the runtime bytecode
+    BOOST_REQUIRE( callResult.size() > 2 );
+    BOOST_REQUIRE( callResult != "0x" );
+
+    // verify state was not modified by eth_call (nonce unchanged)
+    u256 nonceAfterCall = jsToU256(
+        fixture.rpcClient->eth_getTransactionCount( toJS( senderAddress ), "latest" ) );
+    BOOST_REQUIRE_EQUAL( nonceAfterCall, 0 );
+
+    // now actually deploy via eth_sendTransaction and verify we get the same runtime bytecode
+    Json::Value deployTx;
+    deployTx["from"] = toJS( senderAddress );
+    deployTx["code"] = compiled;
+    deployTx["gas"] = "1000000";
+    string txHash = fixture.rpcClient->eth_sendTransaction( deployTx );
+    dev::eth::mineTransaction( *( fixture.client ), 1 );
+
+    Json::Value receipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
+    BOOST_REQUIRE_EQUAL( receipt["status"], string( "0x1" ) );
+    BOOST_REQUIRE( !receipt["contractAddress"].isNull() );
+
+    string contractAddress = receipt["contractAddress"].asString();
+    string deployedCode = fixture.rpcClient->eth_getCode( contractAddress, "latest" );
+
+    // the runtime bytecode from eth_call should match the actually deployed code
+    BOOST_REQUIRE_EQUAL( callResult, deployedCode );
+}
+
 BOOST_AUTO_TEST_CASE( estimate_gas_with_error ) {
     JsonRpcFixture fixture;
     dev::eth::simulateMining( *( fixture.client ), 1 );


### PR DESCRIPTION
## Description

Resolves https://github.com/skalenetwork/skaled/issues/2394.
Before contract creation eth_call was treated as regular one therefore returns 0x instead of expected contract address. 

## Tests

- Tested on local network
- Added unit test

## Performance Impact
- No performance related changes were introduced 
