### PR TITLE
Bug/2442 readonly contract deployment

### DIFF
--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -476,16 +476,20 @@ bool Executive::executeCreate( Address const& _sender, u256 const& _endowment,
     m_s.clearStorage( m_newAddress );
 
     // Schedule _init execution if not empty.
-    if ( !_init.empty() )
+    if ( !_init.empty() ) {
+        bool isReadOnly =
+            ContractCreationReadOnlyPatch::isEnabledWhen( m_envInfo.committedBlockTimestamp() ) ?
+                m_readOnly :
+                true;
         m_ext = make_shared< ExtVM >(
             m_s, m_envInfo, m_chainParams, m_newAddress, _sender, _origin, _endowment, _gasPrice,
-            bytesConstRef(), _init, sha3( _init ), _version, m_depth, true, false
+            bytesConstRef(), _init, sha3( _init ), _version, m_depth, true, false, isReadOnly
 #ifdef BITE2
             ,
-            true, m_txnIndex
+            m_txnIndex
 #endif
         );
-    else
+    } else
         // code stays empty, but we set the version
         m_s.setCode( m_newAddress, {}, _version );
 

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -157,7 +157,7 @@ void ExtVM::setStore( u256 _n, u256 _v ) {
 
 CreateResult ExtVM::create( u256 _endowment, u256& io_gas, bytesConstRef _code, Instruction _op,
     u256 _salt, OnOpFunc const& _onOp ) {
-        bool isReadOnly =
+    bool isReadOnly =
         ContractCreationReadOnlyPatch::isEnabledWhen( envInfo().committedBlockTimestamp() ) ?
             m_readOnly :
             true;

--- a/libethereum/ExtVM.cpp
+++ b/libethereum/ExtVM.cpp
@@ -28,9 +28,7 @@
 #include <boost/thread.hpp>
 
 #include "LastBlockHashesFace.h"
-#ifdef FAIR
 #include "SchainPatch.h"
-#endif
 
 using namespace dev;
 using namespace dev::eth;
@@ -159,10 +157,14 @@ void ExtVM::setStore( u256 _n, u256 _v ) {
 
 CreateResult ExtVM::create( u256 _endowment, u256& io_gas, bytesConstRef _code, Instruction _op,
     u256 _salt, OnOpFunc const& _onOp ) {
-    Executive e{ m_s, envInfo(), m_chainParams, 0, depth + 1
+        bool isReadOnly =
+        ContractCreationReadOnlyPatch::isEnabledWhen( envInfo().committedBlockTimestamp() ) ?
+            m_readOnly :
+            true;
+    Executive e{ m_s, envInfo(), m_chainParams, 0, depth + 1, isReadOnly
 #ifdef BITE2
         ,
-        true, m_txnIndex
+        m_txnIndex
 #endif
     };
     bool result = false;

--- a/libethereum/SchainPatch.cpp
+++ b/libethereum/SchainPatch.cpp
@@ -48,6 +48,8 @@ SchainPatchEnum getEnumForPatchName( const std::string& _patchName ) {
         return SchainPatchEnum::CurrentBlockRandomPatch;
     else if ( _patchName == "GroupIndexInitPatch" )
         return SchainPatchEnum::GroupIndexInitPatch;
+    else if ( _patchName == "ContractCreationReadOnlyPatch" )
+        return SchainPatchEnum::ContractCreationReadOnlyPatch;
 #ifdef FAIR
     else if ( _patchName == "DisableSelfDestructPatch" )
         return SchainPatchEnum::DisableSelfDestructPatch;
@@ -98,6 +100,8 @@ std::string getPatchNameForEnum( SchainPatchEnum _enumValue ) {
         return "CurrentBlockRandomPatch";
     case SchainPatchEnum::GroupIndexInitPatch:
         return "GroupIndexInitPatch";
+    case SchainPatchEnum::ContractCreationReadOnlyPatch:
+        return "ContractCreationReadOnlyPatch";
 #ifdef FAIR
     case SchainPatchEnum::DisableSelfDestructPatch:
         return "DisableSelfDestructPatch";

--- a/libethereum/SchainPatch.h
+++ b/libethereum/SchainPatch.h
@@ -190,6 +190,8 @@ DEFINE_AMNESIC_PATCH( GroupIndexInitPatch );
  */
 DEFINE_SIMPLE_PATCH( SingleStateCommitPerBlockPatch );
 
+DEFINE_SIMPLE_PATCH( ContractCreationReadOnlyPatch );
+
 #ifdef FAIR
 DEFINE_SIMPLE_PATCH( DisableSelfDestructPatch );
 #endif

--- a/libethereum/SchainPatchEnum.h
+++ b/libethereum/SchainPatchEnum.h
@@ -25,6 +25,7 @@ enum class SchainPatchEnum {
     InvalidTransactionFormatPatch,
     CurrentBlockRandomPatch,
     GroupIndexInitPatch,
+    ContractCreationReadOnlyPatch,
 #ifdef FAIR
     DisableSelfDestructPatch,
 #endif


### PR DESCRIPTION
fixes #2442 ing c

fix how `m_readOnly` flag is set during contract deployment
EXTVM was always initialized with readOnly=true for contract creation, which lead to partially incorrect behavior when interacting with precompiled contracts.

introduce `ContractCreationReadOnlyPatch` to fix incorrect EVM behavior during contract deployment

tested on local by machine by deploying contract whose constructor calls `submitCTX` precompiled