### PR TITLE
Reencryption random per block

### DIFF
--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -1288,7 +1288,7 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
         // This ensures all nodes encrypt identically for consensus
         unsigned blockNumberToCall = _ctx.blockNumber.convert_to< unsigned >();
         dev::u256 blockRandomValue =
-            g_skaleHost->getBlockRandom( blockNumberToCall, !_ctx.isReadOnly );
+            g_skaleHost->getReencryptionBlockRandom( blockNumberToCall, !_ctx.isReadOnly );
         bytes blockRandomBytes = toBigEndian( blockRandomValue );
 
         // Create seed array from blockRandom (32 bytes)
@@ -1427,7 +1427,7 @@ ETH_REGISTER_PRECOMPILED( encryptECIES )
         // This ensures all nodes encrypt identically for consensus
         unsigned blockNumberToCall = _ctx.blockNumber.convert_to< unsigned >();
         dev::u256 blockRandomValue =
-            g_skaleHost->getBlockRandom( blockNumberToCall, !_ctx.isReadOnly );
+            g_skaleHost->getReencryptionBlockRandom( blockNumberToCall, !_ctx.isReadOnly );
         bytes blockRandomBytes = toBigEndian( blockRandomValue );
 
         // Create seed from blockRandom (32 bytes)

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -1135,24 +1135,24 @@ unsigned SkaleHost::resolveRandomBlockNumber( unsigned _blockNumber, bool _isCal
     // if not - return value for previous block
     // works for historic calls, eth_call, eth_estimateGas
     // and regular transactions
-    // handle corner case of genesis block
-    // is never a case unless called from debug_traceBlock / eth_call on genesis
-    if ( _blockNumber == 0 )
-        return 0;
-
+    if ( _blockNumber == 0 ) {
+        // handle corner case of genesis block
+        // is never a case unless called from debug_traceBlock / eth_call on genesis
+        return _blockNumber;
+    }
     auto previousBlockTimestamp =
         m_client.blockInfo( m_client.hashFromNumber( _blockNumber - 1 ) ).timestamp();
-
-    if ( !CurrentBlockRandomPatch::isEnabledWhen( previousBlockTimestamp ) )
-        return _blockNumber - 1;
-
-    // means a call outside of block is being executed
-    // if blockNumberToCall > currentBlockNumber, need to decrease it by 1
-    // otherwise the exception is thrown
-    if ( !_isCalledFromTxn && _blockNumber > m_client.number() )
-        return _blockNumber - 1;
-
-    return _blockNumber;
+    if ( CurrentBlockRandomPatch::isEnabledWhen( previousBlockTimestamp ) ) {
+        if ( !_isCalledFromTxn ) {
+            // means a call outside of block is being executed
+            // if blockNumberToCall > currentBlockNumber, need to decrease it by 1
+            // otherwise the exception is thrown
+            if ( _blockNumber > m_client.number() )
+                --_blockNumber;
+        }
+        return _blockNumber;
+    }
+    return _blockNumber - 1;
 }
 
 u256 SkaleHost::getBlockRandom( unsigned _blockNumber, bool _isCalledFromTxn ) const {

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -1128,32 +1128,43 @@ u256 SkaleHost::getGasPrice( unsigned _blockNumber ) const {
     return m_consensus->getPriceForBlockId( _blockNumber );
 }
 
-u256 SkaleHost::getBlockRandom( unsigned _blockNumber, bool _isCalledFromTxn ) const {
+unsigned SkaleHost::resolveRandomBlockNumber(unsigned _blockNumber, bool _isCalledFromTxn) const {
     // for FAIR patch is always enabled
     // check that patch enabled after block _blockNumber - 1
     // if so - return correct value
     // if not - return value for previous block
     // works for historic calls, eth_call, eth_estimateGas
     // and regular transactions
-    if ( _blockNumber == 0 ) {
-        // handle corner case of genesis block
-        // is never a case unless called from debug_traceBlock / eth_call on genesis
-        return m_consensus->getRandomForBlockId( _blockNumber );
-    }
+    // handle corner case of genesis block
+    // is never a case unless called from debug_traceBlock / eth_call on genesis
+    if (_blockNumber == 0) return 0;
+
     auto previousBlockTimestamp =
-        m_client.blockInfo( m_client.hashFromNumber( _blockNumber - 1 ) ).timestamp();
-    if ( CurrentBlockRandomPatch::isEnabledWhen( previousBlockTimestamp ) ) {
-        if ( !_isCalledFromTxn ) {
-            // means a call outside of block is being executed
-            // if blockNumberToCall > currentBlockNumber, need to decrease it by 1
-            // otherwise the exception is thrown
-            if ( _blockNumber > m_client.number() )
-                --_blockNumber;
-        }
-        return m_consensus->getRandomForBlockId( _blockNumber );
-    }
-    return m_consensus->getRandomForBlockId( _blockNumber - 1 );
+        m_client.blockInfo(m_client.hashFromNumber(_blockNumber - 1)).timestamp();
+
+    if (!CurrentBlockRandomPatch::isEnabledWhen(previousBlockTimestamp))
+        return _blockNumber - 1;
+
+    // means a call outside of block is being executed
+    // if blockNumberToCall > currentBlockNumber, need to decrease it by 1
+    // otherwise the exception is thrown
+    if (!_isCalledFromTxn && _blockNumber > m_client.number())
+        return _blockNumber - 1;
+
+    return _blockNumber;
 }
+
+u256 SkaleHost::getBlockRandom( unsigned _blockNumber, bool _isCalledFromTxn ) const {
+    auto blockNumber = resolveRandomBlockNumber(_blockNumber, _isCalledFromTxn);
+    return m_consensus->getRandomForBlockId( blockNumber );
+}
+
+#ifdef BITE2
+u256 SkaleHost::getReencryptionBlockRandom( unsigned _blockNumber, bool _isCalledFromTxn ) const {
+    auto blockNumber = resolveRandomBlockNumber(_blockNumber, _isCalledFromTxn);
+    return m_consensus->getReencryptionRandomForBlockId( blockNumber );
+}
+#endif
 
 dev::eth::SyncStatus SkaleHost::syncStatus() const {
     if ( !m_consensus )

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -1128,7 +1128,7 @@ u256 SkaleHost::getGasPrice( unsigned _blockNumber ) const {
     return m_consensus->getPriceForBlockId( _blockNumber );
 }
 
-unsigned SkaleHost::resolveRandomBlockNumber(unsigned _blockNumber, bool _isCalledFromTxn) const {
+unsigned SkaleHost::resolveRandomBlockNumber( unsigned _blockNumber, bool _isCalledFromTxn ) const {
     // for FAIR patch is always enabled
     // check that patch enabled after block _blockNumber - 1
     // if so - return correct value
@@ -1137,31 +1137,32 @@ unsigned SkaleHost::resolveRandomBlockNumber(unsigned _blockNumber, bool _isCall
     // and regular transactions
     // handle corner case of genesis block
     // is never a case unless called from debug_traceBlock / eth_call on genesis
-    if (_blockNumber == 0) return 0;
+    if ( _blockNumber == 0 )
+        return 0;
 
     auto previousBlockTimestamp =
-        m_client.blockInfo(m_client.hashFromNumber(_blockNumber - 1)).timestamp();
+        m_client.blockInfo( m_client.hashFromNumber( _blockNumber - 1 ) ).timestamp();
 
-    if (!CurrentBlockRandomPatch::isEnabledWhen(previousBlockTimestamp))
+    if ( !CurrentBlockRandomPatch::isEnabledWhen( previousBlockTimestamp ) )
         return _blockNumber - 1;
 
     // means a call outside of block is being executed
     // if blockNumberToCall > currentBlockNumber, need to decrease it by 1
     // otherwise the exception is thrown
-    if (!_isCalledFromTxn && _blockNumber > m_client.number())
+    if ( !_isCalledFromTxn && _blockNumber > m_client.number() )
         return _blockNumber - 1;
 
     return _blockNumber;
 }
 
 u256 SkaleHost::getBlockRandom( unsigned _blockNumber, bool _isCalledFromTxn ) const {
-    auto blockNumber = resolveRandomBlockNumber(_blockNumber, _isCalledFromTxn);
+    auto blockNumber = resolveRandomBlockNumber( _blockNumber, _isCalledFromTxn );
     return m_consensus->getRandomForBlockId( blockNumber );
 }
 
 #ifdef BITE2
 u256 SkaleHost::getReencryptionBlockRandom( unsigned _blockNumber, bool _isCalledFromTxn ) const {
-    auto blockNumber = resolveRandomBlockNumber(_blockNumber, _isCalledFromTxn);
+    auto blockNumber = resolveRandomBlockNumber( _blockNumber, _isCalledFromTxn );
     return m_consensus->getReencryptionRandomForBlockId( blockNumber );
 }
 #endif

--- a/libethereum/SkaleHost.h
+++ b/libethereum/SkaleHost.h
@@ -136,7 +136,6 @@ public:
     void clearTempBITE2Transactions();
 
     dev::u256 getReencryptionBlockRandom( unsigned _blockNumber, bool _isCalledFromTxn ) const;
-  
     std::shared_ptr< std::vector< dev::eth::Transaction > > finalizeBITE2QueueAndGetCtxs();
     void setBITE2QueueOnInit( std::vector< dev::eth::Transaction >&& _ctxs );
 #endif

--- a/libethereum/SkaleHost.h
+++ b/libethereum/SkaleHost.h
@@ -214,7 +214,7 @@ private:
 
     void checkStateRoot( uint64_t _blockId, uint64_t _winningNodeIndex, u256 _stateRoot );
 
-    unsigned resolveRandomBlockNumber(unsigned _blockNumber, bool _isCalledFromTxn) const;
+    unsigned resolveRandomBlockNumber( unsigned _blockNumber, bool _isCalledFromTxn ) const;
 
     std::thread m_broadcastThread;
     void broadcastFunc();

--- a/libethereum/SkaleHost.h
+++ b/libethereum/SkaleHost.h
@@ -135,6 +135,7 @@ public:
     void commitTempBITE2Transactions();
     void clearTempBITE2Transactions();
     void finalizeBITE2Queue();
+    dev::u256 getReencryptionBlockRandom( unsigned _blockNumber, bool _isCalledFromTxn ) const;
 #endif
 
     dev::u256 getGasPrice( unsigned _blockNumber = dev::eth::LatestBlock ) const;
@@ -212,6 +213,8 @@ private:
 #endif
 
     void checkStateRoot( uint64_t _blockId, uint64_t _winningNodeIndex, u256 _stateRoot );
+
+    unsigned resolveRandomBlockNumber(unsigned _blockNumber, bool _isCalledFromTxn) const;
 
     std::thread m_broadcastThread;
     void broadcastFunc();

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -119,6 +119,10 @@ public:
 
     u256 getRandomForBlockId( uint64_t _blockId ) const override { return 0; }
 
+#ifdef BITE2
+    u256 getReencryptionRandomForBlockId( uint64_t _blockId ) const override { return 0; }
+#endif
+
     u256 setPriceForBlockId( uint64_t _blockId, u256 _gasPrice ) {
         assert( _blockId <= block_gas_prices.size() );
         if ( _blockId == block_gas_prices.size() )


### PR DESCRIPTION
## Description

- `encryptTE` and `encryptECIES` now use a deterministic random seed that is **not public**, and is only shared among the nodes participating in consensus.

## Changes

- Refactored block id get logic into helper function
- Added `getReencryptionRandom` to `SkaleHost`
- Updated `encryptTE` & `encryptECIES` to call new `getReencryptionRandom`


## Tests

- Should be no functional changes. Only the value used as seed and how it is computed is changed (tested in consensus)

## Performance Impact

- Should have no impact in performance

Fixes #2354 