### PR TITLE
#1917 init prev block on historic call

### DIFF
--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -116,7 +116,14 @@ Block::Block( const BlockChain& _bc, h256 const& _hash, const State& _state, Bas
         //            BaseState::Empty);  // TODO: try with PreExisting.
         sync( _bc, _hash, bi );
     } else {
-        auto pb = _bc.block( bi.parentHash() );
+        auto parentHash = bi.parentHash();
+        if ( !_bc.isKnown( parentHash ) ) {
+            // Might be worth throwing here.
+            BOOST_LOG( m_loggerWarning )
+                << "Invalid parent hash given for population " << parentHash;
+            BOOST_THROW_EXCEPTION( BlockNotFound() << errinfo_target( parentHash ) );
+        }
+        auto pb = _bc.block( parentHash );
         m_previousBlock = BlockHeader( pb );
     }
 }

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -115,6 +115,9 @@ Block::Block( const BlockChain& _bc, h256 const& _hash, const State& _state, Bas
         //        m_state = State(m_state.accountStartNonce(), m_state.db(),
         //            BaseState::Empty);  // TODO: try with PreExisting.
         sync( _bc, _hash, bi );
+    } else {
+        auto pb = _bc.block( bi.parentHash() );
+        m_previousBlock = BlockHeader( pb );
     }
 }
 
@@ -1088,7 +1091,6 @@ ExecutionResult Block::executeHistoricCall( LastBlockHashesFace const& _lh, Tran
         if ( _tracer ) {
             onOp = _tracer->functionToExecuteOnEachOperation();
         }
-
 
         if ( isSealed() )
             BOOST_THROW_EXCEPTION( InvalidOperationOnSealedBlock() );

--- a/libethereum/ExtVM.h
+++ b/libethereum/ExtVM.h
@@ -119,9 +119,6 @@ private:
         // Otherwise run with the latest schedule known to correspond to the _version.
         EVMSchedule currentBlockSchedule = m_chainParams.makeEvmSchedule(
             envInfo().committedBlockTimestamp(), envInfo().number() );
-        std::cout << "ACCOUNT VERSION: " << currentBlockSchedule.accountVersion
-                  << " : INCOMING VERSION: " << _version << '\n';
-        std::cout << "PUSH0 FROM BASE: " << currentBlockSchedule.havePush0 << '\n';
         if ( currentBlockSchedule.accountVersion == _version )
             return currentBlockSchedule;
         else

--- a/libethereum/ExtVM.h
+++ b/libethereum/ExtVM.h
@@ -119,6 +119,9 @@ private:
         // Otherwise run with the latest schedule known to correspond to the _version.
         EVMSchedule currentBlockSchedule = m_chainParams.makeEvmSchedule(
             envInfo().committedBlockTimestamp(), envInfo().number() );
+        std::cout << "ACCOUNT VERSION: " << currentBlockSchedule.accountVersion
+                  << " : INCOMING VERSION: " << _version << '\n';
+        std::cout << "PUSH0 FROM BASE: " << currentBlockSchedule.havePush0 << '\n';
         if ( currentBlockSchedule.accountVersion == _version )
             return currentBlockSchedule;
         else


### PR DESCRIPTION
fixes https://github.com/skalenetwork/skaled/issues/1917 https://github.com/skalenetwork/internal-support/issues/1420

add proper `m_previousBlock` initialization in `Block` constructor

verified on local machine