### PR TITLE
2322 Support float percentiles for eth_feeHistory

### DIFF
--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -1040,14 +1040,14 @@ Json::Value Eth::eth_feeHistory( dev::u256 _blockCount, const std::string& _newe
             throw std::runtime_error( "Reward percentiles must be a list" );
 
         for ( auto p : _rewardPercentiles ) {
-            double val;
+            double percentileValue;
             if ( p.isUInt() )
-                val = static_cast< double >( p.asUInt() );
+                percentileValue = static_cast< double >( p.asUInt() );
             else if ( p.isDouble() )
-                val = p.asDouble();
+                percentileValue = p.asDouble();
             else
-                throw std::runtime_error( "Percentiles must be int or float numbers" );
-            if ( val < 0.0 || val > 100.0 )
+                throw std::runtime_error( "Percentiles must be integer or floating-point numbers" );
+            if ( percentileValue < 0.0 || percentileValue > 100.0 )
                 throw std::runtime_error( "Percentiles must be numbers between 0 and 100" );
         }
 

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -1046,7 +1046,7 @@ Json::Value Eth::eth_feeHistory( dev::u256 _blockCount, const std::string& _newe
             else if ( p.isDouble() )
                 val = p.asDouble();
             else
-                throw std::runtime_error( "Percentiles must be numbers between 0 and 100" );
+                throw std::runtime_error( "Percentiles must be int or float numbers" );
             if ( val < 0.0 || val > 100.0 )
                 throw std::runtime_error( "Percentiles must be numbers between 0 and 100" );
         }

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -1040,9 +1040,15 @@ Json::Value Eth::eth_feeHistory( dev::u256 _blockCount, const std::string& _newe
             throw std::runtime_error( "Reward percentiles must be a list" );
 
         for ( auto p : _rewardPercentiles ) {
-            if ( !p.isUInt() || p > 100 ) {
-                throw std::runtime_error( "Percentiles must be positive integers less then 100" );
-            }
+            double val;
+            if ( p.isUInt() )
+                val = static_cast< double >( p.asUInt() );
+            else if ( p.isDouble() )
+                val = p.asDouble();
+            else
+                throw std::runtime_error( "Percentiles must be numbers between 0 and 100" );
+            if ( val < 0.0 || val > 100.0 )
+                throw std::runtime_error( "Percentiles must be numbers between 0 and 100" );
         }
 
         if ( _blockCount > MAX_BLOCK_RANGE )

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -4692,6 +4692,21 @@ BOOST_AUTO_TEST_CASE( eip1559RpcMethods ) {
         }
     }
 
+    Json::Value floatPercentiles = Json::Value( Json::arrayValue );
+    floatPercentiles.resize( 2 );
+    floatPercentiles[0] = 20.5;
+    floatPercentiles[1] = 80.0;
+
+    auto feeHistoryWithFloatPercentiles =
+        fixture.rpcClient->eth_feeHistory( toJS( blockCnt ), "latest", floatPercentiles );
+    BOOST_REQUIRE( feeHistoryWithFloatPercentiles.isMember( "reward" ) );
+    BOOST_REQUIRE( feeHistoryWithFloatPercentiles["reward"].isArray() );
+    for ( Json::Value::ArrayIndex i = 0; i < blockCnt; ++i ) {
+        BOOST_REQUIRE( feeHistoryWithFloatPercentiles["reward"][i].isArray() );
+        BOOST_REQUIRE_EQUAL(
+            feeHistoryWithFloatPercentiles["reward"][i].size(), floatPercentiles.size() );
+    }
+
     BOOST_REQUIRE_NO_THROW( fixture.rpcClient->eth_feeHistory( blockCnt, "latest", percentiles ) );
 }
 


### PR DESCRIPTION
## Description

Added support for float values for eth_feeHistory. Fixes https://github.com/skalenetwork/skaled/issues/2322

## Tests

- Tested using cast with no `--legacy` flag
- Added test case 
## Performance Impact

- No performance related changes were made