### PR TITLE
#2399 fix libbls init for snapshot downloading

### DIFF
--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -579,6 +579,7 @@ bool downloadSnapshotFromUrl( std::shared_ptr< SnapshotManager >& snapshotManage
     if ( isRegularSnapshot )
         blockNumber = getBlockToDownladSnapshot( urlToDownloadSnapshotFrom );
 
+    libBLS::init();
     std::unique_ptr< SnapshotHashAgent > snapshotHashAgent;
     if ( forceDownload )
         snapshotHashAgent.reset(
@@ -586,7 +587,6 @@ bool downloadSnapshotFromUrl( std::shared_ptr< SnapshotManager >& snapshotManage
     else
         snapshotHashAgent.reset( new SnapshotHashAgent( chainParams, arrayCommonPublicKey ) );
 
-    libBLS::init();
     std::pair< dev::h256, libBLS::algebra::G1Point > votedHash;
     std::vector< std::string > listUrlsToDownload;
     std::tie( listUrlsToDownload, votedHash ) =

--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -579,7 +579,6 @@ bool downloadSnapshotFromUrl( std::shared_ptr< SnapshotManager >& snapshotManage
     if ( isRegularSnapshot )
         blockNumber = getBlockToDownladSnapshot( urlToDownloadSnapshotFrom );
 
-    libBLS::init();
     std::unique_ptr< SnapshotHashAgent > snapshotHashAgent;
     if ( forceDownload )
         snapshotHashAgent.reset(
@@ -790,6 +789,9 @@ int main( int argc, char** argv ) {
         Defaults::get();
         Ethash::init();
         NoProof::init();
+
+        // init cryptographic parameters
+        libBLS::init();
 
         /// General params for Node operation
         NodeMode nodeMode = NodeMode::Full;


### PR DESCRIPTION
fixes #2399 

initialize libbls parameters before accessing its methods during snapshot downloading