### PR TITLE
Bug/is 1430 ctx from non updated

### DIFF
--- a/libdevcore/CMakeLists.txt
+++ b/libdevcore/CMakeLists.txt
@@ -1,8 +1,7 @@
 file(GLOB sources "*.cpp" "*.c")
 file(GLOB headers "*.h")
 
-set( CMAKE_CXX_STANDARD 17 )
-
+set( CMAKE_CXX_STANDARD 20 )
 
 if( NOT MICROPROFILE )
     file(GLOB_RECURSE microprofile_files "*microprofile*" "miniz.*")

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -65,6 +65,18 @@
 // CryptoPP defines byte in the global namespace, so must we.
 using _byte_ = uint8_t;
 
+template < typename T >
+concept AssociativeContainer = requires {
+    typename T::key_type;
+};
+
+template < typename T >
+concept LinearContainer = requires( T a ) {
+    { a.begin() };
+    { a.end() };
+}
+&&!AssociativeContainer< T >;
+
 #define DEV_IGNORE_EXCEPTIONS( X ) \
     try {                          \
         X;                         \

--- a/libethereum/BITE2TransactionQueue.cpp
+++ b/libethereum/BITE2TransactionQueue.cpp
@@ -118,4 +118,13 @@ bool BITE2TransactionQueue::dropGood( const Transaction& _t ) {
     return false;
 }
 
+void BITE2TransactionQueue::setQueueOnInit( std::deque< Transaction >&& _ctxQueue ) {
+    WriteGuard l( m_lock );
+    CHECK_EXPRESSION( m_current );
+    m_current = std::make_shared< std::deque< Transaction > >( std::move( _ctxQueue ) );
+    m_currentHeadIndex = m_current->empty() ? 0 : m_current->size() - 1;
+    m_empty = m_current->empty();
+    BOOST_LOG( m_loggerInfo ) << "BITE2 queue initialized with " << m_current->size() << " CTXs";
+}
+
 #endif  // BITE

--- a/libethereum/BITE2TransactionQueue.cpp
+++ b/libethereum/BITE2TransactionQueue.cpp
@@ -25,17 +25,19 @@
 using namespace dev;
 using namespace dev::eth;
 
-std::vector< Transaction > BITE2TransactionQueue::debug_pendingBITE2Transactions() const {
+std::deque< Transaction > BITE2TransactionQueue::debug_pendingBITE2Transactions() const {
     // requires lock because called from JSON RPC API
     ReadGuard l( m_lock );
     CHECK_EXPRESSION( m_current );
     return *m_current;
 }
 
-const std::vector< Transaction >& BITE2TransactionQueue::pendingBITE2Transactions() const {
-    // no lock - called strictly AFTER finalize(), no new txns can be added at this point
+std::shared_ptr< std::deque< Transaction > > BITE2TransactionQueue::pendingBITE2Transactions()
+    const {
+    // no lock - always called AFTER all txns in block are executed
+    // no new txns can be added at this point
     CHECK_EXPRESSION( m_current );
-    return *m_current;
+    return m_current;
 }
 
 void BITE2TransactionQueue::addTemp( Transaction&& _t ) {
@@ -76,7 +78,7 @@ void BITE2TransactionQueue::commitTemp() {
         return;
     // m_currentHeadIndex should always point to last element during block execution
     // used as checkpoint for rollbacks
-    m_currentHeadIndex.store( m_current->size() - 1, std::memory_order_relaxed );
+    m_currentHeadIndex = m_current->size() - 1;
     m_empty = false;
 }
 
@@ -94,44 +96,26 @@ void BITE2TransactionQueue::clearTemp() {
     }
 }
 
-void BITE2TransactionQueue::clear() {
-    WriteGuard l( m_lock );
-    CHECK_EXPRESSION( m_current );
-    m_current->clear();
-    m_currentHeadIndex.store( 0, std::memory_order_relaxed );
-    m_empty = true;
-}
-
-std::shared_ptr< std::vector< Transaction > > BITE2TransactionQueue::finalizeAndGetCtxs() {
-    CHECK_EXPRESSION( m_current );
-    // prepare for the next block processing - skaled may delete CTXs added into blockchain
-    // m_currentHeadIndex points to first not yet verified CTX
-    m_currentHeadIndex = 0;
-    return m_current;
-}
-
 bool BITE2TransactionQueue::dropGood( const Transaction& _t ) {
     if ( _t.isCTX() ) {
+        WriteGuard l( m_lock );
         CHECK_EXPRESSION( m_current );
-        // BITE transactions are stored separately
+        CHECK_EXPRESSION( !m_current->empty() );
+        // BITE2 transactions are stored separately
         // they are also stored in the strict order
-        CHECK_EXPRESSION( m_currentHeadIndex < m_current->size() );
         // Check that we indeed are dropping the front transaction
-        CHECK_EXPRESSION( _t == ( *m_current )[m_currentHeadIndex] );
-        m_currentHeadIndex.fetch_add( 1, std::memory_order_relaxed );
+        CHECK_EXPRESSION( _t == m_current->front() );
+        m_current->pop_front();
+        if ( m_current->empty() ) {
+            m_currentHeadIndex = 0;
+            m_empty = true;
+        } else {
+            CHECK_EXPRESSION( m_currentHeadIndex > 0 );
+            m_currentHeadIndex -= 1;
+        }
         return true;
     }
     return false;
 }
-
-void BITE2TransactionQueue::setQueueOnInit( Transactions&& _ctxQueue ) {
-    WriteGuard l( m_lock );
-    CHECK_EXPRESSION( m_current );
-    m_current = std::make_shared< std::vector< Transaction > >( std::move( _ctxQueue ) );
-    m_currentHeadIndex.store( 0, std::memory_order_relaxed );
-    m_empty = m_current->empty();
-    BOOST_LOG( m_loggerInfo ) << "BITE2 queue initialized with " << m_current->size() << " CTXs";
-}
-
 
 #endif  // BITE

--- a/libethereum/BITE2TransactionQueue.h
+++ b/libethereum/BITE2TransactionQueue.h
@@ -57,8 +57,7 @@ public:
     bool dropGood( const Transaction& _t );
 
     /// Set the queue on startup with CTXs that were created in the previous block
-    template < LinearContainer C >
-    void setQueueOnInit( C&& _ctxQueue );
+    void setQueueOnInit( std::deque< Transaction >&& _ctxQueue );
 
 private:
     std::shared_ptr< std::deque< Transaction > > m_current =
@@ -71,17 +70,6 @@ private:
     Logger m_loggerWarning{ createLogger( VerbosityWarning, "BITE2Queue" ) };
     Logger m_loggerTrace{ createLogger( VerbosityTrace, "BITE2Queue" ) };
 };
-
-template < LinearContainer C >
-void BITE2TransactionQueue::setQueueOnInit( C&& _ctxQueue ) {
-    WriteGuard l( m_lock );
-    CHECK_EXPRESSION( m_current );
-    m_current = std::make_shared< std::deque< Transaction > >(
-        std::make_move_iterator( _ctxQueue.begin() ), std::make_move_iterator( _ctxQueue.end() ) );
-    m_currentHeadIndex = m_current->empty() ? 0 : m_current->size() - 1;
-    m_empty = m_current->empty();
-    BOOST_LOG( m_loggerInfo ) << "BITE2 queue initialized with " << m_current->size() << " CTXs";
-}
 
 }  // namespace eth
 }  // namespace dev

--- a/libethereum/BITE2TransactionQueue.h
+++ b/libethereum/BITE2TransactionQueue.h
@@ -22,11 +22,11 @@
 #ifdef BITE
 
 #include "Transaction.h"
+#include <libdevcore/Common.h>
 #include <libdevcore/Guards.h>
 #include <libdevcore/Log.h>
 
-#include <atomic>
-#include <vector>
+#include <deque>
 
 namespace dev {
 namespace eth {
@@ -34,38 +34,36 @@ namespace eth {
 class BITE2TransactionQueue {
 public:
     /// Thread-safe, locks and returns a copy. For Debug/RPC.
-    std::vector< Transaction > debug_pendingBITE2Transactions() const;
+    std::deque< Transaction > debug_pendingBITE2Transactions() const;
 
     /// No lock, returns reference to entire buffer. For internal logic.
-    const std::vector< Transaction >& pendingBITE2Transactions() const;
+    std::shared_ptr< std::deque< Transaction > > pendingBITE2Transactions() const;
 
-    // addTemp(), getTempHashes(), commitTemp(), clearTemp(), clear() and finalize()
+    // addTemp(), getTempHashes(), commitTemp(), clearTemp()
     // are always called from the same thread
     // and pendingBITE2Transactions() always called AFTER methods above are executed
     // therefore, there is no need in extra synchronization
     // only debug_pendingBITE2Transactions requires synchronization
-    // because it is used by JSON RPC API
-
-    std::shared_ptr< std::vector< Transaction > > finalizeAndGetCtxs();
+    // because it is used by external JSON RPC API
 
     void addTemp( Transaction&& _t );
     /// Get hashes of CTXs crafted by transaction that is being executed now
     std::vector< h256 > getTempHashes() const;
     void commitTemp();
     void clearTemp();
-    void clear();
 
     // Returns true if transaction was a BITE2 transaction and was handled
     // Returns false if it's not a BITE2 transaction.
     bool dropGood( const Transaction& _t );
 
     /// Set the queue on startup with CTXs that were created in the previous block
-    void setQueueOnInit( Transactions&& _ctxQueue );
+    template < LinearContainer C >
+    void setQueueOnInit( C&& _ctxQueue );
 
 private:
-    std::shared_ptr< std::vector< Transaction > > m_current =
-        std::make_shared< std::vector< Transaction > >();
-    std::atomic_size_t m_currentHeadIndex = 0;
+    std::shared_ptr< std::deque< Transaction > > m_current =
+        std::make_shared< std::deque< Transaction > >();
+    size_t m_currentHeadIndex = 0;
     bool m_empty = true;
     mutable SharedMutex m_lock;
 
@@ -73,6 +71,17 @@ private:
     Logger m_loggerWarning{ createLogger( VerbosityWarning, "BITE2Queue" ) };
     Logger m_loggerTrace{ createLogger( VerbosityTrace, "BITE2Queue" ) };
 };
+
+template < LinearContainer C >
+void BITE2TransactionQueue::setQueueOnInit( C&& _ctxQueue ) {
+    WriteGuard l( m_lock );
+    CHECK_EXPRESSION( m_current );
+    m_current = std::make_shared< std::deque< Transaction > >(
+        std::make_move_iterator( _ctxQueue.begin() ), std::make_move_iterator( _ctxQueue.end() ) );
+    m_currentHeadIndex = m_current->empty() ? 0 : m_current->size() - 1;
+    m_empty = m_current->empty();
+    BOOST_LOG( m_loggerInfo ) << "BITE2 queue initialized with " << m_current->size() << " CTXs";
+}
 
 }  // namespace eth
 }  // namespace dev

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -542,7 +542,7 @@ std::pair< TransactionReceipts, unsigned > Block::recoverFromReceipts(
 #ifdef BITE
     // set CTXs from previous block to BITE2 queue
     g_skaleHost->setBITE2QueueOnInit( std::move( savedData->ctxsCreatedInBlock ) );
-    m_createdCtxs = g_skaleHost->finalizeBITE2QueueAndGetCtxs();
+    m_pendingCtxs = g_skaleHost->pendingBITE2Transactions();
 #endif
 
     unsigned badCount = 0;
@@ -627,7 +627,7 @@ void Block::executeTransactions( BlockChain const& _bc, const Transactions& _tra
     }
 #ifdef BITE
     // finalize BITE2 queue after executing all txns from current block
-    m_createdCtxs = g_skaleHost->finalizeBITE2QueueAndGetCtxs();
+    m_pendingCtxs = g_skaleHost->pendingBITE2Transactions();
 #endif
 }
 
@@ -742,13 +742,13 @@ void Block::saveStateChanges(
 
     if ( progressLog && _context.singleCommitEnabled ) {
 #ifdef BITE
-        CHECK_EXPRESSION( m_createdCtxs );
+        CHECK_EXPRESSION( m_pendingCtxs );
 #endif
         progressLog->markBlockCommitCompleted(
             m_currentBlock.number(), _context.receipts, m_currentBlock.timestamp()
 #ifdef BITE
                                                             ,
-            *m_createdCtxs
+            *m_pendingCtxs
 #endif
         );
     }

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -335,9 +335,9 @@ public:
         return m_ctxHashesLists;
     }
 
-    const std::shared_ptr< std::vector< dev::eth::Transaction > >& createdCtxs() const {
-        CHECK_EXPRESSION( m_createdCtxs );
-        return m_createdCtxs;
+    const std::shared_ptr< std::deque< dev::eth::Transaction > >& pendingCtxs() const {
+        CHECK_EXPRESSION( m_pendingCtxs );
+        return m_pendingCtxs;
     }
 #endif  // BITE
 
@@ -430,11 +430,10 @@ private:
     // list of ctx hashes crafted by every txn in block
     // only filled for a working block
     std::vector< std::vector< dev::h256 > > m_ctxHashesLists;
-    // list of ctxs created by every txn in block
+    // list of pending ctxs
     // only filled for a working block
-    // safe, because it is filled with transactions from BITE queue
-    // which stay there until the block is committed
-    std::shared_ptr< Transactions > m_createdCtxs = std::make_shared< Transactions >();
+    std::shared_ptr< std::deque< Transaction > > m_pendingCtxs =
+        std::make_shared< std::deque< Transaction > >();
 #endif  // BITE
 
     Logger m_loggerDebug{ createLogger( VerbosityDebug, "block" ) };

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -1902,13 +1902,12 @@ bool BlockChain::isPatchTimestampActiveInBlockNumber( time_t _ts, BlockNumber _b
 
 #ifdef BITE
 
-Transactions BlockChain::pendingCTXsList() const {
+std::deque< Transaction > BlockChain::pendingCTXsList() const {
     std::string lastBlockCTXs = this->m_extrasDB->lookup( ( db::Slice ) "pendingCTXs" );
     if ( lastBlockCTXs.empty() )
         return {};
     RLP rlp( lastBlockCTXs );
-    Transactions ctxs;
-    ctxs.reserve( rlp.itemCount() );
+    std::deque< Transaction > ctxs;
     uint64_t prevBlockTimestamp = info().timestamp();
     for ( auto const& txRlp : rlp ) {
         ctxs.push_back( Transaction( txRlp.data(), CheckTransaction::None, true,

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -628,7 +628,7 @@ ImportRoute BlockChain::import( const Block& _block ) {
 
     CHECK_EXPRESSION( verifiedBlock.decryptedTransactions.ctxTxsMap );
     verifiedBlock.ctxHashesLists = _block.ctxHashesLists();
-    verifiedBlock.createdCtxs = _block.createdCtxs();
+    verifiedBlock.pendingCtxs = _block.pendingCtxs();
 #endif  // BITE
 
     BlockReceipts blockReceipts;
@@ -780,14 +780,14 @@ void BlockChain::insertTransactionsDetailsToDb(
             _extrasWriteBatch.insert( toSlice( _block.info.hash(), ExtraCtxOrigin ),
                 ( db::Slice ) dev::ref( ctxOrigin.rlp() ) );
 
-            CHECK_EXPRESSION( _block.createdCtxs );
+            CHECK_EXPRESSION( _block.pendingCtxs );
             RLPStream s;
-            s.appendList( _block.createdCtxs->size() );
-            for ( const auto& ctx : *_block.createdCtxs )
+            s.appendList( _block.pendingCtxs->size() );
+            for ( const auto& ctx : *_block.pendingCtxs )
                 s.appendRaw( ctx.toBytes() );
             dev::bytes ctxListRlp = s.out();
             _extrasWriteBatch.insert(
-                db::Slice( "lastBlockCTXs" ), ( db::Slice ) dev::ref( ctxListRlp ) );
+                db::Slice( "pendingCTXs" ), ( db::Slice ) dev::ref( ctxListRlp ) );
         }
         CHECK_EXPRESSION( _block.decryptedTransactions.regularTxsMap );
         auto regularTxnsIterator = _block.decryptedTransactions.regularTxsMap->begin();
@@ -1902,8 +1902,8 @@ bool BlockChain::isPatchTimestampActiveInBlockNumber( time_t _ts, BlockNumber _b
 
 #ifdef BITE
 
-Transactions BlockChain::ctxListForPreviousBlock() const {
-    std::string lastBlockCTXs = this->m_extrasDB->lookup( ( db::Slice ) "lastBlockCTXs" );
+Transactions BlockChain::pendingCTXsList() const {
+    std::string lastBlockCTXs = this->m_extrasDB->lookup( ( db::Slice ) "pendingCTXs" );
     if ( lastBlockCTXs.empty() )
         return {};
     RLP rlp( lastBlockCTXs );

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -348,7 +348,7 @@ public:
             _blockHash, m_ctxOrigin, x_ctxOrigin, NullCtxOrigin );
     }
 
-    Transactions pendingCTXsList() const;
+    std::deque< Transaction > pendingCTXsList() const;
 #endif  // BITE
 
     /// Get a number for the given hash (or the most recent mined if none given). Thread-safe.

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -348,7 +348,7 @@ public:
             _blockHash, m_ctxOrigin, x_ctxOrigin, NullCtxOrigin );
     }
 
-    Transactions ctxListForPreviousBlock() const;
+    Transactions pendingCTXsList() const;
 #endif  // BITE
 
     /// Get a number for the given hash (or the most recent mined if none given). Thread-safe.

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -331,7 +331,7 @@ void Client::init( WithExisting _forceAction, u256 _networkId ) {
 
 #ifdef BITE
     if ( SingleStateCommitPerBlockPatch::isEnabledInWorkingBlock() )
-        m_tq.setBITE2QueueOnInit( bc().ctxListForPreviousBlock() );
+        m_tq.setBITE2QueueOnInit( bc().pendingCTXsList() );
 #endif
 
     if ( m_dbPath.size() )

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -155,7 +155,7 @@ public:
     Transactions debugGetFutureTransactions() const { return m_tq.debugGetFutureTransactions(); }
 
 #ifdef BITE
-    Transactions debugGetPendingBITE2Transactions() const {
+    std::deque< Transaction > debugGetPendingBITE2Transactions() const {
         return m_tq.debug_pendingBITE2Transactions();
     }
 #endif

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -51,7 +51,6 @@ using namespace std;
 #include <libethereum/Client.h>
 #include <libethereum/CommonNet.h>
 #include <libethereum/Executive.h>
-#include <libethereum/TransactionQueue.h>
 
 #include <libweb3jsonrpc/JsonHelper.h>
 
@@ -415,12 +414,8 @@ void SkaleHost::clearTempBITE2Transactions() {
     m_tq.clearTempBITE2Transactions();
 }
 
-std::shared_ptr< std::vector< dev::eth::Transaction > > SkaleHost::finalizeBITE2QueueAndGetCtxs() {
-    return m_tq.finalizeBITE2QueueAndGetCtxs();
-}
-
-void SkaleHost::setBITE2QueueOnInit( std::vector< dev::eth::Transaction >&& _ctxs ) {
-    return m_tq.setBITE2QueueOnInit( std::move( _ctxs ) );
+std::shared_ptr< std::deque< Transaction > > SkaleHost::pendingBITE2Transactions() const {
+    return m_tq.pendingBITE2Transactions();
 }
 #endif
 
@@ -512,7 +507,7 @@ ConsensusExtFace::Transactions SkaleHost::pendingTransactions( size_t _limit, u2
     auto bite2Transactions = m_tq.pendingBITE2Transactions();
     u256 gasAccByCTXs = 0;
     // CTXs are not the subject for block gas limit
-    for ( const auto& ctx : bite2Transactions ) {
+    for ( const auto& ctx : *bite2Transactions ) {
         gasAccByCTXs += ctx.gas();
         out_vector.pushBackCTX( ctx.toBytes() );
         m_debugTracer.tracepoint( "sent_txn" );
@@ -1107,12 +1102,6 @@ std::vector< Transaction > SkaleHost::processCTXTransactions(
     [[maybe_unused]] const dev::eth::BlockHeader& latestInfo,
     DecryptedTransactions _decryptedTransactions ) {
     std::vector< Transaction > outTxns;
-    if ( _approvedTransactions.sizeCTX() != m_tq.pendingBITE2Transactions().size() ) {
-        BOOST_LOG( m_loggerInfo ) << "Expected " << m_tq.pendingBITE2Transactions().size()
-                                  << " CTX, but received " << _approvedTransactions.sizeCTX()
-                                  << ".\n Exiting with code 200, repair will be needed.";
-        ExitHandler::exitHandler( -1, ExitHandler::ec_state_root_mismatch );
-    }
     auto ctxIterator = _decryptedTransactions.ctxTxsMap->begin();
     for ( size_t i = 0; i < _approvedTransactions.sizeCTX(); ++i ) {
         const bytes& data = _approvedTransactions.at( i );
@@ -1159,7 +1148,6 @@ std::vector< Transaction > SkaleHost::processCTXTransactions(
         if ( ctxIterator != _decryptedTransactions.ctxTxsMap->end() )
             ++ctxIterator;
     }
-    m_tq.clearAllBITE2Transactions();
     return outTxns;
 }
 #endif

--- a/libethereum/SkaleHost.h
+++ b/libethereum/SkaleHost.h
@@ -37,6 +37,7 @@
 #include <libethcore/Common.h>
 #include <libethereum/InstanceMonitor.h>
 #include <libethereum/Transaction.h>
+#include <libethereum/TransactionQueue.h>
 #include <libskale/SkaleClient.h>
 
 #include <jsonrpccpp/client/client.h>
@@ -146,10 +147,14 @@ public:
     std::vector< dev::h256 > getBITE2HashesForCurrentTxn() const;
     void commitTempBITE2Transactions();
     void clearTempBITE2Transactions();
+    std::shared_ptr< std::deque< dev::eth::Transaction > > pendingBITE2Transactions() const;
+
+    template < LinearContainer C >
+    void setBITE2QueueOnInit( C&& _ctxs ) {
+        return m_tq.setBITE2QueueOnInit( std::move( _ctxs ) );
+    }
 
     dev::u256 getReencryptionBlockRandom( unsigned _blockNumber, bool _isCalledFromTxn ) const;
-    std::shared_ptr< std::vector< dev::eth::Transaction > > finalizeBITE2QueueAndGetCtxs();
-    void setBITE2QueueOnInit( std::vector< dev::eth::Transaction >&& _ctxs );
 #endif
 
     dev::u256 getGasPrice( unsigned _blockNumber = dev::eth::LatestBlock ) const;

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -584,11 +584,11 @@ Transactions TransactionQueue::debugGetFutureTransactions() const {
 }
 
 #ifdef BITE
-const Transactions& TransactionQueue::pendingBITE2Transactions() const {
+std::shared_ptr< std::deque< Transaction > > TransactionQueue::pendingBITE2Transactions() const {
     return m_bite2Queue.pendingBITE2Transactions();
 }
 
-Transactions TransactionQueue::debug_pendingBITE2Transactions() const {
+std::deque< Transaction > TransactionQueue::debug_pendingBITE2Transactions() const {
     return m_bite2Queue.debug_pendingBITE2Transactions();
 }
 
@@ -606,18 +606,5 @@ void TransactionQueue::commitTempBITE2Transactions() {
 
 void TransactionQueue::clearTempBITE2Transactions() {
     m_bite2Queue.clearTemp();
-}
-
-void TransactionQueue::clearAllBITE2Transactions() {
-    m_bite2Queue.clear();
-}
-
-std::shared_ptr< std::vector< dev::eth::Transaction > >
-TransactionQueue::finalizeBITE2QueueAndGetCtxs() {
-    return m_bite2Queue.finalizeAndGetCtxs();
-}
-
-void TransactionQueue::setBITE2QueueOnInit( Transactions&& _ctxQueue ) {
-    m_bite2Queue.setQueueOnInit( std::move( _ctxQueue ) );
 }
 #endif

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -160,11 +160,11 @@ public:
 #ifdef BITE
     /// Get all pending BITE2 transactions. Returned transactions are not removed from the queue
     /// automatically. For internal logic.
-    const Transactions& pendingBITE2Transactions() const;
+    std::shared_ptr< std::deque< Transaction > > pendingBITE2Transactions() const;
 
     /// Get all pending BITE2 transactions. Returned transactions are not removed from the queue
     /// automatically. For Debug/RPC.
-    std::vector< Transaction > debug_pendingBITE2Transactions() const;
+    std::deque< Transaction > debug_pendingBITE2Transactions() const;
 
     /// Add BITE2 txn as temporary
     void addTempBITE2Transaction( dev::eth::Transaction&& _transaction );
@@ -174,13 +174,11 @@ public:
     void commitTempBITE2Transactions();
 
     void clearTempBITE2Transactions();
-    void clearAllBITE2Transactions();
 
-    /// finalizes BITE2 queue to be ready to start processing next block
-    std::shared_ptr< std::vector< dev::eth::Transaction > > finalizeBITE2QueueAndGetCtxs();
-
-    /// Set the queue on startup with CTXs that were created in the previous block
-    void setBITE2QueueOnInit( Transactions&& _ctxQueue );
+    template < LinearContainer C >
+    void setBITE2QueueOnInit( C&& _ctxQueue ) {
+        return m_bite2Queue.setQueueOnInit( std::move( _ctxQueue ) );
+    }
 #endif
 
     struct Status {

--- a/libethereum/VerifiedBlock.h
+++ b/libethereum/VerifiedBlock.h
@@ -44,10 +44,9 @@ struct VerifiedBlockRef {
                                                              ///< to be stored in blockchain
 
     std::vector< std::vector< dev::h256 > > ctxHashesLists;
-    std::shared_ptr< std::vector< Transaction > > createdCtxs =
-        std::make_shared< std::vector< Transaction > >();  ///< List of ctxs created by transactions
-                                                           ///< in block
-#endif                                                     // BITE
+    std::shared_ptr< std::deque< Transaction > > pendingCtxs =
+        std::make_shared< std::deque< Transaction > >();  ///< List of pending ctxs for block
+#endif                                                    // BITE
 };
 
 /// @brief Verified block info, combines block data and verified info/transactions

--- a/libp2p/CMakeLists.txt
+++ b/libp2p/CMakeLists.txt
@@ -1,4 +1,4 @@
-set( CMAKE_CXX_STANDARD 17 )
+set( CMAKE_CXX_STANDARD 20 )
 
 
 

--- a/libskale/StateProgressLog.cpp
+++ b/libskale/StateProgressLog.cpp
@@ -42,7 +42,7 @@ void StateProgressLog::markBlockCommitCompleted(
     uint64_t _blockNumber, const dev::eth::TransactionReceipts& _receipts, uint64_t _timestamp
 #ifdef BITE
     ,
-    const std::vector< dev::eth::Transaction >& _ctxsCreatedInBlock
+    const std::deque< dev::eth::Transaction >& _ctxsCreatedInBlock
 #endif
 ) {
     CommittedProgressData data;

--- a/libskale/StateProgressLog.h
+++ b/libskale/StateProgressLog.h
@@ -5,6 +5,7 @@
 
 #include <boost/filesystem.hpp>
 #include <cstdint>
+#include <deque>
 #include <optional>
 #include <string>
 
@@ -16,7 +17,7 @@ struct CommittedProgressData {
     uint64_t timestamp;
     dev::eth::TransactionReceipts receipts;
 #ifdef BITE
-    std::vector< dev::eth::Transaction > ctxsCreatedInBlock;
+    std::deque< dev::eth::Transaction > ctxsCreatedInBlock;
 #endif
 };
 
@@ -31,7 +32,7 @@ public:
         uint64_t _blockNumber, const dev::eth::TransactionReceipts& _receipts, uint64_t _timestamp
 #ifdef BITE
         ,
-        const std::vector< dev::eth::Transaction >& _ctxsCreatedInBlock
+        const std::deque< dev::eth::Transaction >& _ctxsCreatedInBlock
 #endif
     );
 

--- a/libskutils/CMakeLists.txt
+++ b/libskutils/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries( skutils
     "${DEPS_INSTALL_ROOT}/lib/libboost_context.a"
     "${DEPS_INSTALL_ROOT}/lib/libevent.a"
     "${DEPS_INSTALL_ROOT}/lib/libfmt${DEBUG_SUFFIX_D}.a"
+    "${DEPS_INSTALL_ROOT}/lib/libcurl.a"
     "${DEPS_INSTALL_ROOT}/lib/libdouble-conversion.a"
     "${DEPS_INSTALL_ROOT}/lib/libzstd.a"
     "${DEPS_INSTALL_ROOT}/lib/libzmq.a"

--- a/libweb3jsonrpc/JsonHelper.h
+++ b/libweb3jsonrpc/JsonHelper.h
@@ -104,8 +104,8 @@ namespace rpc {
 h256 h256fromHex( std::string const& _s );
 }
 
-template < class Container >
-auto toJson( Container const& _es ) -> decltype( _es.begin(), _es.end(), Json::Value() ) {
+template < class LinearContainer >
+Json::Value toJson( LinearContainer const& _es ) {
     Json::Value res( Json::arrayValue );
     for ( auto const& e : _es )
         res.append( toJson( e ) );

--- a/skaled_ssl_test/CMakeLists.txt
+++ b/skaled_ssl_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-set( CMAKE_CXX_STANDARD 17 )
+set( CMAKE_CXX_STANDARD 20 )
 set( sources
     main.cpp
     )

--- a/skaled_ssl_test/main.cpp
+++ b/skaled_ssl_test/main.cpp
@@ -239,7 +239,7 @@ void helper_ws_peer::onPeerUnregister() {  // peer will no longer receive onMess
 void helper_ws_peer::onMessage( const std::string& msg, skutils::ws::opcv eOpCode ) {
     if ( eOpCode != skutils::ws::opcv::text )
         throw std::runtime_error( "only ws text messages are supported" );
-    skutils::dispatch::async( strPeerQueueID_, [=]() -> void {
+    skutils::dispatch::async( strPeerQueueID_, [this, msg]() -> void {
         std::cout << ">>> " + std::string( get_helper_server().strSchemeUC_ ) + "-RX >>> " +
                        desc() + " >>> " + msg + "\n";
         std::string strResult = msg;
@@ -506,7 +506,7 @@ helper_client_ws_base::helper_client_ws_base( const char* strClientName, int nTa
     onClose_ = [this]( skutils::ws::client::basic_socket&, skutils::ws::hdl_t,
                    const std::string& reason, int local_close_code,
                    const std::string& local_close_code_as_str ) -> void {
-        ++cntClose_;
+        cntClose_.fetch_add( 1, std::memory_order::relaxed );
         nLocalCloseCode_ = local_close_code;
         strLocalCloseCode_ = local_close_code_as_str;
         strCloseReason_ = reason;
@@ -519,7 +519,7 @@ helper_client_ws_base::helper_client_ws_base( const char* strClientName, int nTa
                        ( reason.empty() ?  "empty text" :  reason ) + "\n";
     };
     onFail_ = [this]( skutils::ws::client::basic_socket&, skutils::ws::hdl_t ) -> void {
-        ++cntFail_;
+        cntFail_.fetch_add( 1, std::memory_order::relaxed );
         std::cerr << strClientName_ +  ": client got fail event\n";
     };
     std::cout << strClientName_ + ": " + "Will initalize client " + strClientName_ +

--- a/skaled_ssl_test/main.h
+++ b/skaled_ssl_test/main.h
@@ -220,7 +220,7 @@ class helper_client_ws_base : public helper_client, public skutils::ws::client::
     std::string strLastMessage_;
 
 public:
-    volatile size_t cntClose_ = 0, cntFail_ = 0;
+    std::atomic_size_t cntClose_ = 0, cntFail_ = 0;
     int nLocalCloseCode_ = 0;
     std::string strLocalCloseCode_;
     std::string strCloseReason_;

--- a/test/unittests/libethereum/BITE2TransactionQueue.cpp
+++ b/test/unittests/libethereum/BITE2TransactionQueue.cpp
@@ -146,13 +146,14 @@ BOOST_AUTO_TEST_CASE( setQueueOnInit ) {
     bytes ctxData;
     ctxData.insert( ctxData.end(), std::begin( BITE2_FUNCTION_SELECTOR_AS_BYTE_ARRAY ),
         std::end( BITE2_FUNCTION_SELECTOR_AS_BYTE_ARRAY ) );
-    Transactions ctxs;
+    std::deque< Transaction > ctxs;
     for ( size_t i = 0; i < 5; ++i ) {
         Transaction txCtx( i, 100, 21000, Address(), ctxData, i, sec );
         txCtx.checkIfCTXAndSet( ctxData );
         ctxs.push_back( std::move( txCtx ) );
     }
-    queue.setQueueOnInit( ctxs );
+    auto ctxsCopy = ctxs;
+    queue.setQueueOnInit( std::move( ctxsCopy ) );
     BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 5 );
 
     Transaction ctx6( 5, 100, 21000, Address(), ctxData, 5, sec );
@@ -167,7 +168,7 @@ BOOST_AUTO_TEST_CASE( setQueueOnInit ) {
     BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 6 );
     BOOST_REQUIRE( queue.debug_pendingBITE2Transactions().at( 5 ) == ctx6 );
     ctxs.push_back( ctx6 );
-    BOOST_REQUIRE( std::ranges::equal( queue.debug_pendingBITE2Transactions(), ctxs ) );
+    BOOST_REQUIRE( queue.debug_pendingBITE2Transactions() == ctxs );
 }
 
 BOOST_AUTO_TEST_CASE( clear ) {

--- a/test/unittests/libethereum/BITE2TransactionQueue.cpp
+++ b/test/unittests/libethereum/BITE2TransactionQueue.cpp
@@ -34,27 +34,37 @@ BOOST_FIXTURE_TEST_SUITE( BITE2TransactionQueueSuite, TestOutputHelperFixture )
 BOOST_AUTO_TEST_CASE( addCommitClear ) {
     BITE2TransactionQueue queue;
 
-    Secret sec = Secret( "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8" );
-    Transaction tx1( 0, 100, 21000, Address(), bytes(), 10, sec );
-    Transaction tx2( 1, 100, 21000, Address(), bytes(), 10, sec );
+    bytes ctxData;
+    ctxData.insert( ctxData.end(), std::begin( BITE2_FUNCTION_SELECTOR_AS_BYTE_ARRAY ),
+        std::end( BITE2_FUNCTION_SELECTOR_AS_BYTE_ARRAY ) );
 
-    queue.addTemp( std::move( tx1 ) );
-    queue.addTemp( std::move( tx2 ) );
+    Secret sec = Secret( "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8" );
+    Transaction tx1( 0, 100, 21000, Address(), ctxData, 10, sec );
+    tx1.checkIfCTXAndSet( ctxData );
+    Transaction tx2( 1, 100, 21000, Address(), ctxData, 10, sec );
+    tx2.checkIfCTXAndSet( ctxData );
+
+    queue.addTemp( Transaction( tx1 ) );
+    queue.addTemp( Transaction( tx2 ) );
 
     BOOST_REQUIRE_EQUAL( queue.debug_pendingBITE2Transactions().size(), 2 );
 
     queue.commitTemp();
-    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions().size(), 2 );
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 2 );
+    BOOST_REQUIRE( queue.pendingBITE2Transactions()->at( 0 ) == tx1 );
+    BOOST_REQUIRE( queue.pendingBITE2Transactions()->at( 1 ) == tx2 );
 
-    Transaction tx3( 2, 100, 21000, Address(), bytes(), 10, sec );
-    queue.addTemp( std::move( tx3 ) );
-    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions().size(), 3 );
+    Transaction tx3( 2, 100, 21000, Address(), ctxData, 10, sec );
+    tx3.checkIfCTXAndSet( ctxData );
+    queue.addTemp( Transaction( tx3 ) );
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 3 );
 
     queue.clearTemp();
-    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions().size(), 2 );
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 2 );
 
-    queue.clear();
-    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions().size(), 0 );
+    BOOST_REQUIRE( queue.dropGood( tx1 ) );
+    BOOST_REQUIRE( queue.dropGood( tx2 ) );
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 0 );
 }
 
 BOOST_AUTO_TEST_CASE( tempHashes ) {
@@ -78,7 +88,7 @@ BOOST_AUTO_TEST_CASE( tempHashes ) {
     queue.commitTemp();
     hashes = queue.getTempHashes();
     BOOST_REQUIRE_EQUAL( hashes.size(), 0 );
-    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions().size(), 2 );
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 2 );
 
     queue.addTemp( Transaction( tx3 ) );
     hashes = queue.getTempHashes();
@@ -89,7 +99,7 @@ BOOST_AUTO_TEST_CASE( tempHashes ) {
     hashes = queue.getTempHashes();
     BOOST_REQUIRE_EQUAL( hashes.size(), 0 );
 
-    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions().size(), 2 );
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 2 );
 }
 
 BOOST_AUTO_TEST_CASE( dropGood ) {
@@ -111,31 +121,56 @@ BOOST_AUTO_TEST_CASE( dropGood ) {
     queue.addTemp( Transaction( txCtx ) );
     queue.commitTemp();
 
-    queue.finalizeAndGetCtxs();
-
     BOOST_REQUIRE( queue.dropGood( txCtx ) );
 
-    queue.clear();
     Transaction txCtx2( 1, 100, 21000, Address(), ctxData, 0, sec );
     txCtx2.checkIfCTXAndSet( ctxData );
 
     queue.addTemp( Transaction( txCtx ) );
     queue.addTemp( Transaction( txCtx2 ) );
     queue.commitTemp();
-    queue.finalizeAndGetCtxs();
 
     BOOST_REQUIRE( queue.dropGood( txCtx ) );
     BOOST_REQUIRE( queue.dropGood( txCtx2 ) );
 
-    queue.clear();
     queue.addTemp( Transaction( txNormal ) );
     queue.commitTemp();
-    queue.finalizeAndGetCtxs();
 
     BOOST_REQUIRE( !queue.dropGood( txNormal ) );
 }
 
-BOOST_AUTO_TEST_CASE( finalizeReset ) {
+BOOST_AUTO_TEST_CASE( setQueueOnInit ) {
+    BITE2TransactionQueue queue;
+    Secret sec = Secret( "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8" );
+
+    bytes ctxData;
+    ctxData.insert( ctxData.end(), std::begin( BITE2_FUNCTION_SELECTOR_AS_BYTE_ARRAY ),
+        std::end( BITE2_FUNCTION_SELECTOR_AS_BYTE_ARRAY ) );
+    Transactions ctxs;
+    for ( size_t i = 0; i < 5; ++i ) {
+        Transaction txCtx( i, 100, 21000, Address(), ctxData, i, sec );
+        txCtx.checkIfCTXAndSet( ctxData );
+        ctxs.push_back( std::move( txCtx ) );
+    }
+    queue.setQueueOnInit( ctxs );
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 5 );
+
+    Transaction ctx6( 5, 100, 21000, Address(), ctxData, 5, sec );
+    ctx6.checkIfCTXAndSet( ctxData );
+    queue.addTemp( Transaction( ctx6 ) );
+    queue.clearTemp();
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 5 );
+    BOOST_REQUIRE( queue.debug_pendingBITE2Transactions().at( 0 ) == ctxs[0] );
+    BOOST_REQUIRE( queue.debug_pendingBITE2Transactions().at( 4 ) == ctxs[4] );
+    queue.addTemp( Transaction( ctx6 ) );
+    queue.commitTemp();
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 6 );
+    BOOST_REQUIRE( queue.debug_pendingBITE2Transactions().at( 5 ) == ctx6 );
+    ctxs.push_back( ctx6 );
+    BOOST_REQUIRE( std::ranges::equal( queue.debug_pendingBITE2Transactions(), ctxs ) );
+}
+
+BOOST_AUTO_TEST_CASE( clear ) {
     BITE2TransactionQueue queue;
     Secret sec = Secret( "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8" );
 
@@ -146,13 +181,46 @@ BOOST_AUTO_TEST_CASE( finalizeReset ) {
     txCtx.checkIfCTXAndSet( ctxData );
 
     queue.addTemp( Transaction( txCtx ) );
+
+    Transaction txCtx1( 0, 100, 21000, Address(), ctxData, 1, sec );
+    txCtx1.checkIfCTXAndSet( ctxData );
+
+    queue.addTemp( Transaction( txCtx1 ) );
     queue.commitTemp();
 
-    queue.finalizeAndGetCtxs();
-    BOOST_REQUIRE( queue.dropGood( txCtx ) );
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 2 );
+    BOOST_REQUIRE( queue.pendingBITE2Transactions()->at( 0 ) == txCtx );
+    BOOST_REQUIRE( queue.pendingBITE2Transactions()->at( 1 ) == txCtx1 );
 
-    queue.finalizeAndGetCtxs();
     BOOST_REQUIRE( queue.dropGood( txCtx ) );
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 1 );
+    BOOST_REQUIRE( queue.pendingBITE2Transactions()->at( 0 ) == txCtx1 );
+
+    Transaction txCtx2( 0, 100, 21000, Address(), ctxData, 2, sec );
+    txCtx2.checkIfCTXAndSet( ctxData );
+
+    queue.addTemp( Transaction( txCtx2 ) );
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 2 );
+    BOOST_REQUIRE( queue.pendingBITE2Transactions()->at( 0 ) == txCtx1 );
+    BOOST_REQUIRE( queue.pendingBITE2Transactions()->at( 1 ) == txCtx2 );
+
+    queue.clearTemp();
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 1 );
+    BOOST_REQUIRE( queue.pendingBITE2Transactions()->at( 0 ) == txCtx1 );
+
+    queue.addTemp( Transaction( txCtx2 ) );
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 2 );
+    BOOST_REQUIRE( queue.pendingBITE2Transactions()->at( 0 ) == txCtx1 );
+    BOOST_REQUIRE( queue.pendingBITE2Transactions()->at( 1 ) == txCtx2 );
+
+    queue.commitTemp();
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 2 );
+    BOOST_REQUIRE( queue.pendingBITE2Transactions()->at( 0 ) == txCtx1 );
+    BOOST_REQUIRE( queue.pendingBITE2Transactions()->at( 1 ) == txCtx2 );
+
+    BOOST_REQUIRE( queue.dropGood( txCtx1 ) );
+    BOOST_REQUIRE( queue.dropGood( txCtx2 ) );
+    BOOST_REQUIRE_EQUAL( queue.pendingBITE2Transactions()->size(), 0 );
 }
 
 #endif

--- a/test/unittests/libskale/StateProgressLogTest.cpp
+++ b/test/unittests/libskale/StateProgressLogTest.cpp
@@ -53,7 +53,8 @@ BOOST_AUTO_TEST_CASE( mark_block_commit_completed ) {
     StateProgressLog log( tempDir.path() );
     log.markBlockCommitCompleted( 67890, emptyReceipts, 0
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
 
@@ -69,7 +70,8 @@ BOOST_AUTO_TEST_CASE( is_block_commit_completed_true ) {
     StateProgressLog log( tempDir.path() );
     log.markBlockCommitCompleted( 100, emptyReceipts, 0
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
 
@@ -91,7 +93,8 @@ BOOST_AUTO_TEST_CASE( is_block_commit_completed_false_wrong_block ) {
     StateProgressLog log( tempDir.path() );
     log.markBlockCommitCompleted( 100, emptyReceipts, 0
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
 
@@ -114,7 +117,8 @@ BOOST_AUTO_TEST_CASE( file_overwrite ) {
     log.markBlockCommitStarted( 1 );
     log.markBlockCommitCompleted( 1, emptyReceipts, 0
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
     log.markBlockCommitStarted( 2 );
@@ -133,7 +137,8 @@ BOOST_AUTO_TEST_CASE( large_block_number ) {
     uint64_t largeBlockNumber = 18446744073709551615ULL;
     log.markBlockCommitCompleted( largeBlockNumber, emptyReceipts, 0
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
 
@@ -147,7 +152,8 @@ BOOST_AUTO_TEST_CASE( zero_block_number ) {
 
     log.markBlockCommitCompleted( 0, emptyReceipts, 0
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
 
@@ -164,7 +170,8 @@ BOOST_AUTO_TEST_CASE( started_then_completed_sequence ) {
 
     log.markBlockCommitCompleted( 42, emptyReceipts, 0
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
     BOOST_CHECK( log.isBlockCommitCompleted( 42 ) );
@@ -177,7 +184,8 @@ BOOST_AUTO_TEST_CASE( persistence_across_instances ) {
         StateProgressLog log( tempDir.path() );
         log.markBlockCommitCompleted( 500, emptyReceipts, 0
 #ifdef BITE
-                                      , emptyCtxs
+            ,
+            emptyCtxs
 #endif
         );
     }
@@ -243,7 +251,8 @@ BOOST_AUTO_TEST_CASE( consecutive_block_numbers ) {
 
         log.markBlockCommitCompleted( block, emptyReceipts, 0
 #ifdef BITE
-                                      , emptyCtxs
+            ,
+            emptyCtxs
 #endif
         );
         BOOST_CHECK( log.isBlockCommitCompleted( block ) );
@@ -268,7 +277,8 @@ BOOST_AUTO_TEST_CASE( crash_after_mark_started ) {
         log.markBlockCommitStarted( 10 );
         log.markBlockCommitCompleted( 10, emptyReceipts, 0
 #ifdef BITE
-                                      , emptyCtxs
+            ,
+            emptyCtxs
 #endif
         );
 
@@ -284,7 +294,8 @@ BOOST_AUTO_TEST_CASE( skip_already_committed_block ) {
         log.markBlockCommitStarted( 40 );
         log.markBlockCommitCompleted( 40, emptyReceipts, 0
 #ifdef BITE
-                                      , emptyCtxs
+            ,
+            emptyCtxs
 #endif
         );
     }
@@ -310,7 +321,8 @@ BOOST_AUTO_TEST_CASE( reprocess_incomplete_block ) {
         log.markBlockCommitStarted( 50 );
         log.markBlockCommitCompleted( 50, emptyReceipts, 0
 #ifdef BITE
-                                      , emptyCtxs
+            ,
+            emptyCtxs
 #endif
         );
 
@@ -327,7 +339,8 @@ BOOST_AUTO_TEST_CASE( multiple_blocks_with_crash_in_middle ) {
             log.markBlockCommitStarted( block );
             log.markBlockCommitCompleted( block, emptyReceipts, 0
 #ifdef BITE
-                                          , emptyCtxs
+                ,
+                emptyCtxs
 #endif
             );
         }
@@ -343,7 +356,8 @@ BOOST_AUTO_TEST_CASE( multiple_blocks_with_crash_in_middle ) {
         log.markBlockCommitStarted( 6 );
         log.markBlockCommitCompleted( 6, emptyReceipts, 0
 #ifdef BITE
-                                      , emptyCtxs
+            ,
+            emptyCtxs
 #endif
         );
 
@@ -361,7 +375,8 @@ BOOST_AUTO_TEST_CASE( restart_same_block_allowed ) {
 
     log.markBlockCommitCompleted( 70, emptyReceipts, 0
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
     BOOST_CHECK( log.isBlockCommitCompleted( 70 ) );
@@ -375,7 +390,8 @@ BOOST_AUTO_TEST_CASE( start_next_block_after_completion ) {
     log.markBlockCommitStarted( 80 );
     log.markBlockCommitCompleted( 80, emptyReceipts, 0
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
 
@@ -385,7 +401,8 @@ BOOST_AUTO_TEST_CASE( start_next_block_after_completion ) {
 
     log.markBlockCommitCompleted( 81, emptyReceipts, 0
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
     BOOST_CHECK( log.isBlockCommitCompleted( 81 ) );
@@ -402,7 +419,8 @@ BOOST_AUTO_TEST_CASE( is_block_commit_started_but_not_completed ) {
 
     log.markBlockCommitCompleted( 99, emptyReceipts, 0
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
     BOOST_CHECK( !log.isBlockCommitStartedButNotCompleted( 99 ) );
@@ -416,7 +434,8 @@ BOOST_AUTO_TEST_CASE( save_load_empty_receipts ) {
     uint64_t timestamp = 1700000000;
     log.markBlockCommitCompleted( 1, emptyReceipts, timestamp
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
 
@@ -442,7 +461,8 @@ BOOST_AUTO_TEST_CASE( save_load_single_receipt ) {
     uint64_t timestamp = 1700000001;
     log.markBlockCommitCompleted( 2, receipts, timestamp
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
 
@@ -473,7 +493,8 @@ BOOST_AUTO_TEST_CASE( save_load_multiple_receipts ) {
     uint64_t timestamp = 1700000002;
     log.markBlockCommitCompleted( 3, receipts, timestamp
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
 
@@ -512,7 +533,8 @@ BOOST_AUTO_TEST_CASE( save_load_receipt_with_logs ) {
     uint64_t timestamp = 1700000003;
     log.markBlockCommitCompleted( 4, receipts, timestamp
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
 
@@ -548,7 +570,8 @@ BOOST_AUTO_TEST_CASE( save_load_receipt_with_revert_reason ) {
     uint64_t timestamp = 1700000004;
     log.markBlockCommitCompleted( 5, receipts, timestamp
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
 
@@ -576,7 +599,8 @@ BOOST_AUTO_TEST_CASE( receipts_persistence_across_instances ) {
         StateProgressLog log( tempDir.path() );
         log.markBlockCommitCompleted( 6, receipts, timestamp
 #ifdef BITE
-                                      , emptyCtxs
+            ,
+            emptyCtxs
 #endif
         );
     }
@@ -619,12 +643,14 @@ BOOST_AUTO_TEST_CASE( receipts_overwrite ) {
     uint64_t timestamp2 = 1700000007;
     log.markBlockCommitCompleted( 7, receipts1, timestamp1
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
     log.markBlockCommitCompleted( 8, receipts2, timestamp2
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
 
@@ -658,7 +684,8 @@ BOOST_AUTO_TEST_CASE( save_load_receipt_bloom_preserved ) {
     uint64_t timestamp = 1700000008;
     log.markBlockCommitCompleted( 9, receipts, timestamp
 #ifdef BITE
-                                  , emptyCtxs
+        ,
+        emptyCtxs
 #endif
     );
 

--- a/test/unittests/libskale/StateProgressLogTest.cpp
+++ b/test/unittests/libskale/StateProgressLogTest.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_SUITE( StateProgressLogSuite )
 
 static const dev::eth::TransactionReceipts emptyReceipts;
 #ifdef BITE
-static const dev::eth::Transactions emptyCtxs;
+static const std::deque< dev::eth::Transaction > emptyCtxs;
 static const dev::eth::Transaction defaultCtx;
 #endif
 
@@ -205,8 +205,7 @@ BOOST_AUTO_TEST_CASE( persistence_started_status ) {
 BOOST_AUTO_TEST_CASE( corrupted_file_content ) {
     dev::TransientDirectory tempDir;
 
-    fs::path progressLogDir =
-        fs::path( tempDir.path() ) / StateProgressLog::PROGRESS_LOG_DIR;
+    fs::path progressLogDir = fs::path( tempDir.path() ) / StateProgressLog::PROGRESS_LOG_DIR;
     fs::create_directories( progressLogDir );
 
     fs::path logFile = progressLogDir / StateProgressLog::PROGRESS_LOG_FILE;
@@ -223,14 +222,11 @@ BOOST_AUTO_TEST_CASE( corrupted_file_content ) {
 BOOST_AUTO_TEST_CASE( empty_file ) {
     dev::TransientDirectory tempDir;
 
-    fs::path progressLogDir =
-        fs::path( tempDir.path() ) / StateProgressLog::PROGRESS_LOG_DIR;
+    fs::path progressLogDir = fs::path( tempDir.path() ) / StateProgressLog::PROGRESS_LOG_DIR;
     fs::create_directories( progressLogDir );
 
     fs::path logFile = progressLogDir / StateProgressLog::PROGRESS_LOG_FILE;
-    {
-        std::ofstream file( logFile.string() );
-    }
+    { std::ofstream file( logFile.string() ); }
 
     StateProgressLog log( tempDir.path() );
     BOOST_CHECK( !log.isBlockCommitCompleted( 0 ) );
@@ -681,11 +677,11 @@ static dev::bytes makeCTXData( const dev::bytes& _payload = {} ) {
     return data;
 }
 
-static dev::eth::Transaction makeSignedCTX(
-    dev::u256 _value, dev::u256 _gasPrice, dev::u256 _gas,
+static dev::eth::Transaction makeSignedCTX( dev::u256 _value, dev::u256 _gasPrice, dev::u256 _gas,
     const dev::Address& _to, const dev::bytes& _payload, dev::u256 _nonce ) {
     dev::Secret secret( "0x1122334455667788112233445566778811223344556677881122334455667788" );
-    return dev::eth::Transaction( _value, _gasPrice, _gas, _to, makeCTXData( _payload ), _nonce, secret );
+    return dev::eth::Transaction(
+        _value, _gasPrice, _gas, _to, makeCTXData( _payload ), _nonce, secret );
 }
 
 BOOST_AUTO_TEST_CASE( save_load_single_ctx ) {
@@ -697,7 +693,7 @@ BOOST_AUTO_TEST_CASE( save_load_single_ctx ) {
     dev::bytes payload = { 0x01, 0x02, 0x03 };
     auto ctx = makeSignedCTX( 1000, 20, 21000, dest, payload, 0 );
 
-    dev::eth::Transactions ctxs = { ctx };
+    std::deque< dev::eth::Transaction > ctxs = { ctx };
 
     uint64_t timestamp = 1700001000;
     log.markBlockCommitCompleted( 100, emptyReceipts, timestamp, ctxs );
@@ -731,7 +727,7 @@ BOOST_AUTO_TEST_CASE( save_load_multiple_ctxs ) {
     auto ctx2 = makeSignedCTX( 200, 20, 42000, dest2, { 0xbb, 0xcc }, 1 );
     auto ctx3 = makeSignedCTX( 300, 30, 63000, dest3, {}, 2 );
 
-    dev::eth::Transactions ctxs = { ctx1, ctx2, ctx3 };
+    std::deque< dev::eth::Transaction > ctxs = { ctx1, ctx2, ctx3 };
 
     uint64_t timestamp = 1700001001;
     log.markBlockCommitCompleted( 101, emptyReceipts, timestamp, ctxs );
@@ -770,7 +766,7 @@ BOOST_AUTO_TEST_CASE( save_load_ctxs_with_receipts ) {
     // Create CTXs
     dev::Address dest( "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" );
     auto ctx = makeSignedCTX( 500, 15, 30000, dest, { 0x01, 0x02 }, 5 );
-    dev::eth::Transactions ctxs = { ctx };
+    std::deque< dev::eth::Transaction > ctxs = { ctx };
 
     uint64_t timestamp = 1700001002;
     log.markBlockCommitCompleted( 102, receipts, timestamp, ctxs );
@@ -813,7 +809,7 @@ BOOST_AUTO_TEST_CASE( ctxs_persistence_across_instances ) {
 
     dev::Address dest( "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" );
     auto ctx = makeSignedCTX( 777, 10, 21000, dest, { 0xde, 0xad }, 42 );
-    dev::eth::Transactions ctxs = { ctx };
+    std::deque< dev::eth::Transaction > ctxs = { ctx };
 
     uint64_t timestamp = 1700001004;
 
@@ -874,7 +870,7 @@ BOOST_AUTO_TEST_CASE( save_load_ctx_with_larger_data ) {
     dev::Address dest( "0xcccccccccccccccccccccccccccccccccccccccc" );
     auto ctx = makeSignedCTX( 0, 100, 100000, dest, largePayload, 99 );
 
-    dev::eth::Transactions ctxs = { ctx };
+    std::deque< dev::eth::Transaction > ctxs = { ctx };
 
     uint64_t timestamp = 1700001007;
     log.markBlockCommitCompleted( 107, emptyReceipts, timestamp, ctxs );
@@ -884,7 +880,8 @@ BOOST_AUTO_TEST_CASE( save_load_ctx_with_larger_data ) {
     BOOST_REQUIRE_EQUAL( loaded->ctxsCreatedInBlock.size(), 1 );
     BOOST_CHECK( loaded->ctxsCreatedInBlock[0].isCTX() );
     BOOST_CHECK( loaded->ctxsCreatedInBlock[0].data() == expectedData );
-    BOOST_CHECK_EQUAL( loaded->ctxsCreatedInBlock[0].data().size(), 1024 + dev::bite::ON_DECRYPT_FUNCTION_SELECTOR_SIZE_BYTES );
+    BOOST_CHECK_EQUAL( loaded->ctxsCreatedInBlock[0].data().size(),
+        1024 + dev::bite::ON_DECRYPT_FUNCTION_SELECTOR_SIZE_BYTES );
 }
 
 BOOST_AUTO_TEST_CASE( save_load_ctx_preserves_gas_fields ) {
@@ -901,7 +898,7 @@ BOOST_AUTO_TEST_CASE( save_load_ctx_preserves_gas_fields ) {
     dev::bytes expectedData = makeCTXData( payload );
 
     auto ctx = makeSignedCTX( value, gasPrice, gas, dest, payload, nonce );
-    dev::eth::Transactions ctxs = { ctx };
+    std::deque< dev::eth::Transaction > ctxs = { ctx };
 
     uint64_t timestamp = 1700001008;
     log.markBlockCommitCompleted( 108, emptyReceipts, timestamp, ctxs );

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -5931,8 +5931,8 @@ BOOST_AUTO_TEST_CASE( submitCTX ) {
     txReceipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
     BOOST_REQUIRE( txReceipt["status"] == "0x1" );
 
-    BOOST_REQUIRE( fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions().size() == 1 );
-    auto bite2Txn = fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions().front();
+    BOOST_REQUIRE( fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions()->size() == 1 );
+    auto bite2Txn = fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions()->front();
     BOOST_REQUIRE( !bite2Txn.isInvalid() );
     BOOST_REQUIRE_NE( bite2Txn.sender(), dev::ZeroAddress );
     auto to = bite2Txn.to();
@@ -5981,7 +5981,7 @@ BOOST_AUTO_TEST_CASE( submitCTX ) {
     txGenerate["from"] = toJS( senderAddress );
     txGenerate["nonce"] = 2;
     std::string txGenerateHash = fixture.rpcClient->eth_sendTransaction( txGenerate );
-    BOOST_REQUIRE_EQUAL( fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions().size(), 1 );
+    BOOST_REQUIRE_EQUAL( fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions()->size(), 1 );
     BOOST_REQUIRE_EQUAL( fixture.client->pending().size(), 1 );
     dev::eth::mineTransaction( *( fixture.client ), 1 );
 
@@ -6059,9 +6059,9 @@ BOOST_AUTO_TEST_CASE( submitCTX ) {
         BOOST_REQUIRE_EQUAL( dev::toHex( rlpPlaintext[i].toBytes() ), dev::toHex( pregeneratedPlaintextValues[i] ) );
     }
 
-    BOOST_REQUIRE_EQUAL( fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions().size(), 1 );
+    BOOST_REQUIRE_EQUAL( fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions()->size(), 1 );
 
-    auto lastBlockCTXs = fixture.client->blockChain().ctxListForPreviousBlock();
+    auto lastBlockCTXs = fixture.client->blockChain().pendingCTXsList();
     BOOST_REQUIRE_EQUAL( lastBlockCTXs.size(), 1 );
     auto ctxFromLastBlock = lastBlockCTXs[0];
     BOOST_REQUIRE( ctxFromLastBlock.isCTX() );
@@ -6155,8 +6155,8 @@ BOOST_AUTO_TEST_CASE( submitCTXInContractConstructor ) {
     BOOST_REQUIRE( txReceipt["status"] == "0x1" );
 
     // BITE2 txn queue should become non-empty
-    BOOST_REQUIRE( fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions().size() == 1 );
-    auto bite2Txn = fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions().front();
+    BOOST_REQUIRE( fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions()->size() == 1 );
+    auto bite2Txn = fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions()->front();
     BOOST_REQUIRE( !bite2Txn.isInvalid() );
     BOOST_REQUIRE_NE( bite2Txn.sender(), dev::ZeroAddress );
     auto to = bite2Txn.to();
@@ -6271,7 +6271,7 @@ BOOST_AUTO_TEST_CASE( CTXTransactionAfterRevert ) {
 
     txReceipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
     BOOST_REQUIRE( txReceipt["status"] == "0x1" );
-    BOOST_REQUIRE_EQUAL( fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions().size(), 1 );
+    BOOST_REQUIRE_EQUAL( fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions()->size(), 1 );
 
 
     // call submitCTXWithRevert()
@@ -6289,7 +6289,7 @@ BOOST_AUTO_TEST_CASE( CTXTransactionAfterRevert ) {
     txReceipt = fixture.rpcClient->eth_getTransactionReceipt( txHash );
     BOOST_REQUIRE( txReceipt["status"] == "0x0" );
 
-    BOOST_REQUIRE_EQUAL( fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions().size(), 0 );
+    BOOST_REQUIRE_EQUAL( fixture.client->debugGetTransactionQueue()->pendingBITE2Transactions()->size(), 0 );
 }
 
 BOOST_AUTO_TEST_CASE( CTXOutOfBlockGasLimit ) {


### PR DESCRIPTION
fixes https://github.com/skalenetwork/internal-support/issues/1430

don't expect all pending CTXs to arrive in the next block
store `pending CTXs` instead of `CTXs created in the last block`
cleanup `BITE2TransactionQueue` logic
