### PR TITLE
Bug/invalid ctx for sync node

### DIFF
--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -325,7 +325,9 @@ SkaleHost::SkaleHost( dev::eth::Client& _client, const ConsensusFactory* _consFa
         m_extFace.reset( new ConsensusExtImpl( *this ) );
 
 #ifdef BITE
-        dev::bite::isCiphertextValidationEnabled = _client.chainParams().isSyncNode() ? !_client.chainParams().isTestSignaturesEnabled() : !_client.chainParams().getSgxServerUrl().empty();
+        dev::bite::isCiphertextValidationEnabled =
+            _client.chainParams().isSyncNode() ? !_client.chainParams().isTestSignaturesEnabled() :
+                                                 !_client.chainParams().getSgxServerUrl().empty();
 #endif
 
     } catch ( const std::exception& e ) {

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -325,7 +325,7 @@ SkaleHost::SkaleHost( dev::eth::Client& _client, const ConsensusFactory* _consFa
         m_extFace.reset( new ConsensusExtImpl( *this ) );
 
 #ifdef BITE
-        dev::bite::isCiphertextValidationEnabled = !_client.chainParams().getSgxServerUrl().empty();
+        dev::bite::isCiphertextValidationEnabled = _client.chainParams().isSyncNode() ? !_client.chainParams().isTestSignaturesEnabled() : !_client.chainParams().getSgxServerUrl().empty();
 #endif
 
     } catch ( const std::exception& e ) {


### PR DESCRIPTION
fixes #2390 

add ctx validation for sync (sync, indexer, archive) nodes for real signatures setup as sgx is missing for sync nodes
