### PR TITLE
Patch-guard BITE2 specific blocks db entries

### DIFF
--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -778,11 +778,11 @@ void BlockChain::insertTransactionsDetailsToDb(
 
 #ifdef BITE
 #ifdef BITE2
-        CtxOrigin ctxOrigin( _block.ctxHashesLists );
-        _extrasWriteBatch.insert( toSlice( _block.info.hash(), ExtraCtxOrigin ),
-            ( db::Slice ) dev::ref( ctxOrigin.rlp() ) );
+        if ( Bite2Patch::isEnabledInWorkingBlock() ) {
+            CtxOrigin ctxOrigin( _block.ctxHashesLists );
+            _extrasWriteBatch.insert( toSlice( _block.info.hash(), ExtraCtxOrigin ),
+                ( db::Slice ) dev::ref( ctxOrigin.rlp() ) );
 
-        if ( SingleStateCommitPerBlockPatch::isEnabledInWorkingBlock() ) {
             CHECK_EXPRESSION( _block.createdCtxs );
             RLPStream s;
             s.appendList( _block.createdCtxs->size() );


### PR DESCRIPTION
### Description

Guard BITE2 specific blocks_and_extras.db entries with BITE2 patch 

### Tests
- Tested on local network by syncing archive node from 0 block

### Performance Impact

- Changes should not impact performance