### PR TITLE
Bug/2459 wrong crafted ctxs

### DIFF
--- a/.github/actions/testeth-run/action.yml
+++ b/.github/actions/testeth-run/action.yml
@@ -9,6 +9,10 @@ inputs:
   verbosity:
     required: true
     description: "1 | 4"
+  bite2_suites:
+    required: false
+    default: "false"
+    description: "include BITE2TransactionQueueSuite (true | false)"
 
 runs:
   using: composite
@@ -43,6 +47,10 @@ runs:
           SnapshotSigningTestSuite SkUtils BlockChainTestSuite TestHelperSuite LevelDBHashBase
           memDB OverlayDBTests AccountHolderTest ClientTests JsonRpcSuite SingleConsensusTests ConsensusTests
         )
+
+        if [[ "${{ inputs.bite2_suites }}" == "true" ]]; then
+          TEST_SUITES+=(BITE2TransactionQueueSuite)
+        fi
 
         if [[ "${{ inputs.verbosity }}" == "1" ]]; then
           mkdir -p /tmp/tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
             build_dir: build
             cmake_args: "-DFAIR=1"
             mode: full
+            bite2_suites: "true"
 
           - name: FAIR-historic
             build_dir: build
@@ -53,6 +54,7 @@ jobs:
             build_dir: build
             cmake_args: "-DBITE=1"
             mode: full
+            bite2_suites: "true"
 
           - name: BITE-historic
             build_dir: build
@@ -105,6 +107,7 @@ jobs:
           build_dir: ${{ matrix.build_dir }}
           mode: ${{ matrix.mode }}
           verbosity: "1"
+          bite2_suites: ${{ matrix.bite2_suites || 'false' }}
 
       - name: Testeth verbosity 4
         uses: ./.github/actions/testeth-run
@@ -112,3 +115,4 @@ jobs:
           build_dir: ${{ matrix.build_dir }}
           mode: ${{ matrix.mode }}
           verbosity: "4"
+          bite2_suites: ${{ matrix.bite2_suites || 'false' }}

--- a/libethcore/TransactionBase.cpp
+++ b/libethcore/TransactionBase.cpp
@@ -591,7 +591,7 @@ int64_t TransactionBase::baseGasRequired(
 #endif
 
 #ifdef BITE
-    // BITE transaction - charge for every encrypted payload
+    // BITE2 transaction - charge for every encrypted payload
     if ( _bite2EncryptedArgsSize.has_value() ) {
         // Check for multiplication overflow
         if ( _bite2EncryptedArgsSize.value() > 0 &&

--- a/libethereum/BITE2TransactionQueue.cpp
+++ b/libethereum/BITE2TransactionQueue.cpp
@@ -60,11 +60,11 @@ std::vector< h256 > BITE2TransactionQueue::getTempHashes() const {
         return res;
     }
 
-    if ( m_currentHeadIndex == m_current->size() )
+    if ( m_currentHeadIndex == m_current->size() - 1 )
         return {};
 
     std::vector< h256 > res;
-    res.reserve( m_current->size() - m_currentHeadIndex );
+    res.reserve( m_current->size() - 1 - m_currentHeadIndex );
     // m_currentHeadIndex always points to the last committed CTX,
     // so we return hashes of all CTXs starting after m_currentHeadIndex
     for ( size_t i = m_currentHeadIndex + 1; i < m_current->size(); ++i ) {

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -686,9 +686,6 @@ std::optional< TransactionReceipt > Block::executeSingleTransaction( BlockChain 
     } else {
         // get list of CTX hashes created by current txn
         m_ctxHashesLists[_txIndex] = g_skaleHost->getBITE2HashesForCurrentTxn();
-        for ( const auto& hash : m_ctxHashesLists[_txIndex] ) {
-            BOOST_LOG( m_loggerError ) << hash.hex();
-        }
         // commit CTXs from temporary to permanent
         g_skaleHost->commitTempBITE2Transactions();
     }

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -128,7 +128,12 @@ Block::Block( Block const& _s )
       m_currentBlock( _s.m_currentBlock ),
       m_currentBytes( _s.m_currentBytes ),
       m_author( _s.m_author ),
-      m_sealEngine( _s.m_sealEngine ) {
+      m_sealEngine( _s.m_sealEngine )
+#ifdef BITE
+      ,
+      m_ctxHashesLists( _s.m_ctxHashesLists )
+#endif
+{
     m_committedToSeal = false;
 }
 
@@ -145,6 +150,10 @@ Block& Block::operator=( Block const& _s ) {
     m_currentBytes = _s.m_currentBytes;
     m_author = _s.m_author;
     m_sealEngine = _s.m_sealEngine;
+
+#ifdef BITE
+    m_ctxHashesLists = _s.m_ctxHashesLists;
+#endif
 
     m_precommit = m_state;
     m_committedToSeal = false;
@@ -173,6 +182,9 @@ void Block::resetCurrent( int64_t _timestamp ) {
     m_transactions.clear();
     m_receipts.clear();
     m_transactionSet.clear();
+#ifdef BITE
+    m_ctxHashesLists.clear();
+#endif
     m_currentBlock = BlockHeader();
     m_currentBlock.setAuthor( m_author );
     m_currentBlock.setTimestamp( _timestamp );  // max( m_previousBlock.timestamp() + 1, _timestamp
@@ -674,6 +686,9 @@ std::optional< TransactionReceipt > Block::executeSingleTransaction( BlockChain 
     } else {
         // get list of CTX hashes created by current txn
         m_ctxHashesLists[_txIndex] = g_skaleHost->getBITE2HashesForCurrentTxn();
+        for ( const auto& hash : m_ctxHashesLists[_txIndex] ) {
+            BOOST_LOG( m_loggerError ) << hash.hex();
+        }
         // commit CTXs from temporary to permanent
         g_skaleHost->commitTempBITE2Transactions();
     }

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -331,7 +331,7 @@ public:
 
     const DecryptedTransactions& decryptedTransactions() const { return m_decryptedTransactions; }
 
-    const std::vector< std::vector< dev::h256 > > ctxHashesLists() const {
+    const std::vector< std::vector< dev::h256 > >& ctxHashesLists() const {
         return m_ctxHashesLists;
     }
 

--- a/libethereum/Precompiled.cpp
+++ b/libethereum/Precompiled.cpp
@@ -1260,12 +1260,12 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
         bigint const dataOffset( parseBigEndianRightPadded( _in, 0, headFieldSizeBytes ) );
         const size_t expectedDataOffset = 32;
         if ( dataOffset != expectedDataOffset ) {
-            return { false, toBigEndian( dev::u256( 5 ) ) };  // error 5: invalid data offset
+            return { false, toBigEndian( dev::u256( 4 ) ) };  // error 4: invalid data offset
         }
 
         // Read data length at the data offset (position 32)
         if ( _in.size() < expectedDataOffset + headFieldSizeBytes ) {
-            return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: data length mismatch
+            return { false, toBigEndian( dev::u256( 5 ) ) };  // error 5: data length mismatch
         }
         bigint const dataLength(
             parseBigEndianRightPadded( _in, expectedDataOffset, headFieldSizeBytes ) );
@@ -1274,14 +1274,14 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
         // Header is 64 bytes (offset + length field), so max data = MAX_SIZE_BYTES - 64
         static constexpr size_t HEADER_SIZE_BYTES = 64;
         if ( dataLength < 0 || dataLength > MAX_SIZE_BYTES - HEADER_SIZE_BYTES ) {
-            return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: data length mismatch
+            return { false, toBigEndian( dev::u256( 5 ) ) };  // error 5: data length mismatch
         }
         size_t dataLengthSafe = static_cast< size_t >( dataLength );
 
         // Calculate data start position and validate bounds
         size_t dataStart = expectedDataOffset + headFieldSizeBytes;
         if ( dataStart + dataLengthSafe > _in.size() ) {
-            return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: data length mismatch
+            return { false, toBigEndian( dev::u256( 5 ) ) };  // error 5: data length mismatch
         }
 
         // Extract data bytes (empty data is allowed)
@@ -1291,7 +1291,7 @@ ETH_REGISTER_PRECOMPILED( encryptTE )
         size_t dataEnd = dataStart + dataLengthSafe;
         if ( !std::all_of( _in.data() + dataEnd, _in.data() + _in.size(),
                  []( uint8_t b ) { return b == 0; } ) ) {
-            return { false, toBigEndian( dev::u256( 7 ) ) };  // error 7: trailing padding not zeros
+            return { false, toBigEndian( dev::u256( 6 ) ) };  // error 6: trailing padding not zeros
         }
 
         std::vector< libBLS::TEPublicKey > publicKeys;

--- a/test/unittests/libethereum/BITE2TransactionQueue.cpp
+++ b/test/unittests/libethereum/BITE2TransactionQueue.cpp
@@ -69,10 +69,18 @@ BOOST_AUTO_TEST_CASE( addCommitClear ) {
 
 BOOST_AUTO_TEST_CASE( tempHashes ) {
     BITE2TransactionQueue queue;
+
+    bytes ctxData;
+    ctxData.insert( ctxData.end(), std::begin( BITE2_FUNCTION_SELECTOR_AS_BYTE_ARRAY ),
+        std::end( BITE2_FUNCTION_SELECTOR_AS_BYTE_ARRAY ) );
+
     Secret sec = Secret( "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8" );
     Transaction tx1( 0, 100, 21000, Address(), bytes(), 10, sec );
+    tx1.checkIfCTXAndSet( ctxData );
     Transaction tx2( 1, 100, 21000, Address(), bytes(), 10, sec );
+    tx2.checkIfCTXAndSet( ctxData );
     Transaction tx3( 2, 100, 21000, Address(), bytes(), 10, sec );
+    tx3.checkIfCTXAndSet( ctxData );
 
     queue.addTemp( Transaction( tx1 ) );
 
@@ -133,7 +141,7 @@ BOOST_AUTO_TEST_CASE( dropGood ) {
     BOOST_REQUIRE( queue.dropGood( txCtx ) );
     BOOST_REQUIRE( queue.dropGood( txCtx2 ) );
 
-    queue.addTemp( Transaction( txNormal ) );
+    BOOST_REQUIRE_THROW( queue.addTemp( Transaction( txNormal ) ), std::invalid_argument );
     queue.commitTemp();
 
     BOOST_REQUIRE( !queue.dropGood( txNormal ) );

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -2080,7 +2080,7 @@ BOOST_AUTO_TEST_CASE( encryptTE_invalidABIEncoding ) {
 
     // Verify failure with error code 5 (invalid data offset)
     BOOST_REQUIRE( !res.first );
-    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 5 ) ) );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 4 ) ) );
 }
 
 BOOST_AUTO_TEST_CASE( encryptTE_dataLengthMismatch ) {
@@ -2100,7 +2100,7 @@ BOOST_AUTO_TEST_CASE( encryptTE_dataLengthMismatch ) {
 
     // Verify failure with error code 6 (data length mismatch)
     BOOST_REQUIRE( !res.first );
-    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 6 ) ) );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 5 ) ) );
 }
 
 BOOST_AUTO_TEST_CASE( encryptTE_trailingPaddingNotZeros ) {
@@ -2123,7 +2123,7 @@ BOOST_AUTO_TEST_CASE( encryptTE_trailingPaddingNotZeros ) {
 
     // Verify failure with error code 7 (trailing padding not zeros)
     BOOST_REQUIRE( !res.first );
-    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 7 ) ) );
+    BOOST_REQUIRE( res.second == toBigEndian( dev::u256( 6 ) ) );
 }
 
 BOOST_AUTO_TEST_CASE( encryptTE_counter_reset_on_new_block ) {


### PR DESCRIPTION
fixes #2459

1. add `BITE2TransactionQueueSuite` to tests for `BITE` and `FAIR` builds, fixed bugs that were missed due to the lack of tests
2. fix how `m_ctxHashesList` is passed from parent block to child block - before this value was never cleaned so it contained old entries

tested on local machine by submit invalid CTX that failed during `AES` decryption stage