### PR TITLE
Bug/1621 tx dropped silently when ctq full

### DIFF
--- a/libethcore/Common.h
+++ b/libethcore/Common.h
@@ -127,7 +127,8 @@ enum class ImportResult {
     Malformed,
     SameNonceAlreadyInQueue,
     BadChain,
-    ZeroSignature
+    ZeroSignature,
+    QueueIsFull
 };
 
 struct ImportRequirements {

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -88,6 +88,7 @@ DEV_SIMPLE_EXCEPTION( PreEIP155LegacyTransactionNotAllowed );
 DEV_SIMPLE_EXCEPTION( PreEIP155ReplayProtectionViolation );
 DEV_SIMPLE_EXCEPTION( PendingTransactionAlreadyExists );
 DEV_SIMPLE_EXCEPTION( TransactionAlreadyInChain );
+DEV_SIMPLE_EXCEPTION( TransactionQueueIsFull );
 DEV_SIMPLE_EXCEPTION( BlockNotFound );
 DEV_SIMPLE_EXCEPTION( UnknownParent );
 DEV_SIMPLE_EXCEPTION( AddressAlreadyUsed );

--- a/libethereum/BITE2TransactionQueue.cpp
+++ b/libethereum/BITE2TransactionQueue.cpp
@@ -140,4 +140,27 @@ std::vector< dev::h256 > BITE2TransactionQueue::getNCTXOrigins( size_t _n ) cons
     return res;
 }
 
+std::optional< std::vector< dev::h256 > >
+BITE2TransactionQueue::validateNextExpectedCTXsAndGetOrigins(
+    std::vector< Transaction > const& _ctxs ) const {
+    ReadGuard l( m_lock );
+    if ( !m_current || _ctxs.size() > m_current->size() )
+        return std::nullopt;
+
+    std::vector< dev::h256 > origins;
+    origins.reserve( _ctxs.size() );
+
+    // advance pending CTXs 1 by 1 & check that they match the provided CTXs
+    auto pending = m_current->begin();
+    for ( auto const& ctx : _ctxs ) {
+        if ( !ctx.isCTX() || ctx.sha3() != pending->sha3() )
+            return std::nullopt;
+
+        origins.push_back( pending->getCTXOrigin() );
+        ++pending;
+    }
+
+    return origins;
+}
+
 #endif  // BITE

--- a/libethereum/BITE2TransactionQueue.h
+++ b/libethereum/BITE2TransactionQueue.h
@@ -27,6 +27,7 @@
 #include <libdevcore/Log.h>
 
 #include <deque>
+#include <optional>
 
 namespace dev {
 namespace eth {
@@ -60,6 +61,10 @@ public:
     void setQueueOnInit( std::deque< Transaction >&& _ctxQueue );
 
     std::vector< dev::h256 > getNCTXOrigins( size_t _n ) const;
+
+    /// Verifies _ctxs exactly match the next expected pending CTXs and returns their origins.
+    std::optional< std::vector< dev::h256 > > validateNextExpectedCTXsAndGetOrigins(
+        std::vector< Transaction > const& _ctxs ) const;
 
 private:
     std::shared_ptr< std::deque< Transaction > > m_current =

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -529,8 +529,8 @@ tuple< TransactionReceipts, unsigned, Transactions > Block::syncEveryone( BlockC
         saveStateChanges( _bc, _transactions, context );
     }
 
-    return make_tuple(
-        context.receipts, context.receipts.size() - context.badCount, context.executedTransactions );
+    return make_tuple( context.receipts, context.receipts.size() - context.badCount,
+        context.executedTransactions );
 }
 
 std::pair< TransactionReceipts, unsigned > Block::recoverFromReceipts(

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -70,6 +70,26 @@ public:
     void clear() override {}
 };
 
+bool transactionWasConsumed( ExecutionResult const& _res ) {
+    return _res.excepted != TransactionException::WouldNotBeInBlock;
+}
+
+bool receiptAdvancedGas( TransactionReceipt const& _receipt, u256 const& _previousCumulativeGas ) {
+    return _receipt.cumulativeGasUsed() != _previousCumulativeGas;
+}
+
+bool notifyConsumedTransactions( Block::OnTransactionConsumed const& _onTransactionConsumed,
+    Transactions const& _transactions ) {
+    if ( !_onTransactionConsumed )
+        return false;
+
+    bool needsQueueReadyNotification = false;
+    for ( auto const& tx : _transactions )
+        needsQueueReadyNotification =
+            _onTransactionConsumed( tx ) || needsQueueReadyNotification;
+    return needsQueueReadyNotification;
+}
+
 }  // namespace
 
 Block::Block( BlockChain const& _bc, boost::filesystem::path const& _dbPath,
@@ -506,8 +526,9 @@ void Block::sanityCheckPartialTransactionReceipts( std::optional< BlockNumber > 
     }
 }
 
-tuple< TransactionReceipts, unsigned, Transactions > Block::syncEveryone( BlockChain const& _bc,
-    const Transactions& _transactions, uint64_t _timestamp, u256 _gasPrice ) {
+tuple< TransactionReceipts, unsigned, bool > Block::syncEveryone( BlockChain const& _bc,
+    const Transactions& _transactions, uint64_t _timestamp, u256 _gasPrice,
+    OnTransactionConsumed const& _onTransactionConsumed ) {
     if ( isSealed() )
         BOOST_THROW_EXCEPTION( InvalidOperationOnSealedBlock() );
 
@@ -519,18 +540,37 @@ tuple< TransactionReceipts, unsigned, Transactions > Block::syncEveryone( BlockC
 
     if ( context.singleCommitEnabled && isCurrentBlockCommitted() ) {
         auto recovered = recoverFromReceipts( _transactions, _timestamp );
-        return make_tuple( recovered.first, recovered.second, Transactions() );
+        bool needsQueueReadyNotification = false;
+        Transactions queueCleanupTransactions;
+        u256 cumulativeGas = 0;
+        for ( unsigned i = 0; i < recovered.first.size() && i < _transactions.size(); ++i ) {
+            if ( receiptAdvancedGas( recovered.first[i], cumulativeGas ) ) {
+#ifdef BITE
+                // recoverFromReceipts() restored the post-block BITE queue from the progress log,
+                // so consumed CTXs are already absent. Only clean regular queues here.
+                if ( !_transactions[i].isCTX() )
+#endif
+                queueCleanupTransactions.push_back( _transactions[i] );
+            }
+            cumulativeGas = recovered.first[i].cumulativeGasUsed();
+        }
+        needsQueueReadyNotification =
+            notifyConsumedTransactions( _onTransactionConsumed, queueCleanupTransactions );
+#ifdef BITE
+        m_pendingCtxs = g_skaleHost->pendingBITE2Transactions();
+#endif
+        return make_tuple( recovered.first, recovered.second, needsQueueReadyNotification );
     }
 
     prepareStateForSync( _timestamp, context );
-    executeTransactions( _bc, _transactions, _gasPrice, context );
+    executeTransactions( _bc, _transactions, _gasPrice, context, _onTransactionConsumed );
 
     if ( !context.singleCommitEnabled || !isCurrentBlockCommitted() ) {
         saveStateChanges( _bc, _transactions, context );
     }
 
     return make_tuple( context.receipts, context.receipts.size() - context.badCount,
-        context.executedTransactions );
+        context.needsQueueReadyNotification );
 }
 
 std::pair< TransactionReceipts, unsigned > Block::recoverFromReceipts(
@@ -613,7 +653,7 @@ void Block::prepareStateForSync( uint64_t _timestamp, SyncContext& _context ) {
 }
 
 void Block::executeTransactions( BlockChain const& _bc, const Transactions& _transactions,
-    u256 _gasPrice, SyncContext& _context ) {
+    u256 _gasPrice, SyncContext& _context, OnTransactionConsumed const& _onTransactionConsumed ) {
     const Permanence permanence =
         _context.singleCommitEnabled ? Permanence::BlockCommitted : Permanence::Committed;
 
@@ -632,7 +672,10 @@ void Block::executeTransactions( BlockChain const& _bc, const Transactions& _tra
                 // multiple commits mode
                 m_transactions.push_back( tr );
                 m_transactionSet.insert( tr.sha3() );
-                _context.executedTransactions.push_back( tr );
+                u256 previousCumulativeGas =
+                    i == 0 ? 0 : savedReceipts[i - 1].cumulativeGasUsed();
+                if ( receiptAdvancedGas( savedReceipts[i], previousCumulativeGas ) )
+                    _context.queueCleanupTransactions.push_back( tr );
                 continue;
             }
 
@@ -650,6 +693,10 @@ void Block::executeTransactions( BlockChain const& _bc, const Transactions& _tra
             BOOST_LOG( m_loggerError ) << "FAILED transaction after consensus! " << ex.what();
         }
     }
+
+    _context.needsQueueReadyNotification =
+        notifyConsumedTransactions( _onTransactionConsumed, _context.queueCleanupTransactions ) ||
+        _context.needsQueueReadyNotification;
 #ifdef BITE
     // finalize BITE2 queue after executing all txns from current block
     m_pendingCtxs = g_skaleHost->pendingBITE2Transactions();
@@ -690,8 +737,6 @@ std::optional< TransactionReceipt > Block::executeSingleTransaction( BlockChain 
     }
 
     ExecutionResult res = execute( _bc.lastBlockHashes(), _tx, _permanence, OnOpFunc(), _txIndex );
-    if ( res.excepted != TransactionException::WouldNotBeInBlock )
-        _context.executedTransactions.push_back( _tx );
 
 #ifdef BITE
     if ( res.excepted != TransactionException::None ) {
@@ -705,6 +750,9 @@ std::optional< TransactionReceipt > Block::executeSingleTransaction( BlockChain 
         g_skaleHost->commitTempBITE2Transactions();
     }
 #endif
+
+    if ( transactionWasConsumed( res ) )
+        _context.queueCleanupTransactions.push_back( _tx );
 
     if ( !_context.singleCommitEnabled && !m_receipts.empty() &&
          !ClearPartialReceiptsPatch::isEnabledWhen( m_previousBlock.timestamp() ) ) {

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -70,8 +70,19 @@ public:
     void clear() override {}
 };
 
-bool transactionWasConsumed( ExecutionResult const& _res ) {
-    return _res.excepted != TransactionException::WouldNotBeInBlock;
+bool shouldKeepRejectedTransactionQueued( Transaction const& _tx, State const& _state ) {
+    if ( _tx.isInvalid() || !_tx.hasSignature() || _tx.hasZeroSignature() )
+        return false;
+
+    return _tx.nonce() > _state.getNonce( _tx.safeSender() );
+}
+
+bool transactionNeedsQueueCleanup(
+    Transaction const& _tx, ExecutionResult const& _res, State const& _state ) {
+    if ( _res.excepted != TransactionException::WouldNotBeInBlock )
+        return true;
+
+    return !shouldKeepRejectedTransactionQueued( _tx, _state );
 }
 
 bool receiptAdvancedGas( TransactionReceipt const& _receipt, u256 const& _previousCumulativeGas ) {
@@ -729,8 +740,12 @@ std::optional< TransactionReceipt > Block::executeSingleTransaction( BlockChain 
                     nullReceipt.rlp(), info().number(), _txIndex );
             }
             ++_context.badCount;
+            if ( !shouldKeepRejectedTransactionQueued( _tx, m_state ) )
+                _context.queueCleanupTransactions.push_back( _tx );
             return nullReceipt;
         }
+        if ( !shouldKeepRejectedTransactionQueued( _tx, m_state ) )
+            _context.queueCleanupTransactions.push_back( _tx );
         return std::nullopt;
     }
 
@@ -749,7 +764,7 @@ std::optional< TransactionReceipt > Block::executeSingleTransaction( BlockChain 
     }
 #endif
 
-    if ( transactionWasConsumed( res ) )
+    if ( transactionNeedsQueueCleanup( _tx, res, m_state ) )
         _context.queueCleanupTransactions.push_back( _tx );
 
     if ( !_context.singleCommitEnabled && !m_receipts.empty() &&

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -85,8 +85,7 @@ bool notifyConsumedTransactions( Block::OnTransactionConsumed const& _onTransact
 
     bool needsQueueReadyNotification = false;
     for ( auto const& tx : _transactions )
-        needsQueueReadyNotification =
-            _onTransactionConsumed( tx ) || needsQueueReadyNotification;
+        needsQueueReadyNotification = _onTransactionConsumed( tx ) || needsQueueReadyNotification;
     return needsQueueReadyNotification;
 }
 
@@ -550,7 +549,7 @@ tuple< TransactionReceipts, unsigned, bool > Block::syncEveryone( BlockChain con
                 // so consumed CTXs are already absent. Only clean regular queues here.
                 if ( !_transactions[i].isCTX() )
 #endif
-                queueCleanupTransactions.push_back( _transactions[i] );
+                    queueCleanupTransactions.push_back( _transactions[i] );
             }
             cumulativeGas = recovered.first[i].cumulativeGasUsed();
         }
@@ -672,8 +671,7 @@ void Block::executeTransactions( BlockChain const& _bc, const Transactions& _tra
                 // multiple commits mode
                 m_transactions.push_back( tr );
                 m_transactionSet.insert( tr.sha3() );
-                u256 previousCumulativeGas =
-                    i == 0 ? 0 : savedReceipts[i - 1].cumulativeGasUsed();
+                u256 previousCumulativeGas = i == 0 ? 0 : savedReceipts[i - 1].cumulativeGasUsed();
                 if ( receiptAdvancedGas( savedReceipts[i], previousCumulativeGas ) )
                     _context.queueCleanupTransactions.push_back( tr );
                 continue;

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -506,7 +506,7 @@ void Block::sanityCheckPartialTransactionReceipts( std::optional< BlockNumber > 
     }
 }
 
-tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _bc,
+tuple< TransactionReceipts, unsigned, Transactions > Block::syncEveryone( BlockChain const& _bc,
     const Transactions& _transactions, uint64_t _timestamp, u256 _gasPrice ) {
     if ( isSealed() )
         BOOST_THROW_EXCEPTION( InvalidOperationOnSealedBlock() );
@@ -518,7 +518,8 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
     context.singleCommitEnabled = SingleStateCommitPerBlockPatch::isEnabledInWorkingBlock();
 
     if ( context.singleCommitEnabled && isCurrentBlockCommitted() ) {
-        return recoverFromReceipts( _transactions, _timestamp );
+        auto recovered = recoverFromReceipts( _transactions, _timestamp );
+        return make_tuple( recovered.first, recovered.second, Transactions() );
     }
 
     prepareStateForSync( _timestamp, context );
@@ -528,7 +529,8 @@ tuple< TransactionReceipts, unsigned > Block::syncEveryone( BlockChain const& _b
         saveStateChanges( _bc, _transactions, context );
     }
 
-    return make_tuple( context.receipts, context.receipts.size() - context.badCount );
+    return make_tuple(
+        context.receipts, context.receipts.size() - context.badCount, context.executedTransactions );
 }
 
 std::pair< TransactionReceipts, unsigned > Block::recoverFromReceipts(
@@ -630,6 +632,7 @@ void Block::executeTransactions( BlockChain const& _bc, const Transactions& _tra
                 // multiple commits mode
                 m_transactions.push_back( tr );
                 m_transactionSet.insert( tr.sha3() );
+                _context.executedTransactions.push_back( tr );
                 continue;
             }
 
@@ -687,6 +690,8 @@ std::optional< TransactionReceipt > Block::executeSingleTransaction( BlockChain 
     }
 
     ExecutionResult res = execute( _bc.lastBlockHashes(), _tx, _permanence, OnOpFunc(), _txIndex );
+    if ( res.excepted != TransactionException::WouldNotBeInBlock )
+        _context.executedTransactions.push_back( _tx );
 
 #ifdef BITE
     if ( res.excepted != TransactionException::None ) {

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -266,7 +266,7 @@ public:
         BlockChain const& _bc, h256 const& _blockHash, BlockHeader const& _bi = BlockHeader() );
 
     /// Sync all transactions unconditionally
-    std::tuple< TransactionReceipts, unsigned > syncEveryone( BlockChain const& _bc,
+    std::tuple< TransactionReceipts, unsigned, Transactions > syncEveryone( BlockChain const& _bc,
         const Transactions& _transactions, uint64_t _timestamp, u256 _gasPrice );
 
     /// Execute all transactions within a given block.
@@ -346,6 +346,7 @@ private:
         bool singleCommitEnabled = false;
         TransactionReceipts receipts;
         TransactionReceipts receiptsOfCommitted;
+        Transactions executedTransactions;
         unsigned badCount = 0;
     };
 

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <array>
+#include <functional>
 #include <optional>
 #include <unordered_map>
 
@@ -84,6 +85,8 @@ class Block {
     friend class BlockChain;
 
 public:
+    using OnTransactionConsumed = std::function< bool( Transaction const& ) >;
+
     // TODO: pass in ChainOperationParams rather than u256
 
     /// Default constructor; creates with a blank database prepopulated with the genesis block.
@@ -266,8 +269,9 @@ public:
         BlockChain const& _bc, h256 const& _blockHash, BlockHeader const& _bi = BlockHeader() );
 
     /// Sync all transactions unconditionally
-    std::tuple< TransactionReceipts, unsigned, Transactions > syncEveryone( BlockChain const& _bc,
-        const Transactions& _transactions, uint64_t _timestamp, u256 _gasPrice );
+    std::tuple< TransactionReceipts, unsigned, bool > syncEveryone( BlockChain const& _bc,
+        const Transactions& _transactions, uint64_t _timestamp, u256 _gasPrice,
+        OnTransactionConsumed const& _onTransactionConsumed = OnTransactionConsumed() );
 
     /// Execute all transactions within a given block.
     /// @returns the additional total difficulty.
@@ -346,7 +350,10 @@ private:
         bool singleCommitEnabled = false;
         TransactionReceipts receipts;
         TransactionReceipts receiptsOfCommitted;
-        Transactions executedTransactions;
+        // Holds transactions that were consumed by execution layer and need
+        // to be removed from transaction queue
+        Transactions queueCleanupTransactions;
+        bool needsQueueReadyNotification = false;
         unsigned badCount = 0;
     };
 
@@ -357,7 +364,8 @@ private:
 
     void prepareStateForSync( uint64_t _timestamp, SyncContext& _context );
     void executeTransactions( BlockChain const& _bc, const Transactions& _transactions,
-        u256 _gasPrice, SyncContext& _context );
+        u256 _gasPrice, SyncContext& _context,
+        OnTransactionConsumed const& _onTransactionConsumed );
     std::optional< TransactionReceipt > executeSingleTransaction( BlockChain const& _bc,
         Transaction const& _tx, unsigned _txIndex, u256 _gasPrice, skale::Permanence _permanence,
         SyncContext& _context );

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -724,11 +724,10 @@ void Client::onDeadBlocks( h256s const& _blocks, h256Hash& io_changed ) {
     for ( auto const& h : _blocks ) {
         BOOST_LOG( m_loggerTrace ) << "Dead block: " << h;
         for ( auto const& t : bc().transactions( h ) ) {
-            BOOST_LOG( m_loggerTrace ) << "Resubmitting dead-block transaction "
-                                       << Transaction( t, CheckTransaction::None );
-            BOOST_LOG( m_loggerTrace ) << "Resubmitting dead-block transaction "
-                                       << Transaction( t, CheckTransaction::None );
-            m_tq.import( t, IfDropped::Retry );
+            Transaction tx( t, CheckTransaction::None );
+            BOOST_LOG( m_loggerTrace ) << "Resubmitting dead-block transaction " << tx;
+            m_tq.import( tx, IfDropped::Retry, chainParams().isMultiTransactionModeEnabled(),
+                state().getNonce( tx.sender() ) );
         }
     }
 
@@ -772,7 +771,8 @@ void Client::restartMining() {
             for ( auto const& t : m_postSeal.pending() ) {
                 BOOST_LOG( m_loggerTrace ) << "Resubmitting post-seal transaction " << t;
                 //                      ctrace << "Resubmitting post-seal transaction " << t;
-                auto ir = m_tq.import( t, IfDropped::Retry );
+                auto ir = m_tq.import( t, IfDropped::Retry,
+                    chainParams().isMultiTransactionModeEnabled(), state().getNonce( t.sender() ) );
                 if ( ir != ImportResult::Success )
                     onTransactionQueueReady();
             }
@@ -1224,13 +1224,9 @@ h256 Client::importTransaction( Transaction const& _t, TransactionBroadcast _txO
 #endif  // BITE
 
     ImportResult res;
-    if ( chainParams().isMultiTransactionModeEnabled() &&
-         state.getNonce( _t.sender() ) < _t.nonce() &&
-         m_tq.maxCurrentNonce( _t.sender() ) != _t.nonce() ) {
-        res = m_tq.import( _t, IfDropped::Ignore, true );
-    } else {
-        res = m_tq.import( _t );
-    }
+    auto stateNonce = state.getNonce( _t.sender() );
+    bool const allowFutureQueue = chainParams().isMultiTransactionModeEnabled();
+    res = m_tq.import( _t, IfDropped::Ignore, allowFutureQueue, stateNonce );
 
     switch ( res ) {
     case ImportResult::Success:
@@ -1243,6 +1239,8 @@ h256 Client::importTransaction( Transaction const& _t, TransactionBroadcast _txO
         BOOST_THROW_EXCEPTION( PendingTransactionAlreadyExists() );
     case ImportResult::AlreadyInChain:
         BOOST_THROW_EXCEPTION( TransactionAlreadyInChain() );
+    case ImportResult::QueueIsFull:
+        BOOST_THROW_EXCEPTION( TransactionQueueIsFull() );
     default:
         BOOST_THROW_EXCEPTION( UnknownTransactionValidationError() );
     }

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -590,8 +590,7 @@ size_t Client::importTransactionsAsBlock( const Transactions& _transactions,
 #endif
 
     size_t cntSucceeded = 0;
-    cntSucceeded = syncTransactions(
-        _transactions, _gasPrice, _timestamp, _onTransactionConsumed,
+    cntSucceeded = syncTransactions( _transactions, _gasPrice, _timestamp, _onTransactionConsumed,
         _needsQueueReadyNotification );
     sealUnconditionally( false );
     importWorkingBlock();
@@ -693,8 +692,8 @@ size_t Client::syncTransactions( const Transactions& _transactions, u256 _gasPri
         // assert(m_state.m_db_write_lock.has_value());
 
         tie( newPendingReceipts, goodReceipts, needsQueueReadyNotification ) =
-            m_working.syncEveryone( bc(), _transactions, _timestamp, _gasPrice,
-                _onTransactionConsumed );
+            m_working.syncEveryone(
+                bc(), _transactions, _timestamp, _gasPrice, _onTransactionConsumed );
         m_state = m_state.createStateCopyAndClearCaches();
 #ifdef HISTORIC_STATE
         // make sure the trie in new state object points to the new state root

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -560,7 +560,7 @@ size_t Client::importTransactionsAsBlock( const Transactions& _transactions,
 #ifdef FAIR
     uint64_t _winningNodeIndex,
 #endif
-    uint64_t _timestamp ) {
+    uint64_t _timestamp, Transactions* _executedTransactions ) {
     // on schain creation, SnapshotAgent needs timestamp of block 1
     // so we use this HACK
     // pass block number 0 as for bigger BN it is initialized in init()
@@ -589,7 +589,7 @@ size_t Client::importTransactionsAsBlock( const Transactions& _transactions,
 #endif
 
     size_t cntSucceeded = 0;
-    cntSucceeded = syncTransactions( _transactions, _gasPrice, _timestamp );
+    cntSucceeded = syncTransactions( _transactions, _gasPrice, _timestamp, _executedTransactions );
     sealUnconditionally( false );
     importWorkingBlock();
 
@@ -663,8 +663,8 @@ bool Client::updateGroupIfNeeded() {
 
 #endif  // BITE
 
-size_t Client::syncTransactions(
-    const Transactions& _transactions, u256 _gasPrice, uint64_t _timestamp ) {
+size_t Client::syncTransactions( const Transactions& _transactions, u256 _gasPrice,
+    uint64_t _timestamp, Transactions* _executedTransactions ) {
     assert( m_skaleHost );
 
     while ( m_working.isSealed() ) {
@@ -678,6 +678,7 @@ size_t Client::syncTransactions(
 
     TransactionReceipts newPendingReceipts;
     unsigned goodReceipts;
+    Transactions executedTransactions;
 
     DEV_WRITE_GUARDED( x_working ) {
         assert( !m_working.isSealed() );
@@ -687,7 +688,7 @@ size_t Client::syncTransactions(
 #endif
         // assert(m_state.m_db_write_lock.has_value());
 
-        tie( newPendingReceipts, goodReceipts ) =
+        tie( newPendingReceipts, goodReceipts, executedTransactions ) =
             m_working.syncEveryone( bc(), _transactions, _timestamp, _gasPrice );
         m_state = m_state.createStateCopyAndClearCaches();
 #ifdef HISTORIC_STATE
@@ -700,6 +701,9 @@ size_t Client::syncTransactions(
     DEV_READ_GUARDED( x_working )
     DEV_WRITE_GUARDED( x_postSeal )
     m_postSeal = m_working;
+
+    if ( _executedTransactions )
+        *_executedTransactions = std::move( executedTransactions );
 
     // Tell farm about new transaction (i.e. restart mining).
     onPostStateChanged();

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -560,7 +560,8 @@ size_t Client::importTransactionsAsBlock( const Transactions& _transactions,
 #ifdef FAIR
     uint64_t _winningNodeIndex,
 #endif
-    uint64_t _timestamp, Transactions* _executedTransactions ) {
+    uint64_t _timestamp, Block::OnTransactionConsumed const& _onTransactionConsumed,
+    bool* _needsQueueReadyNotification ) {
     // on schain creation, SnapshotAgent needs timestamp of block 1
     // so we use this HACK
     // pass block number 0 as for bigger BN it is initialized in init()
@@ -589,7 +590,9 @@ size_t Client::importTransactionsAsBlock( const Transactions& _transactions,
 #endif
 
     size_t cntSucceeded = 0;
-    cntSucceeded = syncTransactions( _transactions, _gasPrice, _timestamp, _executedTransactions );
+    cntSucceeded = syncTransactions(
+        _transactions, _gasPrice, _timestamp, _onTransactionConsumed,
+        _needsQueueReadyNotification );
     sealUnconditionally( false );
     importWorkingBlock();
 
@@ -664,7 +667,8 @@ bool Client::updateGroupIfNeeded() {
 #endif  // BITE
 
 size_t Client::syncTransactions( const Transactions& _transactions, u256 _gasPrice,
-    uint64_t _timestamp, Transactions* _executedTransactions ) {
+    uint64_t _timestamp, Block::OnTransactionConsumed const& _onTransactionConsumed,
+    bool* _needsQueueReadyNotification ) {
     assert( m_skaleHost );
 
     while ( m_working.isSealed() ) {
@@ -678,7 +682,7 @@ size_t Client::syncTransactions( const Transactions& _transactions, u256 _gasPri
 
     TransactionReceipts newPendingReceipts;
     unsigned goodReceipts;
-    Transactions executedTransactions;
+    bool needsQueueReadyNotification = false;
 
     DEV_WRITE_GUARDED( x_working ) {
         assert( !m_working.isSealed() );
@@ -688,8 +692,9 @@ size_t Client::syncTransactions( const Transactions& _transactions, u256 _gasPri
 #endif
         // assert(m_state.m_db_write_lock.has_value());
 
-        tie( newPendingReceipts, goodReceipts, executedTransactions ) =
-            m_working.syncEveryone( bc(), _transactions, _timestamp, _gasPrice );
+        tie( newPendingReceipts, goodReceipts, needsQueueReadyNotification ) =
+            m_working.syncEveryone( bc(), _transactions, _timestamp, _gasPrice,
+                _onTransactionConsumed );
         m_state = m_state.createStateCopyAndClearCaches();
 #ifdef HISTORIC_STATE
         // make sure the trie in new state object points to the new state root
@@ -702,8 +707,8 @@ size_t Client::syncTransactions( const Transactions& _transactions, u256 _gasPri
     DEV_WRITE_GUARDED( x_postSeal )
     m_postSeal = m_working;
 
-    if ( _executedTransactions )
-        *_executedTransactions = std::move( executedTransactions );
+    if ( _needsQueueReadyNotification )
+        *_needsQueueReadyNotification = needsQueueReadyNotification;
 
     // Tell farm about new transaction (i.e. restart mining).
     onPostStateChanged();

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -188,8 +188,7 @@ void Client::stopWorking() {
 
     m_signalled.notify_all();  // to wake up the thread from Client::doWork()
 
-    m_tq.HandleDestruction();  // l_sergiy: destroy transaction queue earlier
-    m_bq.stop();               // l_sergiy: added to stop block queue processing
+    m_bq.stop();  // l_sergiy: added to stop block queue processing
 
     m_bc.close();
     BOOST_LOG( m_loggerInfo ) << "Blockchain is closed";

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -949,7 +949,7 @@ void Client::sealUnconditionally( bool submitToBlockChain ) {
                  << ":TXRS:" << TransactionReceipt::howMany() << ":BLCKS:" << Block::howMany()
                  << ":ACCS:" << Account::howMany() << ":BQS:" << BlockQueue::howMany()
                  << ":BDS:" << BlockDetails::howMany() << ":TSS:" << TransactionSkeleton::howMany()
-                 << ":UTX:" << TransactionQueue::UnverifiedTransaction::howMany()
+                 << ":UTX:" << 0
                  << ":VTX:" << TransactionQueue::VerifiedTransaction::howMany()
                  << ":CMM:" << bc().getTotalCacheMemory()
                  << ":KDS:" << db::LevelDB::getKeyDeletesStats();

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -949,8 +949,7 @@ void Client::sealUnconditionally( bool submitToBlockChain ) {
                  << ":TXRS:" << TransactionReceipt::howMany() << ":BLCKS:" << Block::howMany()
                  << ":ACCS:" << Account::howMany() << ":BQS:" << BlockQueue::howMany()
                  << ":BDS:" << BlockDetails::howMany() << ":TSS:" << TransactionSkeleton::howMany()
-                 << ":UTX:" << 0
-                 << ":VTX:" << TransactionQueue::VerifiedTransaction::howMany()
+                 << ":UTX:" << 0 << ":VTX:" << TransactionQueue::VerifiedTransaction::howMany()
                  << ":CMM:" << bc().getTotalCacheMemory()
                  << ":KDS:" << db::LevelDB::getKeyDeletesStats();
     if ( number() % 1000 == 0 ) {

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -308,7 +308,9 @@ public:
         uint64_t _winningNodeIndex,
 #endif
         uint64_t _timestamp = ( uint64_t ) utcTime(),
-        Transactions* _executedTransactions = nullptr );
+        Block::OnTransactionConsumed const& _onTransactionConsumed =
+            Block::OnTransactionConsumed(),
+        bool* _needsQueueReadyNotification = nullptr );
 
     boost::filesystem::path createSnapshotFile( unsigned _blockNumber ) {
         return m_snapshotAgent->createSnapshotFile( _blockNumber );
@@ -408,7 +410,9 @@ protected:
     /// thread unsafe!!
     size_t syncTransactions( const Transactions& _transactions, u256 _gasPrice,
         uint64_t _timestamp = ( uint64_t ) utcTime(),
-        Transactions* _executedTransactions = nullptr );
+        Block::OnTransactionConsumed const& _onTransactionConsumed =
+            Block::OnTransactionConsumed(),
+        bool* _needsQueueReadyNotification = nullptr );
 
     /// As rejigSealing - but stub
     /// thread unsafe!!

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -308,8 +308,7 @@ public:
         uint64_t _winningNodeIndex,
 #endif
         uint64_t _timestamp = ( uint64_t ) utcTime(),
-        Block::OnTransactionConsumed const& _onTransactionConsumed =
-            Block::OnTransactionConsumed(),
+        Block::OnTransactionConsumed const& _onTransactionConsumed = Block::OnTransactionConsumed(),
         bool* _needsQueueReadyNotification = nullptr );
 
     boost::filesystem::path createSnapshotFile( unsigned _blockNumber ) {
@@ -410,8 +409,7 @@ protected:
     /// thread unsafe!!
     size_t syncTransactions( const Transactions& _transactions, u256 _gasPrice,
         uint64_t _timestamp = ( uint64_t ) utcTime(),
-        Block::OnTransactionConsumed const& _onTransactionConsumed =
-            Block::OnTransactionConsumed(),
+        Block::OnTransactionConsumed const& _onTransactionConsumed = Block::OnTransactionConsumed(),
         bool* _needsQueueReadyNotification = nullptr );
 
     /// As rejigSealing - but stub

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -307,7 +307,8 @@ public:
 #ifdef FAIR
         uint64_t _winningNodeIndex,
 #endif
-        uint64_t _timestamp = ( uint64_t ) utcTime() );
+        uint64_t _timestamp = ( uint64_t ) utcTime(),
+        Transactions* _executedTransactions = nullptr );
 
     boost::filesystem::path createSnapshotFile( unsigned _blockNumber ) {
         return m_snapshotAgent->createSnapshotFile( _blockNumber );
@@ -406,7 +407,8 @@ protected:
     /// returns number of successfullty executed transactions
     /// thread unsafe!!
     size_t syncTransactions( const Transactions& _transactions, u256 _gasPrice,
-        uint64_t _timestamp = ( uint64_t ) utcTime() );
+        uint64_t _timestamp = ( uint64_t ) utcTime(),
+        Transactions* _executedTransactions = nullptr );
 
     /// As rejigSealing - but stub
     /// thread unsafe!!

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -1120,7 +1120,6 @@ std::vector< Transaction > SkaleHost::processCTXTransactions(
     const ConsensusExtFace::Transactions& _approvedTransactions,
     [[maybe_unused]] const dev::eth::BlockHeader& latestInfo,
     DecryptedTransactions _decryptedTransactions ) {
-        
     CHECK_EXPRESSION( _decryptedTransactions.ctxTxsMap );
 
     std::vector< Transaction > outTxns;
@@ -1162,8 +1161,8 @@ std::vector< Transaction > SkaleHost::processCTXTransactions(
     if ( !ctxOrigins ) {
         BOOST_LOG( m_loggerError )
             << "Received CTX list that does not match next expected pending BITE2 CTXs";
-        BOOST_THROW_EXCEPTION(
-            std::runtime_error( "Block CTX list does not match next expected pending BITE2 CTXs" ) );
+        BOOST_THROW_EXCEPTION( std::runtime_error(
+            "Block CTX list does not match next expected pending BITE2 CTXs" ) );
     }
 
     for ( size_t i = 0; i < outTxns.size(); ++i )

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -1050,6 +1050,7 @@ std::vector< Transaction > SkaleHost::processRegularTransactions(
 ) {
     std::vector< Transaction > outTxns;
 #ifdef BITE
+    CHECK_EXPRESSION( _decryptedTransactions.regularTxsMap );
     auto regularTxnsIterator = _decryptedTransactions.regularTxsMap->begin();
 #endif
     size_t regularTxnsStartIndex = 0;
@@ -1113,6 +1114,7 @@ std::vector< Transaction > SkaleHost::processCTXTransactions(
     DecryptedTransactions _decryptedTransactions ) {
     std::vector< dev::h256 > ctxOrigins = m_tq.getNCTXOrigins( _approvedTransactions.sizeCTX() );
     std::vector< Transaction > outTxns;
+    CHECK_EXPRESSION( _decryptedTransactions.ctxTxsMap );
     auto ctxIterator = _decryptedTransactions.ctxTxsMap->begin();
     for ( size_t i = 0; i < _approvedTransactions.sizeCTX(); ++i ) {
         const bytes& data = _approvedTransactions.at( i );

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -673,6 +673,7 @@ void SkaleHost::createBlock( const ConsensusExtFace::Transactions& _approvedTran
         checkStateRoot( _blockID, _winningNodeIndex, _stateRoot );
 
     std::vector< Transaction > outTxns;  // resultant Transaction vector
+    std::vector< Transaction > executedTxns;
 
     size_t n_succeeded;
 
@@ -728,7 +729,13 @@ void SkaleHost::createBlock( const ConsensusExtFace::Transactions& _approvedTran
 #ifdef FAIR
             _winningNodeIndex,
 #endif
-            _timeStamp );
+            _timeStamp, &executedTxns );
+
+        // remove txs from tx queue
+        for ( auto const& t : executedTxns ) {
+            m_debugTracer.tracepoint( "drop_good" );
+            m_tq.dropGood( t );
+        }
     }  // m_blockImportMutex
 
 #ifdef FAIR
@@ -1097,8 +1104,6 @@ std::vector< Transaction > SkaleHost::processRegularTransactions(
         }
 #endif
         outTxns.push_back( t );
-        m_debugTracer.tracepoint( "drop_good" );
-        m_tq.dropGood( t );
 #ifdef BITE
         if ( regularTxnsIterator != _decryptedTransactions.regularTxsMap->end() )
             ++regularTxnsIterator;
@@ -1144,8 +1149,6 @@ std::vector< Transaction > SkaleHost::processCTXTransactions(
 
         t.setCTXOrigin( ctxOrigins[i] );
         outTxns.push_back( t );
-        m_debugTracer.tracepoint( "drop_good" );
-        m_tq.dropGood( t );
         if ( ctxIterator != _decryptedTransactions.ctxTxsMap->end() )
             ++ctxIterator;
     }

--- a/libethereum/SkaleHost.cpp
+++ b/libethereum/SkaleHost.cpp
@@ -27,6 +27,7 @@
 #include <atomic>
 #include <chrono>
 #include <future>
+#include <stdexcept>
 #include <string>
 
 using namespace std;
@@ -673,7 +674,7 @@ void SkaleHost::createBlock( const ConsensusExtFace::Transactions& _approvedTran
         checkStateRoot( _blockID, _winningNodeIndex, _stateRoot );
 
     std::vector< Transaction > outTxns;  // resultant Transaction vector
-    std::vector< Transaction > executedTxns;
+    bool needsQueueReadyNotification = false;
 
     size_t n_succeeded;
 
@@ -720,6 +721,11 @@ void SkaleHost::createBlock( const ConsensusExtFace::Transactions& _approvedTran
 
         m_debugTracer.tracepoint( "import_block" );
 
+        auto onTransactionConsumed = [this]( Transaction const& _tx ) {
+            m_debugTracer.tracepoint( "drop_good" );
+            return m_tq.dropGood( _tx, TransactionQueue::ReadyNotification::Defer ).readyChanged;
+        };
+
         n_succeeded = m_client.importTransactionsAsBlock( outTxns,
 
 #ifdef BITE
@@ -729,14 +735,11 @@ void SkaleHost::createBlock( const ConsensusExtFace::Transactions& _approvedTran
 #ifdef FAIR
             _winningNodeIndex,
 #endif
-            _timeStamp, &executedTxns );
-
-        // remove txs from tx queue
-        for ( auto const& t : executedTxns ) {
-            m_debugTracer.tracepoint( "drop_good" );
-            m_tq.dropGood( t );
-        }
+            _timeStamp, onTransactionConsumed, &needsQueueReadyNotification );
     }  // m_blockImportMutex
+
+    if ( needsQueueReadyNotification )
+        m_tq.notifyReady();
 
 #ifdef FAIR
     syncNodeGroups();
@@ -1117,9 +1120,12 @@ std::vector< Transaction > SkaleHost::processCTXTransactions(
     const ConsensusExtFace::Transactions& _approvedTransactions,
     [[maybe_unused]] const dev::eth::BlockHeader& latestInfo,
     DecryptedTransactions _decryptedTransactions ) {
-    std::vector< dev::h256 > ctxOrigins = m_tq.getNCTXOrigins( _approvedTransactions.sizeCTX() );
-    std::vector< Transaction > outTxns;
+        
     CHECK_EXPRESSION( _decryptedTransactions.ctxTxsMap );
+
+    std::vector< Transaction > outTxns;
+    outTxns.reserve( _approvedTransactions.sizeCTX() );
+
     auto ctxIterator = _decryptedTransactions.ctxTxsMap->begin();
     for ( size_t i = 0; i < _approvedTransactions.sizeCTX(); ++i ) {
         const bytes& data = _approvedTransactions.at( i );
@@ -1147,11 +1153,22 @@ std::vector< Transaction > SkaleHost::processCTXTransactions(
 
         // no POW for CTXs
 
-        t.setCTXOrigin( ctxOrigins[i] );
         outTxns.push_back( t );
         if ( ctxIterator != _decryptedTransactions.ctxTxsMap->end() )
             ++ctxIterator;
     }
+
+    auto ctxOrigins = m_tq.validateNextExpectedBITE2CTXsAndGetOrigins( outTxns );
+    if ( !ctxOrigins ) {
+        BOOST_LOG( m_loggerError )
+            << "Received CTX list that does not match next expected pending BITE2 CTXs";
+        BOOST_THROW_EXCEPTION(
+            std::runtime_error( "Block CTX list does not match next expected pending BITE2 CTXs" ) );
+    }
+
+    for ( size_t i = 0; i < outTxns.size(); ++i )
+        outTxns[i].setCTXOrigin( ( *ctxOrigins )[i] );
+
     return outTxns;
 }
 #endif

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -37,6 +37,17 @@ using namespace dev::eth;
 
 namespace {
 constexpr size_t c_maxDroppedTransactionCount = 1024;
+
+Transaction decodeTransaction( bytesConstRef _transactionRLP ) {
+    return Transaction( _transactionRLP, CheckTransaction::Everything, false,
+        EIP1559TransactionsPatch::isEnabledInWorkingBlock(),
+        InvalidTransactionFormatPatch::isEnabledInWorkingBlock()
+#ifdef BITE
+            ,
+        Bite2Patch::isEnabledInWorkingBlock()
+#endif  // BITE
+    );
+}
 }  // namespace
 
 TransactionQueue::TransactionQueue( unsigned _limit, unsigned _futureLimit,
@@ -55,35 +66,10 @@ TransactionQueue::TransactionQueue( unsigned _limit, unsigned _futureLimit,
 
 TransactionQueue::~TransactionQueue() {}
 
-ImportResult TransactionQueue::import(
-    bytesConstRef _transactionRLP, IfDropped _ik, bool _isFuture ) {
-    try {
-        Transaction t = Transaction( _transactionRLP, CheckTransaction::Everything, false,
-            EIP1559TransactionsPatch::isEnabledInWorkingBlock(),
-            InvalidTransactionFormatPatch::isEnabledInWorkingBlock()
-#ifdef BITE
-                ,
-            Bite2Patch::isEnabledInWorkingBlock()
-#endif  // BITE
-        );
-        return import( t, _ik, _isFuture );
-    } catch ( Exception const& ) {
-        return ImportResult::Malformed;
-    }
-}
-
 ImportResult TransactionQueue::import( bytesConstRef _transactionRLP, IfDropped _ik,
     bool _allowFutureQueue, u256 const& _stateNonce ) {
     try {
-        Transaction t = Transaction( _transactionRLP, CheckTransaction::Everything, false,
-            EIP1559TransactionsPatch::isEnabledInWorkingBlock(),
-            InvalidTransactionFormatPatch::isEnabledInWorkingBlock()
-#ifdef BITE
-                ,
-            Bite2Patch::isEnabledInWorkingBlock()
-#endif  // BITE
-        );
-        return import( t, _ik, _allowFutureQueue, _stateNonce );
+        return import( decodeTransaction( _transactionRLP ), _ik, _allowFutureQueue, _stateNonce );
     } catch ( Exception const& ) {
         return ImportResult::Malformed;
     }
@@ -97,55 +83,6 @@ ImportResult TransactionQueue::check_WITH_LOCK( h256 const& _h, IfDropped _ik ) 
         return ImportResult::AlreadyInChain;
 
     return ImportResult::Success;
-}
-
-ImportResult TransactionQueue::import(
-    Transaction const& _transaction, IfDropped _ik, bool _isFuture ) {
-    if ( _transaction.hasZeroSignature() )
-        return ImportResult::ZeroSignature;
-    // Check if we already know this transaction.
-    h256 h = _transaction.sha3( WithSignature );
-
-    ImportResult ret;
-    {
-        MICROPROFILE_SCOPEI( "TransactionQueue", "import", MP_THISTLE );
-        // WriteGuard l2( m_lock );
-        UpgradableGuard l( m_lock );
-
-        // HACK remove it from future and re-insert (allows to "push" stuck transaction)
-        auto fs = m_future.find( _transaction.from() );
-        if ( fs != m_future.end() ) {
-            auto t = fs->second.find( _transaction.nonce() );
-
-            // if transaction found:
-            if ( t != fs->second.end() ) {
-                UpgradeGuard ul( l );
-                --m_futureSize;
-                m_futureSizeBytes -= t->second.transaction.toBytes().size();
-                auto erasedHash = t->second.transaction.sha3();
-                BOOST_LOG( m_loggerTrace ) << "Re-inserting future transaction " << erasedHash;
-                m_known.erase( erasedHash );
-                fs->second.erase( t->second.transaction.nonce() );
-                if ( fs->second.empty() )
-                    m_future.erase( fs );
-            }  // if found
-        }      // if fs->second
-
-        auto ir = check_WITH_LOCK( h, _ik );
-        if ( ir != ImportResult::Success )
-            return ir;
-
-        {
-            _transaction.safeSender();  // Perform EC recovery outside of the write lock
-
-            UpgradeGuard ul( l );
-            ret = manageImport_WITH_LOCK( h, _transaction );
-
-            if ( _isFuture )
-                setFuture_WITH_LOCK( h );
-        }
-    }
-    return ret;
 }
 
 ImportResult TransactionQueue::import( Transaction const& _transaction, IfDropped _ik,
@@ -272,49 +209,6 @@ const h256Hash TransactionQueue::knownTransactions() const {
     return rv;
 }
 
-ImportResult TransactionQueue::manageImport_WITH_LOCK(
-    h256 const& _h, Transaction const& _transaction ) {
-    try {
-        assert( _h == _transaction.sha3() );
-        // Remove any prior transaction with the same nonce but a lower gas price.
-        // Bomb out if there's a prior transaction with higher gas price.
-        auto cs = m_currentByAddressAndNonce.find( _transaction.from() );
-        if ( cs != m_currentByAddressAndNonce.end() ) {
-            auto t = cs->second.find( _transaction.nonce() );
-            if ( t != cs->second.end() ) {
-                return ImportResult::SameNonceAlreadyInQueue;
-            }
-        }
-
-        auto fs = m_future.find( _transaction.from() );
-        if ( fs != m_future.end() ) {
-            auto t = fs->second.find( _transaction.nonce() );
-            if ( t != fs->second.end() ) {
-                return ImportResult::SameNonceAlreadyInQueue;
-            }  // if found
-        }      // if fs->second
-
-        ImportResult ret = insertCurrent_WITH_LOCK( make_pair( _h, _transaction ) );
-        if ( ret == ImportResult::Success ) {
-            BOOST_LOG( m_loggerTrace ) << "Queued vaguely legit-looking transaction " << _h;
-            m_onReady();
-        } else if ( ret == ImportResult::QueueIsFull ) {
-            BOOST_LOG( m_loggerWarning ) << "Transaction queue is full. Rejecting transaction "
-                                         << _h;
-        }
-        return ret;
-    } catch ( Exception const& _e ) {
-        BOOST_LOG( m_loggerTrace )
-            << "Ignoring invalid transaction: " << diagnostic_information( _e );
-        return ImportResult::Malformed;
-    } catch ( std::exception const& _e ) {
-        BOOST_LOG( m_loggerTrace ) << "Ignoring invalid transaction: " << _e.what();
-        return ImportResult::Malformed;
-    }
-
-    return ImportResult::Success;
-}
-
 ImportResult TransactionQueue::manageImport_WITH_LOCK( h256 const& _h,
     Transaction const& _transaction, bool _allowFutureQueue, u256 const& _stateNonce ) {
     try {
@@ -426,15 +320,23 @@ ImportResult TransactionQueue::insertCurrent_WITH_LOCK(
 ImportResult TransactionQueue::insertFuture_WITH_LOCK(
     std::pair< h256, Transaction > const& _p ) {
     Transaction const& t = _p.second;
-    size_t const transactionSizeBytes = t.toBytes().size();
-    if ( m_futureSize + 1 > m_futureLimit ||
-         m_futureSizeBytes + transactionSizeBytes > m_futureSizeBytesLimit )
-        return ImportResult::QueueIsFull;
-
     m_future[t.from()].emplace( t.nonce(), VerifiedTransaction( t ) );
     ++m_futureSize;
-    m_futureSizeBytes += transactionSizeBytes;
+    m_futureSizeBytes += t.toBytes().size();
     m_known.insert( _p.first );
+
+    while ( m_futureSize > m_futureLimit || m_futureSizeBytes > m_futureSizeBytesLimit ) {
+        // TODO: priority queue for future transactions
+        // For now just drop random chain end
+        --m_futureSize;
+        m_futureSizeBytes -= m_future.begin()->second.rbegin()->second.transaction.toBytes().size();
+        auto erasedHash = m_future.begin()->second.rbegin()->second.transaction.sha3();
+        BOOST_LOG( m_loggerTrace ) << "Dropping out of bounds future transaction " << erasedHash;
+        m_known.erase( erasedHash );
+        m_future.begin()->second.erase( --m_future.begin()->second.end() );
+        if ( m_future.begin()->second.empty() )
+            m_future.erase( m_future.begin() );
+    }
 
     return ImportResult::Success;
 }

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -640,6 +640,8 @@ void TransactionQueue::dropGood( Transaction const& _t ) {
             removedCurrentInfo = true;
         }
         removedCurrent = remove_WITH_LOCK( _t.sha3() );
+        if ( !removedCurrent && !_t.isInvalid() )
+            removeFuture_WITH_LOCK( _t );
     }
 
     if ( !_t.isInvalid() ) {

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -105,8 +105,7 @@ ImportResult TransactionQueue::import( Transaction const& _transaction, IfDroppe
             _transaction.safeSender();  // Perform EC recovery outside of the write lock
 
             UpgradeGuard ul( l );
-            ret =
-                manageImport_WITH_LOCK( h, _transaction, _allowFutureQueue, _stateNonce );
+            ret = manageImport_WITH_LOCK( h, _transaction, _allowFutureQueue, _stateNonce );
         }
     }
     return ret;
@@ -218,7 +217,6 @@ ImportResult TransactionQueue::manageImport_WITH_LOCK( h256 const& _h,
         if ( fs != m_future.end() ) {
             auto t = fs->second.find( _transaction.nonce() );
             if ( t != fs->second.end() ) {
-
                 // exact same tx already in future
                 if ( t->second.transaction.sha3() != _h )
                     return ImportResult::SameNonceAlreadyInQueue;
@@ -256,8 +254,7 @@ ImportResult TransactionQueue::manageImport_WITH_LOCK( h256 const& _h,
                 eraseFuture();
                 ImportResult ret = insertCurrent_WITH_LOCK( make_pair( _h, _transaction ) );
                 if ( ret == ImportResult::Success ) {
-                    BOOST_LOG( m_loggerTrace )
-                        << "Queued vaguely legit-looking transaction " << _h;
+                    BOOST_LOG( m_loggerTrace ) << "Queued vaguely legit-looking transaction " << _h;
                     m_onReady();
                 }
                 return ret;
@@ -279,7 +276,7 @@ ImportResult TransactionQueue::manageImport_WITH_LOCK( h256 const& _h,
                 BOOST_LOG( m_loggerTrace ) << "Queued vaguely legit-looking transaction " << _h;
                 m_onReady();
             }
-        // if future -> try insert in FTQ
+            // if future -> try insert in FTQ
         } else if ( _allowFutureQueue && _transaction.nonce() > _stateNonce ) {
             // may fail insertion if queue full
             ret = insertFuture_WITH_LOCK( make_pair( _h, _transaction ) );
@@ -288,8 +285,8 @@ ImportResult TransactionQueue::manageImport_WITH_LOCK( h256 const& _h,
         }
 
         if ( ret == ImportResult::QueueIsFull ) {
-            BOOST_LOG( m_loggerWarning ) << "Transaction queue is full. Rejecting transaction "
-                                         << _h;
+            BOOST_LOG( m_loggerWarning )
+                << "Transaction queue is full. Rejecting transaction " << _h;
         }
         return ret;
     } catch ( Exception const& _e ) {
@@ -331,8 +328,7 @@ u256 TransactionQueue::maxCurrentNonce_WITH_LOCK( Address const& _a ) const {
     return ret;
 }
 
-ImportResult TransactionQueue::insertCurrent_WITH_LOCK(
-    std::pair< h256, Transaction > const& _p ) {
+ImportResult TransactionQueue::insertCurrent_WITH_LOCK( std::pair< h256, Transaction > const& _p ) {
     if ( m_currentByHash.count( _p.first ) ) {
         BOOST_LOG( m_loggerWarning ) << "Transaction hash" << _p.first << "already in current";
         return ImportResult::Success;
@@ -359,8 +355,7 @@ ImportResult TransactionQueue::insertCurrent_WITH_LOCK(
     return ImportResult::Success;
 }
 
-ImportResult TransactionQueue::insertFuture_WITH_LOCK(
-    std::pair< h256, Transaction > const& _p ) {
+ImportResult TransactionQueue::insertFuture_WITH_LOCK( std::pair< h256, Transaction > const& _p ) {
     Transaction const& t = _p.second;
     size_t const transactionSizeBytes = t.toBytes().size();
 
@@ -516,7 +511,6 @@ void TransactionQueue::makeCurrent_WITH_LOCK( Transaction const& _t ) {
 
 bool TransactionQueue::promoteFutureTransactions_WITH_LOCK(
     Address const& _from, u256 const& _nonce ) {
-
     auto fs = m_future.find( _from );
     // no such sender in FTQ but in blocked promotions - remove from blocked promotions
     if ( fs == m_future.end() ) {
@@ -583,7 +577,6 @@ void TransactionQueue::retryBlockedPromotions_WITH_LOCK() {
         blockedPromotions.push_back( blockedPromotion );
 
     for ( auto const& blockedPromotion : blockedPromotions ) {
-
         // early exit if no capacity in CTQ
         if ( m_current.size() >= m_limit || m_currentSizeBytes >= m_currentSizeBytesLimit )
             return;

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -48,49 +48,14 @@ TransactionQueue::TransactionQueue( unsigned _limit, unsigned _futureLimit,
       m_limit( _limit ),
       m_futureLimit( _futureLimit ),
       m_currentSizeBytesLimit( _currentLimitBytes ),
-      m_futureSizeBytesLimit( _futureLimitBytes ),
-      m_aborting( false ) {
+      m_futureSizeBytesLimit( _futureLimitBytes ) {
     m_readyCondNotifier = this->onReady( [this]() {
         this->m_cond.notify_all();
         return;
     } );
-
-    unsigned verifierThreads = 0;  // std::max( thread::hardware_concurrency(), 3U ) - 2U;
-    for ( unsigned i = 0; i < verifierThreads; ++i )
-        m_verifiers.emplace_back( [this, i]() {
-            setThreadName( "txcheck" + toString( i ) );
-            this->verifierBody();
-        } );
 }
 
-TransactionQueue::~TransactionQueue() {
-    HandleDestruction();
-}
-
-void TransactionQueue::HandleDestruction() {
-    std::list< std::thread > listAwait;
-    {
-        DEV_GUARDED( x_queue ) {
-            m_aborting = true;
-            m_queueReady.notify_all();
-            for ( auto& i : m_verifiers ) {
-                try {
-                    if ( i.joinable() )
-                        listAwait.push_back( std::move( i ) );
-                } catch ( ... ) {
-                }
-            }
-            m_verifiers.clear();
-        }
-    }
-    for ( auto& i : listAwait ) {
-        try {
-            if ( i.joinable() )
-                i.join();
-        } catch ( ... ) {
-        }
-    }
-}
+TransactionQueue::~TransactionQueue() {}
 
 ImportResult TransactionQueue::import( bytesConstRef _transactionRLP, IfDropped _ik,
     bool _allowFutureQueue, u256 const& _stateNonce ) {
@@ -601,64 +566,6 @@ void TransactionQueue::clear() {
     m_futureSizeBytes = 0;
 }
 
-void TransactionQueue::enqueue( RLP const& _data, h512 const& _nodeId ) {
-    bool queued = false;
-    {
-        Guard l( x_queue );
-        unsigned itemCount = _data.itemCount();
-        for ( unsigned i = 0; i < itemCount; ++i ) {
-            if ( m_unverified.size() >= c_maxVerificationQueueSize ) {
-                BOOST_LOG( m_loggerInfo ) << "Transaction verification queue is full. Dropping "
-                                          << itemCount - i << " transactions";
-                break;
-            }
-            m_unverified.emplace_back( UnverifiedTransaction( _data[i].data(), _nodeId ) );
-            queued = true;
-        }
-    }
-    if ( queued )
-        m_queueReady.notify_all();
-}
-
-void TransactionQueue::verifierBody() {
-    while ( !m_aborting ) {
-        UnverifiedTransaction work;
-
-        {  // block
-            MICROPROFILE_SCOPEI( "TransactionQueue", "unique_lock<Mutex> l(x_queue)", MP_DIMGRAY );
-            unique_lock< Mutex > l( x_queue );
-            {
-                MICROPROFILE_SCOPEI( "TransactionQueue", "m_queueReady.wait", MP_DIMGRAY );
-                m_queueReady.wait(
-                    l, [&]() { return bool( m_aborting ) || ( !m_unverified.empty() ); } );
-            }
-            if ( m_aborting )
-                return;
-            MICROPROFILE_ENTERI(
-                "TransactionQueue", "verifierBody while", MP_LIGHTGOLDENRODYELLOW );
-            work = move( m_unverified.front() );
-            m_unverified.pop_front();
-        }  // block
-
-        try {
-            Transaction t( work.transaction, CheckTransaction::Cheap, false,
-                EIP1559TransactionsPatch::isEnabledInWorkingBlock(),
-                InvalidTransactionFormatPatch::isEnabledInWorkingBlock()
-#ifdef BITE
-                    ,
-                Bite2Patch::isEnabledInWorkingBlock()
-#endif          // BITE
-            );  // Signature will be checked later
-            ImportResult ir = import( t, IfDropped::Ignore, true, 0 );
-            m_onImport( ir, t.sha3(), work.nodeId );
-        } catch ( ... ) {
-            // should not happen as exceptions are handled in import.
-            BOOST_LOG( m_loggerWarning )
-                << "Bad transaction:" << boost::current_exception_diagnostic_information();
-        }
-        MICROPROFILE_LEAVE();
-    }
-}
 
 Transactions TransactionQueue::debugGetFutureTransactions() const {
     Transactions res;

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -640,8 +640,6 @@ void TransactionQueue::dropGood( Transaction const& _t ) {
             removedCurrentInfo = true;
         }
         removedCurrent = remove_WITH_LOCK( _t.sha3() );
-        if ( !removedCurrent && !_t.isInvalid() )
-            removeFuture_WITH_LOCK( _t );
     }
 
     if ( !_t.isInvalid() ) {

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -28,8 +28,7 @@
 #include <libethcore/Exceptions.h>
 #include <libethereum/SchainPatch.h>
 
-#include <list>
-#include <thread>
+#include <algorithm>
 #include <vector>
 
 using namespace std;
@@ -37,7 +36,6 @@ using namespace dev;
 using namespace dev::eth;
 
 namespace {
-constexpr size_t c_maxVerificationQueueSize = 8192;
 constexpr size_t c_maxDroppedTransactionCount = 1024;
 }  // namespace
 
@@ -56,6 +54,23 @@ TransactionQueue::TransactionQueue( unsigned _limit, unsigned _futureLimit,
 }
 
 TransactionQueue::~TransactionQueue() {}
+
+ImportResult TransactionQueue::import(
+    bytesConstRef _transactionRLP, IfDropped _ik, bool _isFuture ) {
+    try {
+        Transaction t = Transaction( _transactionRLP, CheckTransaction::Everything, false,
+            EIP1559TransactionsPatch::isEnabledInWorkingBlock(),
+            InvalidTransactionFormatPatch::isEnabledInWorkingBlock()
+#ifdef BITE
+                ,
+            Bite2Patch::isEnabledInWorkingBlock()
+#endif  // BITE
+        );
+        return import( t, _ik, _isFuture );
+    } catch ( Exception const& ) {
+        return ImportResult::Malformed;
+    }
+}
 
 ImportResult TransactionQueue::import( bytesConstRef _transactionRLP, IfDropped _ik,
     bool _allowFutureQueue, u256 const& _stateNonce ) {
@@ -84,6 +99,55 @@ ImportResult TransactionQueue::check_WITH_LOCK( h256 const& _h, IfDropped _ik ) 
     return ImportResult::Success;
 }
 
+ImportResult TransactionQueue::import(
+    Transaction const& _transaction, IfDropped _ik, bool _isFuture ) {
+    if ( _transaction.hasZeroSignature() )
+        return ImportResult::ZeroSignature;
+    // Check if we already know this transaction.
+    h256 h = _transaction.sha3( WithSignature );
+
+    ImportResult ret;
+    {
+        MICROPROFILE_SCOPEI( "TransactionQueue", "import", MP_THISTLE );
+        // WriteGuard l2( m_lock );
+        UpgradableGuard l( m_lock );
+
+        // HACK remove it from future and re-insert (allows to "push" stuck transaction)
+        auto fs = m_future.find( _transaction.from() );
+        if ( fs != m_future.end() ) {
+            auto t = fs->second.find( _transaction.nonce() );
+
+            // if transaction found:
+            if ( t != fs->second.end() ) {
+                UpgradeGuard ul( l );
+                --m_futureSize;
+                m_futureSizeBytes -= t->second.transaction.toBytes().size();
+                auto erasedHash = t->second.transaction.sha3();
+                BOOST_LOG( m_loggerTrace ) << "Re-inserting future transaction " << erasedHash;
+                m_known.erase( erasedHash );
+                fs->second.erase( t->second.transaction.nonce() );
+                if ( fs->second.empty() )
+                    m_future.erase( fs );
+            }  // if found
+        }      // if fs->second
+
+        auto ir = check_WITH_LOCK( h, _ik );
+        if ( ir != ImportResult::Success )
+            return ir;
+
+        {
+            _transaction.safeSender();  // Perform EC recovery outside of the write lock
+
+            UpgradeGuard ul( l );
+            ret = manageImport_WITH_LOCK( h, _transaction );
+
+            if ( _isFuture )
+                setFuture_WITH_LOCK( h );
+        }
+    }
+    return ret;
+}
+
 ImportResult TransactionQueue::import( Transaction const& _transaction, IfDropped _ik,
     bool _allowFutureQueue, u256 const& _stateNonce ) {
     if ( _transaction.hasZeroSignature() )
@@ -97,17 +161,35 @@ ImportResult TransactionQueue::import( Transaction const& _transaction, IfDroppe
         // WriteGuard l2( m_lock );
         UpgradableGuard l( m_lock );
 
-        if ( !isKnownFuture_WITH_LOCK( h, _transaction ) ) {
-            auto ir = check_WITH_LOCK( h, _ik );
-            if ( ir != ImportResult::Success )
-                return ir;
-        }
+        // HACK remove it from future and re-insert (allows to "push" stuck transaction)
+        auto fs = m_future.find( _transaction.from() );
+        if ( fs != m_future.end() ) {
+            auto t = fs->second.find( _transaction.nonce() );
+
+            // if transaction found:
+            if ( t != fs->second.end() ) {
+                UpgradeGuard ul( l );
+                --m_futureSize;
+                m_futureSizeBytes -= t->second.transaction.toBytes().size();
+                auto erasedHash = t->second.transaction.sha3();
+                BOOST_LOG( m_loggerTrace ) << "Re-inserting future transaction " << erasedHash;
+                m_known.erase( erasedHash );
+                fs->second.erase( t->second.transaction.nonce() );
+                if ( fs->second.empty() )
+                    m_future.erase( fs );
+            }  // if found
+        }      // if fs->second
+
+        auto ir = check_WITH_LOCK( h, _ik );
+        if ( ir != ImportResult::Success )
+            return ir;
 
         {
             _transaction.safeSender();  // Perform EC recovery outside of the write lock
 
             UpgradeGuard ul( l );
-            ret = manageImport_WITH_LOCK( h, _transaction, _allowFutureQueue, _stateNonce );
+            ret =
+                manageImport_WITH_LOCK( h, _transaction, _allowFutureQueue, _stateNonce );
         }
     }
     return ret;
@@ -190,8 +272,8 @@ const h256Hash TransactionQueue::knownTransactions() const {
     return rv;
 }
 
-ImportResult TransactionQueue::manageImport_WITH_LOCK( h256 const& _h,
-    Transaction const& _transaction, bool _allowFutureQueue, u256 const& _stateNonce ) {
+ImportResult TransactionQueue::manageImport_WITH_LOCK(
+    h256 const& _h, Transaction const& _transaction ) {
     try {
         assert( _h == _transaction.sha3() );
         // Remove any prior transaction with the same nonce but a lower gas price.
@@ -204,42 +286,75 @@ ImportResult TransactionQueue::manageImport_WITH_LOCK( h256 const& _h,
             }
         }
 
+        auto fs = m_future.find( _transaction.from() );
+        if ( fs != m_future.end() ) {
+            auto t = fs->second.find( _transaction.nonce() );
+            if ( t != fs->second.end() ) {
+                return ImportResult::SameNonceAlreadyInQueue;
+            }  // if found
+        }      // if fs->second
+
+        ImportResult ret = insertCurrent_WITH_LOCK( make_pair( _h, _transaction ) );
+        if ( ret == ImportResult::Success ) {
+            BOOST_LOG( m_loggerTrace ) << "Queued vaguely legit-looking transaction " << _h;
+            m_onReady();
+        } else if ( ret == ImportResult::QueueIsFull ) {
+            BOOST_LOG( m_loggerWarning ) << "Transaction queue is full. Rejecting transaction "
+                                         << _h;
+        }
+        return ret;
+    } catch ( Exception const& _e ) {
+        BOOST_LOG( m_loggerTrace )
+            << "Ignoring invalid transaction: " << diagnostic_information( _e );
+        return ImportResult::Malformed;
+    } catch ( std::exception const& _e ) {
+        BOOST_LOG( m_loggerTrace ) << "Ignoring invalid transaction: " << _e.what();
+        return ImportResult::Malformed;
+    }
+
+    return ImportResult::Success;
+}
+
+ImportResult TransactionQueue::manageImport_WITH_LOCK( h256 const& _h,
+    Transaction const& _transaction, bool _allowFutureQueue, u256 const& _stateNonce ) {
+    try {
+        assert( _h == _transaction.sha3() );
+        auto cs = m_currentByAddressAndNonce.find( _transaction.from() );
+        if ( cs != m_currentByAddressAndNonce.end() ) {
+            auto t = cs->second.find( _transaction.nonce() );
+            if ( t != cs->second.end() ) {
+                return ImportResult::SameNonceAlreadyInQueue;
+            }
+        }
+
+        auto fs = m_future.find( _transaction.from() );
+        if ( fs != m_future.end() ) {
+            auto t = fs->second.find( _transaction.nonce() );
+            if ( t != fs->second.end() ) {
+                return ImportResult::SameNonceAlreadyInQueue;
+            }  // if found
+        }      // if fs->second
+
         if ( _transaction.nonce() < _stateNonce )
             return ImportResult::AlreadyInChain;
 
         ImportResult ret = ImportResult::QueueIsFull;
-        bool const txNonceIsCompatibleWithCurrentQueue =
-            isCurrentNonceCompatible_WITH_LOCK( _transaction, _stateNonce );
-
-        if ( txNonceIsCompatibleWithCurrentQueue ) {
-            ret = tryInsertCurrent_WITH_LOCK( make_pair( _h, _transaction ) );
+        if ( isCurrentNonceCompatible_WITH_LOCK( _transaction, _stateNonce ) ) {
+            ret = insertCurrent_WITH_LOCK( make_pair( _h, _transaction ) );
             if ( ret == ImportResult::Success ) {
                 BOOST_LOG( m_loggerTrace ) << "Queued vaguely legit-looking transaction " << _h;
                 m_onReady();
-                return ret;
             }
-
-            // some error other than QueueIsFull happenned (should never happen)
-            if ( ret != ImportResult::QueueIsFull )
-                return ret;
+        } else if ( _allowFutureQueue && _transaction.nonce() > _stateNonce ) {
+            ret = insertFuture_WITH_LOCK( make_pair( _h, _transaction ) );
+            if ( ret == ImportResult::Success )
+                BOOST_LOG( m_loggerTrace ) << "Queued future transaction " << _h;
         }
 
-        // If transaction was not compatible with CTQ, meaning it was a future tx
-        // AND FTQ (future tx queue) is disabled
-        if ( !_allowFutureQueue ) {
-            BOOST_LOG( m_loggerWarning ) << "Transaction queue cannot accept transaction " << _h;
-            return ret;  // ret is QueueIsFull
+        if ( ret == ImportResult::QueueIsFull ) {
+            BOOST_LOG( m_loggerWarning ) << "Transaction queue is full. Rejecting transaction "
+                                         << _h;
         }
-
-        // If transaction was not compatible with CTQ, meaning it was a future tx
-        // AND FTQ is enabled -> try to add to FTQ
-        ret = tryInsertFuture_WITH_LOCK( make_pair( _h, _transaction ) );
-        if ( ret == ImportResult::Success )
-            BOOST_LOG( m_loggerTrace ) << "Queued future transaction " << _h;
-        else if ( ret == ImportResult::QueueIsFull )
-            BOOST_LOG( m_loggerWarning )
-                << "Future transaction queue is full. Dropping transaction " << _h;
-
         return ret;
     } catch ( Exception const& _e ) {
         BOOST_LOG( m_loggerTrace )
@@ -280,29 +395,16 @@ u256 TransactionQueue::maxCurrentNonce_WITH_LOCK( Address const& _a ) const {
     return ret;
 }
 
-ImportResult TransactionQueue::tryInsertCurrent_WITH_LOCK(
+ImportResult TransactionQueue::insertCurrent_WITH_LOCK(
     std::pair< h256, Transaction > const& _p ) {
-    const size_t transactionSizeBytes = _p.second.toBytes().size();
-
-    if ( m_current.size() + 1 > m_limit ||
-         m_currentSizeBytes + transactionSizeBytes > m_currentSizeBytesLimit ) {
-        return ImportResult::QueueIsFull;
-    }
-
     if ( m_currentByHash.count( _p.first ) ) {
         BOOST_LOG( m_loggerWarning ) << "Transaction hash" << _p.first << "already in current";
         return ImportResult::Success;
     }
 
-    // Defensive: compatibility was checked by the caller, but keep CTQ insertion self-contained.
     Transaction const& t = _p.second;
-    auto cs = m_currentByAddressAndNonce.find( t.from() );
-    if ( cs != m_currentByAddressAndNonce.end() &&
-         cs->second.find( t.nonce() ) != cs->second.end() ) {
-        return ImportResult::SameNonceAlreadyInQueue;
-    }
-
-    removeFuture_WITH_LOCK( t.from(), t.nonce() );
+    if ( !hasCurrentCapacity_WITH_LOCK( t ) )
+        return ImportResult::QueueIsFull;
 
     // Insert into current
     auto inserted = m_currentByAddressAndNonce[t.from()].insert(
@@ -313,81 +415,43 @@ ImportResult TransactionQueue::tryInsertCurrent_WITH_LOCK(
     inserted.first->second = handle;
     m_currentByHash[_p.first] = handle;
 #pragma GCC diagnostic pop
-    m_currentSizeBytes += transactionSizeBytes;
+    m_currentSizeBytes += t.toBytes().size();
 
     // Move following transactions from future to current
     makeCurrent_WITH_LOCK( t );
+    m_known.insert( _p.first );
+    return ImportResult::Success;
+}
+
+ImportResult TransactionQueue::insertFuture_WITH_LOCK(
+    std::pair< h256, Transaction > const& _p ) {
+    Transaction const& t = _p.second;
+    size_t const transactionSizeBytes = t.toBytes().size();
+    if ( m_futureSize + 1 > m_futureLimit ||
+         m_futureSizeBytes + transactionSizeBytes > m_futureSizeBytesLimit )
+        return ImportResult::QueueIsFull;
+
+    m_future[t.from()].emplace( t.nonce(), VerifiedTransaction( t ) );
+    ++m_futureSize;
+    m_futureSizeBytes += transactionSizeBytes;
     m_known.insert( _p.first );
 
     return ImportResult::Success;
 }
 
-ImportResult TransactionQueue::tryInsertFuture_WITH_LOCK(
-    std::pair< h256, Transaction > const& _p ) {
-    Transaction const& t = _p.second;
-    size_t const transactionSizeBytes = t.toBytes().size();
-    auto fs = m_future.find( t.from() );
-
-    if ( fs != m_future.end() ) {
-        auto existing = fs->second.find( t.nonce() );
-        if ( existing != fs->second.end() ) {
-            if ( existing->second.transaction.sha3() == _p.first )
-                return ImportResult::Success;  // tx already exists
-
-            // different tx with same nonce
-            return ImportResult::SameNonceAlreadyInQueue;
-        }
-    }
-
-    size_t const nextFutureSize = m_futureSize + 1;
-    size_t const nextFutureSizeBytes = m_futureSizeBytes + transactionSizeBytes;
-    if ( nextFutureSize > m_futureLimit || nextFutureSizeBytes > m_futureSizeBytesLimit )
-        return ImportResult::QueueIsFull;
-
-    ++m_futureSize;
-    m_futureSizeBytes += transactionSizeBytes;
-    m_future[t.from()].emplace( t.nonce(), VerifiedTransaction( t ) );
-    m_known.insert( _p.first );
-    return ImportResult::Success;
+bool TransactionQueue::hasCurrentCapacity_WITH_LOCK( Transaction const& _transaction ) const {
+    size_t const transactionSizeBytes = _transaction.toBytes().size();
+    return m_current.size() + 1 <= m_limit &&
+           m_currentSizeBytes + transactionSizeBytes <= m_currentSizeBytesLimit;
 }
 
 bool TransactionQueue::isCurrentNonceCompatible_WITH_LOCK(
     Transaction const& _transaction, u256 const& _stateNonce ) const {
     auto cs = m_currentByAddressAndNonce.find( _transaction.from() );
-
-    // no txs from same user in queue -> check if nonce is compatible with state nonce
     if ( cs == m_currentByAddressAndNonce.end() || cs->second.empty() )
         return _transaction.nonce() == _stateNonce;
 
-    // Some txs from same user in queue -> check if nonce is compatible with last tx from same user
-    // in queue
     return _transaction.nonce() == cs->second.rbegin()->first + 1;
-}
-
-bool TransactionQueue::isKnownFuture_WITH_LOCK(
-    h256 const& _h, Transaction const& _transaction ) const {
-    auto fs = m_future.find( _transaction.from() );
-    if ( fs == m_future.end() )
-        return false;
-    auto existing = fs->second.find( _transaction.nonce() );
-    return existing != fs->second.end() && existing->second.transaction.sha3() == _h;
-}
-
-void TransactionQueue::removeFuture_WITH_LOCK( Address const& _from, u256 const& _nonce ) {
-    auto fs = m_future.find( _from );
-    if ( fs == m_future.end() )
-        return;
-
-    auto existing = fs->second.find( _nonce );
-    if ( existing == fs->second.end() )
-        return;
-
-    m_futureSizeBytes -= existing->second.transaction.toBytes().size();
-    m_known.erase( existing->second.transaction.sha3() );
-    fs->second.erase( existing );
-    --m_futureSize;
-    if ( fs->second.empty() )
-        m_future.erase( fs );
 }
 
 bool TransactionQueue::remove_WITH_LOCK( h256 const& _txHash ) {
@@ -479,11 +543,8 @@ void TransactionQueue::makeCurrent_WITH_LOCK( Transaction const& _t ) {
         if ( fb != fs->second.end() ) {
             auto ft = fb;
             while ( ft != fs->second.end() && ft->second.transaction.nonce() == nonce ) {
-                size_t const transactionSizeBytes = ft->second.transaction.toBytes().size();
-                if ( m_current.size() + 1 > m_limit ||
-                     m_currentSizeBytes + transactionSizeBytes > m_currentSizeBytesLimit ) {
+                if ( !hasCurrentCapacity_WITH_LOCK( ft->second.transaction ) )
                     break;
-                }
 
                 auto inserted = m_currentByAddressAndNonce[_t.from()].insert(
                     std::make_pair( ft->second.transaction.nonce(), PriorityQueue::iterator() ) );
@@ -493,8 +554,8 @@ void TransactionQueue::makeCurrent_WITH_LOCK( Transaction const& _t ) {
                 inserted.first->second = handle;
                 m_currentByHash[( *handle ).transaction.sha3()] = handle;
 #pragma GCC diagnostic pop
-                m_futureSizeBytes -= transactionSizeBytes;
-                m_currentSizeBytes += transactionSizeBytes;
+                m_futureSizeBytes -= ( *handle ).transaction.toBytes().size();
+                m_currentSizeBytes += ( *handle ).transaction.toBytes().size();
                 --m_futureSize;
                 ++ft;
                 ++nonce;
@@ -565,7 +626,6 @@ void TransactionQueue::clear() {
     m_futureSize = 0;
     m_futureSizeBytes = 0;
 }
-
 
 Transactions TransactionQueue::debugGetFutureTransactions() const {
     Transactions res;

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -92,8 +92,8 @@ void TransactionQueue::HandleDestruction() {
     }
 }
 
-ImportResult TransactionQueue::import(
-    bytesConstRef _transactionRLP, IfDropped _ik, bool _isFuture ) {
+ImportResult TransactionQueue::import( bytesConstRef _transactionRLP, IfDropped _ik,
+    bool _allowFutureQueue, u256 const& _stateNonce ) {
     try {
         Transaction t = Transaction( _transactionRLP, CheckTransaction::Everything, false,
             EIP1559TransactionsPatch::isEnabledInWorkingBlock(),
@@ -103,7 +103,7 @@ ImportResult TransactionQueue::import(
             Bite2Patch::isEnabledInWorkingBlock()
 #endif  // BITE
         );
-        return import( t, _ik, _isFuture );
+        return import( t, _ik, _allowFutureQueue, _stateNonce );
     } catch ( Exception const& ) {
         return ImportResult::Malformed;
     }
@@ -119,8 +119,8 @@ ImportResult TransactionQueue::check_WITH_LOCK( h256 const& _h, IfDropped _ik ) 
     return ImportResult::Success;
 }
 
-ImportResult TransactionQueue::import(
-    Transaction const& _transaction, IfDropped _ik, bool _isFuture ) {
+ImportResult TransactionQueue::import( Transaction const& _transaction, IfDropped _ik,
+    bool _allowFutureQueue, u256 const& _stateNonce ) {
     if ( _transaction.hasZeroSignature() )
         return ImportResult::ZeroSignature;
     // Check if we already know this transaction.
@@ -132,37 +132,17 @@ ImportResult TransactionQueue::import(
         // WriteGuard l2( m_lock );
         UpgradableGuard l( m_lock );
 
-        // HACK remove it from future and re-insert (allows to "push" stuck transaction)
-        auto fs = m_future.find( _transaction.from() );
-        if ( fs != m_future.end() ) {
-            auto t = fs->second.find( _transaction.nonce() );
-
-            // if transaction found:
-            if ( t != fs->second.end() ) {
-                UpgradeGuard ul( l );
-                --m_futureSize;
-                m_futureSizeBytes -= t->second.transaction.toBytes().size();
-                auto erasedHash = t->second.transaction.sha3();
-                BOOST_LOG( m_loggerTrace ) << "Re-inserting future transaction " << erasedHash;
-                m_known.erase( erasedHash );
-                fs->second.erase( t->second.transaction.nonce() );
-                if ( fs->second.empty() )
-                    m_future.erase( fs );
-            }  // if found
-        }      // if fs->second
-
-        auto ir = check_WITH_LOCK( h, _ik );
-        if ( ir != ImportResult::Success )
-            return ir;
+        if ( !isKnownFuture_WITH_LOCK( h, _transaction ) ) {
+            auto ir = check_WITH_LOCK( h, _ik );
+            if ( ir != ImportResult::Success )
+                return ir;
+        }
 
         {
             _transaction.safeSender();  // Perform EC recovery outside of the write lock
 
             UpgradeGuard ul( l );
-            ret = manageImport_WITH_LOCK( h, _transaction );
-
-            if ( _isFuture )
-                setFuture_WITH_LOCK( h );
+            ret = manageImport_WITH_LOCK( h, _transaction, _allowFutureQueue, _stateNonce );
         }
     }
     return ret;
@@ -245,8 +225,8 @@ const h256Hash TransactionQueue::knownTransactions() const {
     return rv;
 }
 
-ImportResult TransactionQueue::manageImport_WITH_LOCK(
-    h256 const& _h, Transaction const& _transaction ) {
+ImportResult TransactionQueue::manageImport_WITH_LOCK( h256 const& _h,
+    Transaction const& _transaction, bool _allowFutureQueue, u256 const& _stateNonce ) {
     try {
         assert( _h == _transaction.sha3() );
         // Remove any prior transaction with the same nonce but a lower gas price.
@@ -259,24 +239,44 @@ ImportResult TransactionQueue::manageImport_WITH_LOCK(
             }
         }
 
-        auto fs = m_future.find( _transaction.from() );
-        if ( fs != m_future.end() ) {
-            auto t = fs->second.find( _transaction.nonce() );
-            if ( t != fs->second.end() ) {
-                return ImportResult::SameNonceAlreadyInQueue;
-            }  // if found
-        }      // if fs->second
+        if ( _transaction.nonce() < _stateNonce )
+            return ImportResult::AlreadyInChain;
 
-        // If valid, append to transactions.
-        insertCurrent_WITH_LOCK( make_pair( _h, _transaction ) );
-        BOOST_LOG( m_loggerTrace ) << "Queued vaguely legit-looking transaction " << _h;
+        ImportResult ret = ImportResult::QueueIsFull;
+        bool const txNonceIsCompatibleWithCurrentQueue =
+            isCurrentNonceCompatible_WITH_LOCK( _transaction, _stateNonce );
 
-        while ( m_current.size() > m_limit || m_currentSizeBytes > m_currentSizeBytesLimit ) {
-            BOOST_LOG( m_loggerTrace ) << "Dropping out of bounds transaction " << _h;
-            remove_WITH_LOCK( m_current.rbegin()->transaction.sha3() );
+        if ( txNonceIsCompatibleWithCurrentQueue ) {
+            ret = tryInsertCurrent_WITH_LOCK( make_pair( _h, _transaction ) );
+            if ( ret == ImportResult::Success ) {
+                BOOST_LOG( m_loggerTrace ) << "Queued vaguely legit-looking transaction " << _h;
+                m_onReady();
+                return ret;
+            }
+
+            // some error other than QueueIsFull happenned (should never happen)
+            if ( ret != ImportResult::QueueIsFull )
+                return ret;
         }
 
-        m_onReady();
+        // If transaction was not compatible with CTQ, meaning it was a future tx
+        // AND FTQ (future tx queue) is disabled
+        if ( !_allowFutureQueue ) {
+            BOOST_LOG( m_loggerWarning )
+                << "Transaction queue cannot accept transaction " << _h;
+            return ret; // ret is QueueIsFull
+        }
+
+        // If transaction was not compatible with CTQ, meaning it was a future tx
+        // AND FTQ is enabled -> try to add to FTQ
+        ret = tryInsertFuture_WITH_LOCK( make_pair( _h, _transaction ) );
+        if ( ret == ImportResult::Success )
+            BOOST_LOG( m_loggerTrace ) << "Queued future transaction " << _h;
+        else if ( ret == ImportResult::QueueIsFull )
+            BOOST_LOG( m_loggerWarning ) << "Future transaction queue is full. Dropping transaction "
+                                         << _h;
+
+        return ret;
     } catch ( Exception const& _e ) {
         BOOST_LOG( m_loggerTrace )
             << "Ignoring invalid transaction: " << diagnostic_information( _e );
@@ -285,8 +285,6 @@ ImportResult TransactionQueue::manageImport_WITH_LOCK(
         BOOST_LOG( m_loggerTrace ) << "Ignoring invalid transaction: " << _e.what();
         return ImportResult::Malformed;
     }
-
-    return ImportResult::Success;
 }
 
 u256 TransactionQueue::maxNonce( Address const& _a ) const {
@@ -318,13 +316,30 @@ u256 TransactionQueue::maxCurrentNonce_WITH_LOCK( Address const& _a ) const {
     return ret;
 }
 
-void TransactionQueue::insertCurrent_WITH_LOCK( std::pair< h256, Transaction > const& _p ) {
-    if ( m_currentByHash.count( _p.first ) ) {
-        BOOST_LOG( m_loggerWarning ) << "Transaction hash" << _p.first << "already in current";
-        return;
+ImportResult TransactionQueue::tryInsertCurrent_WITH_LOCK(
+    std::pair< h256, Transaction > const& _p ) {
+    const size_t transactionSizeBytes = _p.second.toBytes().size();
+
+    if ( m_current.size() + 1 > m_limit ||
+         m_currentSizeBytes + transactionSizeBytes > m_currentSizeBytesLimit ) {
+        return ImportResult::QueueIsFull;
     }
 
+    if ( m_currentByHash.count( _p.first ) ) {
+        BOOST_LOG( m_loggerWarning ) << "Transaction hash" << _p.first << "already in current";
+        return ImportResult::Success;
+    }
+
+    // Defensive: compatibility was checked by the caller, but keep CTQ insertion self-contained.
     Transaction const& t = _p.second;
+    auto cs = m_currentByAddressAndNonce.find( t.from() );
+    if ( cs != m_currentByAddressAndNonce.end() &&
+         cs->second.find( t.nonce() ) != cs->second.end() ) {
+        return ImportResult::SameNonceAlreadyInQueue;
+    }
+
+    removeFuture_WITH_LOCK( t.from(), t.nonce() );
+
     // Insert into current
     auto inserted = m_currentByAddressAndNonce[t.from()].insert(
         std::make_pair( t.nonce(), PriorityQueue::iterator() ) );
@@ -334,11 +349,80 @@ void TransactionQueue::insertCurrent_WITH_LOCK( std::pair< h256, Transaction > c
     inserted.first->second = handle;
     m_currentByHash[_p.first] = handle;
 #pragma GCC diagnostic pop
-    m_currentSizeBytes += t.toBytes().size();
+    m_currentSizeBytes += transactionSizeBytes;
 
     // Move following transactions from future to current
     makeCurrent_WITH_LOCK( t );
     m_known.insert( _p.first );
+
+    return ImportResult::Success;
+}
+
+ImportResult TransactionQueue::tryInsertFuture_WITH_LOCK(
+    std::pair< h256, Transaction > const& _p ) {
+    Transaction const& t = _p.second;
+    size_t const transactionSizeBytes = t.toBytes().size();
+    auto fs = m_future.find( t.from() );
+
+    if ( fs != m_future.end() ) {
+        auto existing = fs->second.find( t.nonce() );
+        if ( existing != fs->second.end() ) {
+            if ( existing->second.transaction.sha3() == _p.first )
+                return ImportResult::Success; // tx already exists
+            
+            // different tx with same nonce
+            return ImportResult::SameNonceAlreadyInQueue;
+        }
+    }
+
+    size_t const nextFutureSize = m_futureSize + 1;
+    size_t const nextFutureSizeBytes = m_futureSizeBytes + transactionSizeBytes;
+    if ( nextFutureSize > m_futureLimit || nextFutureSizeBytes > m_futureSizeBytesLimit )
+        return ImportResult::QueueIsFull;
+
+    ++m_futureSize;
+    m_futureSizeBytes += transactionSizeBytes;
+    m_future[t.from()].emplace( t.nonce(), VerifiedTransaction( t ) );
+    m_known.insert( _p.first );
+    return ImportResult::Success;
+}
+
+bool TransactionQueue::isCurrentNonceCompatible_WITH_LOCK(
+    Transaction const& _transaction, u256 const& _stateNonce ) const {
+    auto cs = m_currentByAddressAndNonce.find( _transaction.from() );
+
+    // no txs from same user in queue -> check if nonce is compatible with state nonce
+    if ( cs == m_currentByAddressAndNonce.end() || cs->second.empty() )
+        return _transaction.nonce() == _stateNonce;
+
+    // Some txs from same user in queue -> check if nonce is compatible with last tx from same user in queue
+    return _transaction.nonce() == cs->second.rbegin()->first + 1;
+}
+
+bool TransactionQueue::isKnownFuture_WITH_LOCK(
+    h256 const& _h, Transaction const& _transaction ) const {
+    auto fs = m_future.find( _transaction.from() );
+    if ( fs == m_future.end() )
+        return false;
+    auto existing = fs->second.find( _transaction.nonce() );
+    return existing != fs->second.end() && existing->second.transaction.sha3() == _h;
+}
+
+void TransactionQueue::removeFuture_WITH_LOCK( Address const& _from, u256 const& _nonce ) {
+    auto fs = m_future.find( _from );
+    if ( fs == m_future.end() )
+        return;
+
+    auto existing = fs->second.find( _nonce );
+    if ( existing == fs->second.end() )
+        return;
+
+    m_futureSizeBytes -= existing->second.transaction.toBytes().size();
+    m_known.erase( existing->second.transaction.sha3() );
+    fs->second.erase( existing );
+    --m_futureSize;
+    if ( fs->second.empty() )
+        m_future.erase( fs );
 }
 
 bool TransactionQueue::remove_WITH_LOCK( h256 const& _txHash ) {
@@ -430,6 +514,12 @@ void TransactionQueue::makeCurrent_WITH_LOCK( Transaction const& _t ) {
         if ( fb != fs->second.end() ) {
             auto ft = fb;
             while ( ft != fs->second.end() && ft->second.transaction.nonce() == nonce ) {
+                size_t const transactionSizeBytes = ft->second.transaction.toBytes().size();
+                if ( m_current.size() + 1 > m_limit ||
+                     m_currentSizeBytes + transactionSizeBytes > m_currentSizeBytesLimit ) {
+                    break;
+                }
+
                 auto inserted = m_currentByAddressAndNonce[_t.from()].insert(
                     std::make_pair( ft->second.transaction.nonce(), PriorityQueue::iterator() ) );
                 PriorityQueue::iterator handle = m_current.emplace( move( ft->second ) );
@@ -438,8 +528,8 @@ void TransactionQueue::makeCurrent_WITH_LOCK( Transaction const& _t ) {
                 inserted.first->second = handle;
                 m_currentByHash[( *handle ).transaction.sha3()] = handle;
 #pragma GCC diagnostic pop
-                m_futureSizeBytes -= ( *handle ).transaction.toBytes().size();
-                m_currentSizeBytes += ( *handle ).transaction.toBytes().size();
+                m_futureSizeBytes -= transactionSizeBytes;
+                m_currentSizeBytes += transactionSizeBytes;
                 --m_futureSize;
                 ++ft;
                 ++nonce;
@@ -480,13 +570,11 @@ void TransactionQueue::dropGood( Transaction const& _t ) {
         return;
 #endif
 
+    if ( m_known.count( _t.sha3() ) )
+        remove_WITH_LOCK( _t.sha3() );
+
     if ( !_t.isInvalid() )
         makeCurrent_WITH_LOCK( _t );
-
-    if ( !m_known.count( _t.sha3() ) )
-        return;
-
-    remove_WITH_LOCK( _t.sha3() );
 }
 
 void TransactionQueue::dropMany( h256Hash const& _txHashes ) {
@@ -561,7 +649,7 @@ void TransactionQueue::verifierBody() {
                 Bite2Patch::isEnabledInWorkingBlock()
 #endif          // BITE
             );  // Signature will be checked later
-            ImportResult ir = import( t );
+            ImportResult ir = import( t, IfDropped::Ignore, true, 0 );
             m_onImport( ir, t.sha3(), work.nodeId );
         } catch ( ... ) {
             // should not happen as exceptions are handled in import.

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -262,9 +262,8 @@ ImportResult TransactionQueue::manageImport_WITH_LOCK( h256 const& _h,
         // If transaction was not compatible with CTQ, meaning it was a future tx
         // AND FTQ (future tx queue) is disabled
         if ( !_allowFutureQueue ) {
-            BOOST_LOG( m_loggerWarning )
-                << "Transaction queue cannot accept transaction " << _h;
-            return ret; // ret is QueueIsFull
+            BOOST_LOG( m_loggerWarning ) << "Transaction queue cannot accept transaction " << _h;
+            return ret;  // ret is QueueIsFull
         }
 
         // If transaction was not compatible with CTQ, meaning it was a future tx
@@ -273,8 +272,8 @@ ImportResult TransactionQueue::manageImport_WITH_LOCK( h256 const& _h,
         if ( ret == ImportResult::Success )
             BOOST_LOG( m_loggerTrace ) << "Queued future transaction " << _h;
         else if ( ret == ImportResult::QueueIsFull )
-            BOOST_LOG( m_loggerWarning ) << "Future transaction queue is full. Dropping transaction "
-                                         << _h;
+            BOOST_LOG( m_loggerWarning )
+                << "Future transaction queue is full. Dropping transaction " << _h;
 
         return ret;
     } catch ( Exception const& _e ) {
@@ -368,8 +367,8 @@ ImportResult TransactionQueue::tryInsertFuture_WITH_LOCK(
         auto existing = fs->second.find( t.nonce() );
         if ( existing != fs->second.end() ) {
             if ( existing->second.transaction.sha3() == _p.first )
-                return ImportResult::Success; // tx already exists
-            
+                return ImportResult::Success;  // tx already exists
+
             // different tx with same nonce
             return ImportResult::SameNonceAlreadyInQueue;
         }
@@ -395,7 +394,8 @@ bool TransactionQueue::isCurrentNonceCompatible_WITH_LOCK(
     if ( cs == m_currentByAddressAndNonce.end() || cs->second.empty() )
         return _transaction.nonce() == _stateNonce;
 
-    // Some txs from same user in queue -> check if nonce is compatible with last tx from same user in queue
+    // Some txs from same user in queue -> check if nonce is compatible with last tx from same user
+    // in queue
     return _transaction.nonce() == cs->second.rbegin()->first + 1;
 }
 

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -38,16 +38,6 @@ using namespace dev::eth;
 namespace {
 constexpr size_t c_maxDroppedTransactionCount = 1024;
 
-Transaction decodeTransaction( bytesConstRef _transactionRLP ) {
-    return Transaction( _transactionRLP, CheckTransaction::Everything, false,
-        EIP1559TransactionsPatch::isEnabledInWorkingBlock(),
-        InvalidTransactionFormatPatch::isEnabledInWorkingBlock()
-#ifdef BITE
-            ,
-        Bite2Patch::isEnabledInWorkingBlock()
-#endif  // BITE
-    );
-}
 }  // namespace
 
 TransactionQueue::TransactionQueue( unsigned _limit, unsigned _futureLimit,
@@ -69,7 +59,15 @@ TransactionQueue::~TransactionQueue() {}
 ImportResult TransactionQueue::import( bytesConstRef _transactionRLP, IfDropped _ik,
     bool _allowFutureQueue, u256 const& _stateNonce ) {
     try {
-        return import( decodeTransaction( _transactionRLP ), _ik, _allowFutureQueue, _stateNonce );
+        Transaction t = Transaction( _transactionRLP, CheckTransaction::Everything, false,
+            EIP1559TransactionsPatch::isEnabledInWorkingBlock(),
+            InvalidTransactionFormatPatch::isEnabledInWorkingBlock()
+#ifdef BITE
+                ,
+            Bite2Patch::isEnabledInWorkingBlock()
+#endif  // BITE
+        );
+        return import( t, _ik, _allowFutureQueue, _stateNonce );
     } catch ( Exception const& ) {
         return ImportResult::Malformed;
     }
@@ -95,31 +93,13 @@ ImportResult TransactionQueue::import( Transaction const& _transaction, IfDroppe
     ImportResult ret;
     {
         MICROPROFILE_SCOPEI( "TransactionQueue", "import", MP_THISTLE );
-        // WriteGuard l2( m_lock );
         UpgradableGuard l( m_lock );
 
-        // HACK remove it from future and re-insert (allows to "push" stuck transaction)
-        auto fs = m_future.find( _transaction.from() );
-        if ( fs != m_future.end() ) {
-            auto t = fs->second.find( _transaction.nonce() );
-
-            // if transaction found:
-            if ( t != fs->second.end() ) {
-                UpgradeGuard ul( l );
-                --m_futureSize;
-                m_futureSizeBytes -= t->second.transaction.toBytes().size();
-                auto erasedHash = t->second.transaction.sha3();
-                BOOST_LOG( m_loggerTrace ) << "Re-inserting future transaction " << erasedHash;
-                m_known.erase( erasedHash );
-                fs->second.erase( t->second.transaction.nonce() );
-                if ( fs->second.empty() )
-                    m_future.erase( fs );
-            }  // if found
-        }      // if fs->second
-
-        auto ir = check_WITH_LOCK( h, _ik );
-        if ( ir != ImportResult::Success )
-            return ir;
+        if ( !isExactFutureTransactionQueued_WITH_LOCK( h, _transaction ) ) {
+            auto ir = check_WITH_LOCK( h, _ik );
+            if ( ir != ImportResult::Success )
+                return ir;
+        }
 
         {
             _transaction.safeSender();  // Perform EC recovery outside of the write lock
@@ -130,6 +110,16 @@ ImportResult TransactionQueue::import( Transaction const& _transaction, IfDroppe
         }
     }
     return ret;
+}
+
+bool TransactionQueue::isExactFutureTransactionQueued_WITH_LOCK(
+    h256 const& _h, Transaction const& _transaction ) const {
+    auto fs = m_future.find( _transaction.from() );
+    if ( fs == m_future.end() )
+        return false;
+
+    auto existing = fs->second.find( _transaction.nonce() );
+    return existing != fs->second.end() && existing->second.transaction.sha3() == _h;
 }
 
 Transactions TransactionQueue::topTransactions( unsigned _limit, h256Hash const& _avoid ) const {
@@ -213,6 +203,8 @@ ImportResult TransactionQueue::manageImport_WITH_LOCK( h256 const& _h,
     Transaction const& _transaction, bool _allowFutureQueue, u256 const& _stateNonce ) {
     try {
         assert( _h == _transaction.sha3() );
+
+        // check if same nonce tx already in CTQ
         auto cs = m_currentByAddressAndNonce.find( _transaction.from() );
         if ( cs != m_currentByAddressAndNonce.end() ) {
             auto t = cs->second.find( _transaction.nonce() );
@@ -221,25 +213,75 @@ ImportResult TransactionQueue::manageImport_WITH_LOCK( h256 const& _h,
             }
         }
 
+        // try finding a tx with same nonce in future queue first
         auto fs = m_future.find( _transaction.from() );
         if ( fs != m_future.end() ) {
             auto t = fs->second.find( _transaction.nonce() );
             if ( t != fs->second.end() ) {
-                return ImportResult::SameNonceAlreadyInQueue;
-            }  // if found
-        }      // if fs->second
 
+                // exact same tx already in future
+                if ( t->second.transaction.sha3() != _h )
+                    return ImportResult::SameNonceAlreadyInQueue;
+
+                auto eraseFuture = [&]() {
+                    --m_futureSize;
+                    m_futureSizeBytes -= t->second.transaction.toBytes().size();
+                    m_known.erase( _h );
+                    fs->second.erase( t );
+                    if ( fs->second.empty() )
+                        m_future.erase( fs );
+                };
+
+                // tx with same nonce already in FTQ & has old nonce -> remove
+                if ( _transaction.nonce() < _stateNonce ) {
+                    eraseFuture();
+                    return ImportResult::AlreadyInChain;
+                }
+
+                // tx with same nonce already in FTQ & has future nonce -> leave it be
+                if ( !isCurrentNonceCompatible_WITH_LOCK( _transaction, _stateNonce ) )
+                    return ImportResult::Success;
+
+                // at this point, the tx is:
+                // - in FTQ
+                // - has same nonce as the new tx
+                // - has nonce compatible with CTQ (i.e. not too old, not too in the future)
+
+                if ( !hasCurrentCapacity_WITH_LOCK( _transaction ) ) {
+                    m_blockedPromotions[_transaction.from()] = _transaction.nonce();
+                    return ImportResult::QueueIsFull;
+                }
+
+                // move it from future to current
+                eraseFuture();
+                ImportResult ret = insertCurrent_WITH_LOCK( make_pair( _h, _transaction ) );
+                if ( ret == ImportResult::Success ) {
+                    BOOST_LOG( m_loggerTrace )
+                        << "Queued vaguely legit-looking transaction " << _h;
+                    m_onReady();
+                }
+                return ret;
+            }
+        }
+
+        // at this point - tx was not in FTQ
+
+        // old tx -> discard
         if ( _transaction.nonce() < _stateNonce )
             return ImportResult::AlreadyInChain;
 
         ImportResult ret = ImportResult::QueueIsFull;
+        // if compatible with CTQ - try insert in CTQ - may fail due to queue full
         if ( isCurrentNonceCompatible_WITH_LOCK( _transaction, _stateNonce ) ) {
+            // may fail insertion if queue full
             ret = insertCurrent_WITH_LOCK( make_pair( _h, _transaction ) );
             if ( ret == ImportResult::Success ) {
                 BOOST_LOG( m_loggerTrace ) << "Queued vaguely legit-looking transaction " << _h;
                 m_onReady();
             }
+        // if future -> try insert in FTQ
         } else if ( _allowFutureQueue && _transaction.nonce() > _stateNonce ) {
+            // may fail insertion if queue full
             ret = insertFuture_WITH_LOCK( make_pair( _h, _transaction ) );
             if ( ret == ImportResult::Success )
                 BOOST_LOG( m_loggerTrace ) << "Queued future transaction " << _h;
@@ -320,23 +362,16 @@ ImportResult TransactionQueue::insertCurrent_WITH_LOCK(
 ImportResult TransactionQueue::insertFuture_WITH_LOCK(
     std::pair< h256, Transaction > const& _p ) {
     Transaction const& t = _p.second;
+    size_t const transactionSizeBytes = t.toBytes().size();
+
+    if ( m_futureSize + 1 > m_futureLimit ||
+         m_futureSizeBytes + transactionSizeBytes > m_futureSizeBytesLimit )
+        return ImportResult::QueueIsFull;
+
     m_future[t.from()].emplace( t.nonce(), VerifiedTransaction( t ) );
     ++m_futureSize;
-    m_futureSizeBytes += t.toBytes().size();
+    m_futureSizeBytes += transactionSizeBytes;
     m_known.insert( _p.first );
-
-    while ( m_futureSize > m_futureLimit || m_futureSizeBytes > m_futureSizeBytesLimit ) {
-        // TODO: priority queue for future transactions
-        // For now just drop random chain end
-        --m_futureSize;
-        m_futureSizeBytes -= m_future.begin()->second.rbegin()->second.transaction.toBytes().size();
-        auto erasedHash = m_future.begin()->second.rbegin()->second.transaction.sha3();
-        BOOST_LOG( m_loggerTrace ) << "Dropping out of bounds future transaction " << erasedHash;
-        m_known.erase( erasedHash );
-        m_future.begin()->second.erase( --m_future.begin()->second.end() );
-        if ( m_future.begin()->second.empty() )
-            m_future.erase( m_future.begin() );
-    }
 
     return ImportResult::Success;
 }
@@ -350,10 +385,18 @@ bool TransactionQueue::hasCurrentCapacity_WITH_LOCK( Transaction const& _transac
 bool TransactionQueue::isCurrentNonceCompatible_WITH_LOCK(
     Transaction const& _transaction, u256 const& _stateNonce ) const {
     auto cs = m_currentByAddressAndNonce.find( _transaction.from() );
-    if ( cs == m_currentByAddressAndNonce.end() || cs->second.empty() )
+    if ( cs == m_currentByAddressAndNonce.end() || cs->second.empty() ) {
         return _transaction.nonce() == _stateNonce;
+    }
 
-    return _transaction.nonce() == cs->second.rbegin()->first + 1;
+    u256 expectedNonce = _stateNonce;
+    auto it = cs->second.lower_bound( expectedNonce );
+    while ( it != cs->second.end() && it->first == expectedNonce ) {
+        ++expectedNonce;
+        ++it;
+    }
+
+    return _transaction.nonce() == expectedNonce;
 }
 
 bool TransactionQueue::remove_WITH_LOCK( h256 const& _txHash ) {
@@ -373,6 +416,30 @@ bool TransactionQueue::remove_WITH_LOCK( h256 const& _txHash ) {
     if ( it->second.empty() )
         m_currentByAddressAndNonce.erase( it );
     m_known.erase( _txHash );
+    return true;
+}
+
+bool TransactionQueue::removeFuture_WITH_LOCK( Transaction const& _transaction ) {
+    auto fs = m_future.find( _transaction.from() );
+    if ( fs == m_future.end() )
+        return false;
+
+    auto ft = fs->second.find( _transaction.nonce() );
+    if ( ft == fs->second.end() || ft->second.transaction.sha3() != _transaction.sha3() )
+        return false;
+
+    m_futureSizeBytes -= ft->second.transaction.toBytes().size();
+    --m_futureSize;
+    m_known.erase( _transaction.sha3() );
+    fs->second.erase( ft );
+    if ( fs->second.empty() )
+        m_future.erase( fs );
+
+    auto blockedPromotion = m_blockedPromotions.find( _transaction.from() );
+    if ( blockedPromotion != m_blockedPromotions.end() &&
+         blockedPromotion->second <= _transaction.nonce() )
+        m_blockedPromotions.erase( blockedPromotion );
+
     return true;
 }
 
@@ -399,6 +466,7 @@ void TransactionQueue::setFuture_WITH_LOCK( h256 const& _txHash ) {
     auto& queue = m_currentByAddressAndNonce[from];
     auto& target = m_future[from];
     auto cutoff = queue.lower_bound( st.transaction.nonce() );
+    bool movedToFuture = false;
     for ( auto m = cutoff; m != queue.end(); ++m ) {
         VerifiedTransaction& t = const_cast< VerifiedTransaction& >(
             *( m->second ) );  // set has only const iterators. Since we are moving out of container
@@ -409,10 +477,13 @@ void TransactionQueue::setFuture_WITH_LOCK( h256 const& _txHash ) {
         target.emplace( t.transaction.nonce(), move( t ) );
         m_current.erase( m->second );
         ++m_futureSize;
+        movedToFuture = true;
     }
     queue.erase( cutoff, queue.end() );
     if ( queue.empty() )
         m_currentByAddressAndNonce.erase( from );
+    if ( movedToFuture )
+        m_blockedPromotions.erase( from );
 
     while ( m_futureSize > m_futureLimit || m_futureSizeBytes > m_futureSizeBytesLimit ) {
         // TODO: priority queue for future transactions
@@ -426,6 +497,9 @@ void TransactionQueue::setFuture_WITH_LOCK( h256 const& _txHash ) {
         if ( m_future.begin()->second.empty() )
             m_future.erase( m_future.begin() );
     }
+
+    if ( movedToFuture )
+        retryBlockedPromotions_WITH_LOCK();
 }
 
 // Note - this function is only used for tests
@@ -437,40 +511,95 @@ void TransactionQueue::setFuture( h256 const& _txHash ) {
 void TransactionQueue::makeCurrent_WITH_LOCK( Transaction const& _t ) {
     MICROPROFILE_SCOPEI( "TransactionQueue", "makeCurrent_WITH_LOCK", MP_DEEPSKYBLUE );
 
-    bool newCurrent = false;
-    auto fs = m_future.find( _t.from() );
-    if ( fs != m_future.end() ) {
-        u256 nonce = _t.nonce() + 1;
-        auto fb = fs->second.find( nonce );
-        if ( fb != fs->second.end() ) {
-            auto ft = fb;
-            while ( ft != fs->second.end() && ft->second.transaction.nonce() == nonce ) {
-                if ( !hasCurrentCapacity_WITH_LOCK( ft->second.transaction ) )
-                    break;
+    promoteFutureTransactions_WITH_LOCK( _t.from(), _t.nonce() + 1 );
+}
 
-                auto inserted = m_currentByAddressAndNonce[_t.from()].insert(
-                    std::make_pair( ft->second.transaction.nonce(), PriorityQueue::iterator() ) );
-                PriorityQueue::iterator handle = m_current.emplace( move( ft->second ) );
+bool TransactionQueue::promoteFutureTransactions_WITH_LOCK(
+    Address const& _from, u256 const& _nonce ) {
+
+    auto fs = m_future.find( _from );
+    // no such sender in FTQ but in blocked promotions - remove from blocked promotions
+    if ( fs == m_future.end() ) {
+        m_blockedPromotions.erase( _from );
+        return false;
+    }
+
+    auto fb = fs->second.find( _nonce );
+    // tx with nonce is in FTQ already - remove from blocked promotions if it was there
+    if ( fb == fs->second.end() ) {
+        auto blockedPromotion = m_blockedPromotions.find( _from );
+        if ( blockedPromotion != m_blockedPromotions.end() && blockedPromotion->second == _nonce )
+            m_blockedPromotions.erase( blockedPromotion );
+        return false;
+    }
+
+    bool newCurrent = false;
+    u256 nonce = _nonce;
+    auto ft = fb;
+    while ( ft != fs->second.end() && ft->second.transaction.nonce() == nonce ) {
+        if ( !hasCurrentCapacity_WITH_LOCK( ft->second.transaction ) ) {
+            m_blockedPromotions[_from] = nonce;
+            break;
+        }
+
+        auto inserted = m_currentByAddressAndNonce[_from].insert(
+            std::make_pair( ft->second.transaction.nonce(), PriorityQueue::iterator() ) );
+        PriorityQueue::iterator handle = m_current.emplace( move( ft->second ) );
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-copy"
-                inserted.first->second = handle;
-                m_currentByHash[( *handle ).transaction.sha3()] = handle;
+        inserted.first->second = handle;
+        m_currentByHash[( *handle ).transaction.sha3()] = handle;
 #pragma GCC diagnostic pop
-                m_futureSizeBytes -= ( *handle ).transaction.toBytes().size();
-                m_currentSizeBytes += ( *handle ).transaction.toBytes().size();
-                --m_futureSize;
-                ++ft;
-                ++nonce;
-                newCurrent = true;
-            }
-            fs->second.erase( fb, ft );
-            if ( fs->second.empty() )
-                m_future.erase( _t.from() );
-        }
+        m_futureSizeBytes -= ( *handle ).transaction.toBytes().size();
+        m_currentSizeBytes += ( *handle ).transaction.toBytes().size();
+        --m_futureSize;
+        ++ft;
+        ++nonce;
+        newCurrent = true;
+    }
+    fs->second.erase( fb, ft );
+    if ( fs->second.empty() )
+        m_future.erase( _from );
+
+    if ( newCurrent ) {
+        auto blockedPromotion = m_blockedPromotions.find( _from );
+        if ( blockedPromotion != m_blockedPromotions.end() && blockedPromotion->second < nonce )
+            m_blockedPromotions.erase( blockedPromotion );
     }
 
     if ( newCurrent )
         m_onReady();
+
+    return newCurrent;
+}
+
+void TransactionQueue::retryBlockedPromotions_WITH_LOCK() {
+    if ( m_blockedPromotions.empty() )
+        return;
+
+    std::vector< std::pair< Address, u256 > > blockedPromotions;
+    blockedPromotions.reserve( m_blockedPromotions.size() );
+    for ( auto const& blockedPromotion : m_blockedPromotions )
+        blockedPromotions.push_back( blockedPromotion );
+
+    for ( auto const& blockedPromotion : blockedPromotions ) {
+
+        // early exit if no capacity in CTQ
+        if ( m_current.size() >= m_limit || m_currentSizeBytes >= m_currentSizeBytesLimit )
+            return;
+
+        auto current = m_blockedPromotions.find( blockedPromotion.first );
+        if ( current == m_blockedPromotions.end() || current->second != blockedPromotion.second )
+            continue;
+        promoteFutureTransactions_WITH_LOCK( blockedPromotion.first, blockedPromotion.second );
+    }
+}
+
+void TransactionQueue::invalidateBlockedPromotion_WITH_LOCK(
+    Address const& _from, u256 const& _nonce ) {
+    auto blockedPromotion = m_blockedPromotions.find( _from );
+    if ( blockedPromotion != m_blockedPromotions.end() && _nonce < blockedPromotion->second )
+        m_blockedPromotions.erase( blockedPromotion );
 }
 
 void TransactionQueue::drop( h256 const& _txHash ) {
@@ -481,7 +610,14 @@ void TransactionQueue::drop( h256 const& _txHash ) {
 
     UpgradeGuard ul( l );
     m_dropped.insert( _txHash, true );
-    remove_WITH_LOCK( _txHash );
+
+    auto current = m_currentByHash.find( _txHash );
+    if ( current != m_currentByHash.end() )
+        invalidateBlockedPromotion_WITH_LOCK(
+            ( *current->second ).transaction.from(), ( *current->second ).transaction.nonce() );
+
+    if ( remove_WITH_LOCK( _txHash ) )
+        retryBlockedPromotions_WITH_LOCK();
 }
 
 void TransactionQueue::dropGood( Transaction const& _t ) {
@@ -498,22 +634,53 @@ void TransactionQueue::dropGood( Transaction const& _t ) {
         return;
 #endif
 
-    if ( m_known.count( _t.sha3() ) )
-        remove_WITH_LOCK( _t.sha3() );
+    bool removedCurrent = false;
+    Address removedFrom;
+    u256 removedNonce;
+    bool removedCurrentInfo = false;
 
-    if ( !_t.isInvalid() )
+    if ( m_known.count( _t.sha3() ) ) {
+        auto current = m_currentByHash.find( _t.sha3() );
+        if ( current != m_currentByHash.end() ) {
+            removedFrom = ( *current->second ).transaction.from();
+            removedNonce = ( *current->second ).transaction.nonce();
+            removedCurrentInfo = true;
+        }
+        removedCurrent = remove_WITH_LOCK( _t.sha3() );
+        if ( !removedCurrent && !_t.isInvalid() )
+            removeFuture_WITH_LOCK( _t );
+    }
+
+    if ( !_t.isInvalid() ) {
+        auto blockedPromotion = m_blockedPromotions.find( _t.from() );
+        if ( blockedPromotion != m_blockedPromotions.end() &&
+             blockedPromotion->second <= _t.nonce() )
+            m_blockedPromotions.erase( blockedPromotion );
         makeCurrent_WITH_LOCK( _t );
+    } else if ( removedCurrentInfo )
+        invalidateBlockedPromotion_WITH_LOCK( removedFrom, removedNonce );
+
+    if ( removedCurrent )
+        retryBlockedPromotions_WITH_LOCK();
 }
 
 void TransactionQueue::dropMany( h256Hash const& _txHashes ) {
     WriteGuard l( m_lock );
 
+    bool removedCurrent = false;
     for ( auto&& _txHash : _txHashes ) {
         if ( !m_known.count( _txHash ) )
             continue;
         m_dropped.insert( _txHash, true );
-        remove_WITH_LOCK( _txHash );
+        auto current = m_currentByHash.find( _txHash );
+        if ( current != m_currentByHash.end() )
+            invalidateBlockedPromotion_WITH_LOCK(
+                ( *current->second ).transaction.from(), ( *current->second ).transaction.nonce() );
+        removedCurrent = remove_WITH_LOCK( _txHash ) || removedCurrent;
     }
+
+    if ( removedCurrent )
+        retryBlockedPromotions_WITH_LOCK();
 }
 
 void TransactionQueue::clear() {
@@ -527,6 +694,7 @@ void TransactionQueue::clear() {
     m_future.clear();
     m_futureSize = 0;
     m_futureSizeBytes = 0;
+    m_blockedPromotions.clear();
 }
 
 Transactions TransactionQueue::debugGetFutureTransactions() const {

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -450,10 +450,10 @@ unsigned TransactionQueue::waiting( Address const& _a ) const {
     return ret;
 }
 
-void TransactionQueue::setFuture_WITH_LOCK( h256 const& _txHash ) {
+bool TransactionQueue::setFuture_WITH_LOCK( h256 const& _txHash ) {
     auto it = m_currentByHash.find( _txHash );
     if ( it == m_currentByHash.end() )
-        return;
+        return false;
 
     VerifiedTransaction const& st = *( it->second );
 
@@ -494,19 +494,26 @@ void TransactionQueue::setFuture_WITH_LOCK( h256 const& _txHash ) {
     }
 
     if ( movedToFuture )
-        retryBlockedPromotions_WITH_LOCK();
+        return retryBlockedPromotions_WITH_LOCK();
+
+    return false;
 }
 
 // Note - this function is only used for tests
 void TransactionQueue::setFuture( h256 const& _txHash ) {
-    WriteGuard l( m_lock );
-    return setFuture_WITH_LOCK( _txHash );
+    bool readyChanged = false;
+    {
+        WriteGuard l( m_lock );
+        readyChanged = setFuture_WITH_LOCK( _txHash );
+    }
+    if ( readyChanged )
+        notifyReady();
 }
 
-void TransactionQueue::makeCurrent_WITH_LOCK( Transaction const& _t ) {
+bool TransactionQueue::makeCurrent_WITH_LOCK( Transaction const& _t ) {
     MICROPROFILE_SCOPEI( "TransactionQueue", "makeCurrent_WITH_LOCK", MP_DEEPSKYBLUE );
 
-    promoteFutureTransactions_WITH_LOCK( _t.from(), _t.nonce() + 1 );
+    return promoteFutureTransactions_WITH_LOCK( _t.from(), _t.nonce() + 1 );
 }
 
 bool TransactionQueue::promoteFutureTransactions_WITH_LOCK(
@@ -561,31 +568,33 @@ bool TransactionQueue::promoteFutureTransactions_WITH_LOCK(
             m_blockedPromotions.erase( blockedPromotion );
     }
 
-    if ( newCurrent )
-        m_onReady();
-
     return newCurrent;
 }
 
-void TransactionQueue::retryBlockedPromotions_WITH_LOCK() {
+bool TransactionQueue::retryBlockedPromotions_WITH_LOCK() {
     if ( m_blockedPromotions.empty() )
-        return;
+        return false;
 
     std::vector< std::pair< Address, u256 > > blockedPromotions;
     blockedPromotions.reserve( m_blockedPromotions.size() );
     for ( auto const& blockedPromotion : m_blockedPromotions )
         blockedPromotions.push_back( blockedPromotion );
 
+    bool readyChanged = false;
     for ( auto const& blockedPromotion : blockedPromotions ) {
         // early exit if no capacity in CTQ
         if ( m_current.size() >= m_limit || m_currentSizeBytes >= m_currentSizeBytesLimit )
-            return;
+            return readyChanged;
 
         auto current = m_blockedPromotions.find( blockedPromotion.first );
         if ( current == m_blockedPromotions.end() || current->second != blockedPromotion.second )
             continue;
-        promoteFutureTransactions_WITH_LOCK( blockedPromotion.first, blockedPromotion.second );
+        readyChanged =
+            promoteFutureTransactions_WITH_LOCK( blockedPromotion.first, blockedPromotion.second ) ||
+            readyChanged;
     }
+
+    return readyChanged;
 }
 
 void TransactionQueue::invalidateBlockedPromotion_WITH_LOCK(
@@ -596,38 +605,61 @@ void TransactionQueue::invalidateBlockedPromotion_WITH_LOCK(
 }
 
 void TransactionQueue::drop( h256 const& _txHash ) {
-    UpgradableGuard l( m_lock );
+    bool readyChanged = false;
+    {
+        UpgradableGuard l( m_lock );
 
-    if ( !m_known.count( _txHash ) )
-        return;
+        if ( !m_known.count( _txHash ) )
+            return;
 
-    UpgradeGuard ul( l );
-    m_dropped.insert( _txHash, true );
+        UpgradeGuard ul( l );
+        m_dropped.insert( _txHash, true );
 
-    auto current = m_currentByHash.find( _txHash );
-    if ( current != m_currentByHash.end() )
-        invalidateBlockedPromotion_WITH_LOCK(
-            ( *current->second ).transaction.from(), ( *current->second ).transaction.nonce() );
+        auto current = m_currentByHash.find( _txHash );
+        if ( current != m_currentByHash.end() )
+            invalidateBlockedPromotion_WITH_LOCK(
+                ( *current->second ).transaction.from(), ( *current->second ).transaction.nonce() );
 
-    if ( remove_WITH_LOCK( _txHash ) )
-        retryBlockedPromotions_WITH_LOCK();
+        if ( remove_WITH_LOCK( _txHash ) )
+            readyChanged = retryBlockedPromotions_WITH_LOCK();
+    }
+
+    if ( readyChanged )
+        notifyReady();
 }
 
-void TransactionQueue::dropGood( Transaction const& _t ) {
+TransactionQueue::DropGoodResult TransactionQueue::dropGood(
+    Transaction const& _t, ReadyNotification _notification ) {
     MICROPROFILE_SCOPEI( "TransactionQueue", "dropGood", MP_CORNSILK );
     MICROPROFILE_ENTERI( "TransactionQueue", "lock", MP_OLDLACE );
-    WriteGuard l( m_lock );
-    MICROPROFILE_LEAVE();
+    DropGoodResult result;
+    {
+        WriteGuard l( m_lock );
+        MICROPROFILE_LEAVE();
+        result = dropGood_WITH_LOCK( _t );
+    }
+
+    if ( result.readyChanged && _notification == ReadyNotification::Notify )
+        notifyReady();
+
+    return result;
+}
+
+TransactionQueue::DropGoodResult TransactionQueue::dropGood_WITH_LOCK( Transaction const& _t ) {
+    DropGoodResult result;
 
 #ifdef BITE
     // BITE transactions are stored separately
     // they are also stored in the strict order
     // delete and return
-    if ( m_bite2Queue.dropGood( _t ) )
-        return;
+    if ( m_bite2Queue.dropGood( _t ) ) {
+        result.removed = true;
+        return result;
+    }
 #endif
 
     bool removedCurrent = false;
+    bool removedFuture = false;
     Address removedFrom;
     u256 removedNonce;
     bool removedCurrentInfo = false;
@@ -641,39 +673,52 @@ void TransactionQueue::dropGood( Transaction const& _t ) {
         }
         removedCurrent = remove_WITH_LOCK( _t.sha3() );
         if ( !removedCurrent && !_t.isInvalid() )
-            removeFuture_WITH_LOCK( _t );
+            removedFuture = removeFuture_WITH_LOCK( _t );
     }
+    result.removed = removedCurrent || removedFuture;
 
     if ( !_t.isInvalid() ) {
         auto blockedPromotion = m_blockedPromotions.find( _t.from() );
         if ( blockedPromotion != m_blockedPromotions.end() &&
              blockedPromotion->second <= _t.nonce() )
             m_blockedPromotions.erase( blockedPromotion );
-        makeCurrent_WITH_LOCK( _t );
+        result.readyChanged = makeCurrent_WITH_LOCK( _t ) || result.readyChanged;
     } else if ( removedCurrentInfo )
         invalidateBlockedPromotion_WITH_LOCK( removedFrom, removedNonce );
 
     if ( removedCurrent )
-        retryBlockedPromotions_WITH_LOCK();
+        result.readyChanged = retryBlockedPromotions_WITH_LOCK() || result.readyChanged;
+
+    return result;
 }
 
 void TransactionQueue::dropMany( h256Hash const& _txHashes ) {
-    WriteGuard l( m_lock );
-
+    bool readyChanged = false;
     bool removedCurrent = false;
-    for ( auto&& _txHash : _txHashes ) {
-        if ( !m_known.count( _txHash ) )
-            continue;
-        m_dropped.insert( _txHash, true );
-        auto current = m_currentByHash.find( _txHash );
-        if ( current != m_currentByHash.end() )
-            invalidateBlockedPromotion_WITH_LOCK(
-                ( *current->second ).transaction.from(), ( *current->second ).transaction.nonce() );
-        removedCurrent = remove_WITH_LOCK( _txHash ) || removedCurrent;
+    {
+        WriteGuard l( m_lock );
+
+        for ( auto&& _txHash : _txHashes ) {
+            if ( !m_known.count( _txHash ) )
+                continue;
+            m_dropped.insert( _txHash, true );
+            auto current = m_currentByHash.find( _txHash );
+            if ( current != m_currentByHash.end() )
+                invalidateBlockedPromotion_WITH_LOCK( ( *current->second ).transaction.from(),
+                    ( *current->second ).transaction.nonce() );
+            removedCurrent = remove_WITH_LOCK( _txHash ) || removedCurrent;
+        }
+
+        if ( removedCurrent )
+            readyChanged = retryBlockedPromotions_WITH_LOCK();
     }
 
-    if ( removedCurrent )
-        retryBlockedPromotions_WITH_LOCK();
+    if ( readyChanged )
+        notifyReady();
+}
+
+void TransactionQueue::notifyReady() {
+    m_onReady();
 }
 
 void TransactionQueue::clear() {
@@ -728,6 +773,12 @@ void TransactionQueue::clearTempBITE2Transactions() {
 
 std::vector< dev::h256 > TransactionQueue::getNCTXOrigins( size_t _n ) const {
     return m_bite2Queue.getNCTXOrigins( _n );
+}
+
+std::optional< std::vector< dev::h256 > >
+TransactionQueue::validateNextExpectedBITE2CTXsAndGetOrigins(
+    std::vector< Transaction > const& _ctxs ) const {
+    return m_bite2Queue.validateNextExpectedCTXsAndGetOrigins( _ctxs );
 }
 
 void TransactionQueue::setBITE2QueueOnInit( std::deque< Transaction >&& _ctxQueue ) {

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -589,9 +589,9 @@ bool TransactionQueue::retryBlockedPromotions_WITH_LOCK() {
         auto current = m_blockedPromotions.find( blockedPromotion.first );
         if ( current == m_blockedPromotions.end() || current->second != blockedPromotion.second )
             continue;
-        readyChanged =
-            promoteFutureTransactions_WITH_LOCK( blockedPromotion.first, blockedPromotion.second ) ||
-            readyChanged;
+        readyChanged = promoteFutureTransactions_WITH_LOCK(
+                           blockedPromotion.first, blockedPromotion.second ) ||
+                       readyChanged;
     }
 
     return readyChanged;

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -46,8 +46,13 @@ namespace dev {
 namespace eth {
 
 /**
- * @brief A queue of Transactions, each stored as RLP.
- * Maintains a transaction queue sorted by nonce diff and gas price.
+ * @brief Queue of verified transactions.
+ * Maintains a current transaction queue (CTQ) sorted by nonce distance and gas price, plus a
+ * future transaction queue (FTQ) for valid transactions whose nonce is not executable yet.
+ * Keeps track of a 'blockedPromotions' mapping used to keep track of txs that were tried
+ * to be promoted from FTQ to CTQ, but CTQ was full at the time.
+ * This is needed since we only promote FTQ txs from a specific sender that must be in CTQ.
+ * blockedPromotions solves the case where a FTQ that hasn't same sender in CTQ to be promoted.
  * @threadsafe
  */
 class TransactionQueue {
@@ -71,41 +76,45 @@ public:
               _l.currentLimit, _l.futureLimit, _l.currentLimitBytes, _l.futureLimitBytes ) {}
     ~TransactionQueue();
 
+    /// Import an RLP-encoded transaction.
+    /// @param _allowFutureQueue If true, valid future nonce transactions may be queued in FTQ.
+    /// @param _stateNonce Current nonce for the transaction sender according to chain state.
     ImportResult import(
         bytes const& _tx, IfDropped _ik, bool _allowFutureQueue, u256 const& _stateNonce ) {
         return import( &_tx, _ik, _allowFutureQueue, _stateNonce );
     }
 
+    /// Import a decoded transaction. See the RLP overload for queue placement parameters.
     ImportResult import(
         Transaction const& _tx, IfDropped _ik, bool _allowFutureQueue, u256 const& _stateNonce );
 
-    /// Remove transaction from the queue
+    /// Remove a transaction from the current queue by hash.
     /// @param _txHash Transaction hash
     void drop( h256 const& _txHash );
 
-    /// Remove many transactions from the queue at once
-    /// @param _txHash Transaction hash
+    /// Remove many transactions from the current queue by hash.
+    /// @param _txHashes Transaction hashes
     void dropMany( h256Hash const& _txHashes );
 
     /// Get number of pending transactions for account.
     /// @returns Pending transaction count.
     unsigned waiting( Address const& _a ) const;
 
-    /// Get top transactions from the queue. Returned transactions are not removed from the queue
+    /// Get top current transactions from the queue. Returned transactions are not removed
     /// automatically.
     /// @param _limit Max number of transactions to return.
     /// @param _avoid Transactions to avoid returning.
     /// @returns up to _limit transactions ordered by nonce and gas price.
     Transactions topTransactions( unsigned _limit, h256Hash const& _avoid = h256Hash() ) const;
 
-    // same with categories
+    /// Get top current transactions using the category-aware ordering path.
     Transactions topTransactions( unsigned _limit );
 
-    // generalization of previous
+    /// Get top current transactions that satisfy pred.
     template < class Pred >
     Transactions topTransactions( unsigned _limit, Pred pred ) const;
 
-    /// Synchronuous version of topTransactions
+    /// Synchronous version of topTransactions.
     template < class... Args >
     Transactions topTransactionsSync( unsigned _limit, Args... args ) const;
     template < class... Args >
@@ -113,30 +122,27 @@ public:
 
     Transactions debugGetFutureTransactions() const;
 
-    /// Get a hash set of transactions in the queue
-    /// @returns A hash set of all transactions in the queue
-    // this is really heavy operation and should be used with caution
+    /// Get hashes of all known transactions in current and future queues.
+    // This is a heavy operation and should be used with caution.
     const h256Hash knownTransactions() const;
 
-    // Check if transaction is in the queue
+    /// Check whether a transaction hash is known to the queue.
     bool isTransactionKnown( h256& _hash ) const;
 
-    /// Get max nonce for an account
-    /// @returns Max transaction nonce for account in the queue
+    /// Get one greater than the highest queued nonce for an account across CTQ and FTQ.
     u256 maxNonce( Address const& _a ) const;
 
-    /// Get max nonce from current queue for an account
-    /// @returns Max transaction nonce for account in the queue
+    /// Get one greater than the highest queued nonce for an account in CTQ only.
     u256 maxCurrentNonce( Address const& _a ) const;
 
-    /// Mark transaction as future. It wont be returned in topTransactions list until a transaction
-    /// with a preceeding nonce is imported or marked with dropGood
+    /// Move this transaction and any following same-sender current transactions to FTQ.
+    /// Moved transactions are not returned by topTransactions until their preceding nonces are
+    /// imported or marked with dropGood.
     /// @param _t Transaction hash
     void setFuture( h256 const& _t );
 
-    /// Drop a transaction from the list if exists and move following future transactions to current
-    /// (if any)
-    /// @param _t Transaction hash
+    /// Remove an accepted transaction and promote following future transactions when possible.
+    /// @param _t Accepted transaction
     void dropGood( Transaction const& _t );
 
 #ifdef BITE
@@ -217,9 +223,8 @@ public:
 public:
     /// Verified and imported transaction
     struct VerifiedTransaction {
-        // record object creation time. This is to make sure that
-        // transaction queue gives priority to transastions received earliest
-        // when everything else like gas price and height are the same
+        // Record creation time so transactions received earlier keep priority when nonce height and
+        // gas price are equal.
         uint64_t creationTimeMs;
 
         VerifiedTransaction( Transaction const& _t ) : transaction( _t ) {
@@ -232,8 +237,7 @@ public:
             creationTimeMs = _t.creationTimeMs;
         }
 
-        VerifiedTransaction( VerifiedTransaction const& ) = default;  // XXX removed "delete" for
-                                                                      // tricks with queue
+        VerifiedTransaction( VerifiedTransaction const& ) = default;  // Needed by queue operations.
         VerifiedTransaction& operator=( VerifiedTransaction const& ) = delete;
 
         Transaction transaction;  ///< Transaction data
@@ -276,32 +280,48 @@ public:
                 it2->second.begin()->first;
 
             if ( height1 != height2 ) {
-                // transactions with smaller nonce difference vs the current account nonce go first
+                // Prefer transactions closer to the sender's lowest current queued nonce.
                 return height1 < height2;
             }
 
-            // for the same height, transactions vs larger gas price go first
+            // For the same height, prefer transactions with larger gas price.
             if ( _first.transaction.gasPrice() != _second.transaction.gasPrice() ) {
                 return _first.transaction.gasPrice() > _second.transaction.gasPrice();
             }
 
-            // new - if the height and the gas price are the same, the earlier received transactions
-            // go first
+            // If height and gas price are equal, prefer the transaction received earlier.
 
             return _first.creationTimeMs < _second.creationTimeMs;
         }
     };
 
 private:
-    // Use a set with dynamic comparator for minmax priority queue. The comparator takes into
-    // account min account nonce. Updating it does not affect the order.
+    // Current transactions are stored in a set ordered by PriorityCompare. The comparator depends
+    // on each sender's lowest current nonce, so callers that change nonce ranges may need to
+    // refresh ordering explicitly.
     using PriorityQueue = boost::container::multiset< VerifiedTransaction, PriorityCompare >;
 
+    /**
+     * Decodes and imports a transaction using the caller-provided sender state nonce.
+     * @param _allowFutureQueue If true, valid future nonce transactions may be queued in FTQ.
+     * @param _stateNonce Current nonce for the transaction sender according to chain state.
+     */
     ImportResult import(
         bytesConstRef _tx, IfDropped _ik, bool _allowFutureQueue, u256 const& _stateNonce );
+
     ImportResult check_WITH_LOCK( h256 const& _h, IfDropped _ik );
+
+    /**
+     * Places a checked transaction in CTQ or FTQ, using _stateNonce to decide whether the nonce is
+     * current, future, or already in chain. Re-importing an exact FTQ transaction can promote it to
+     * CTQ once it becomes current-compatible.
+     */
     ImportResult manageImport_WITH_LOCK( h256 const& _h, Transaction const& _transaction,
         bool _allowFutureQueue, u256 const& _stateNonce );
+
+    /**
+     * Returns true when FTQ already contains this exact transaction at the same sender and nonce.
+     */
     bool isExactFutureTransactionQueued_WITH_LOCK(
         h256 const& _h, Transaction const& _transaction ) const;
 
@@ -312,27 +332,55 @@ private:
     Transactions topTransactions_WITH_LOCK( unsigned _limit );
 
     /**
-     * Tries inserting a transaction into CTQ.
-     * @returns Success if tx was inserted, or there was already a tx with same hash.
-     *          QueueIsFull if tx is valid but there is no room in CTQ.
+     * Inserts a current-compatible transaction into CTQ without evicting existing transactions.
+     * @returns Success if the transaction was inserted, or was already present by hash.
+     *          QueueIsFull when CTQ lacks count or byte capacity.
      */
     ImportResult insertCurrent_WITH_LOCK( std::pair< h256, Transaction > const& _p );
 
     /**
-     * Tries inserting a transaction into the future queue.
-     * @returns Success if tx was inserted, or there was already a tx with same hash.
-     *          QueueIsFull if tx is valid but there is no room in the future queue.
+     * Inserts a future nonce transaction into FTQ without evicting existing transactions.
+     * @returns Success if the transaction was inserted.
+     *          QueueIsFull when FTQ lacks count or byte capacity.
      */
     ImportResult insertFuture_WITH_LOCK( std::pair< h256, Transaction > const& _p );
+
+    /// Returns whether adding _transaction would fit within CTQ count and byte limits.
     bool hasCurrentCapacity_WITH_LOCK( Transaction const& _transaction ) const;
+
+    /**
+     * Returns whether _transaction is the next nonce CTQ can currently accept for its sender.
+     * The check starts at _stateNonce and walks the sender's contiguous CTQ nonce range, so gaps
+     * created by drops can be filled even when higher nonces are already queued.
+     */
     bool isCurrentNonceCompatible_WITH_LOCK(
         Transaction const& _transaction, u256 const& _stateNonce ) const;
+
+    /**
+     * Promotes the sender's contiguous FTQ range starting at _nonce into CTQ while capacity allows.
+     * If CTQ fills up, records the first nonce that could not be promoted in m_blockedPromotions.
+     * @returns true if at least one transaction was moved to CTQ.
+     */
     bool promoteFutureTransactions_WITH_LOCK( Address const& _from, u256 const& _nonce );
+
+    /// Retries cached FTQ-to-CTQ promotions after CTQ capacity may have been freed.
     void retryBlockedPromotions_WITH_LOCK();
+
+    /**
+     * Clears _from's cached promotion when dropping _nonce breaks the contiguous path to the cached
+     * future transaction.
+     */
     void invalidateBlockedPromotion_WITH_LOCK( Address const& _from, u256 const& _nonce );
+
+    /// Promotes future transactions that immediately follow the newly current transaction _t.
     void makeCurrent_WITH_LOCK( Transaction const& _t );
+
+    /// Removes a transaction from CTQ and its secondary indexes.
     bool remove_WITH_LOCK( h256 const& _txHash );
+
+    /// Removes an exact transaction from FTQ and clears any blocked promotion that depended on it.
     bool removeFuture_WITH_LOCK( Transaction const& _transaction );
+
     u256 maxNonce_WITH_LOCK( Address const& _a ) const;
     u256 maxCurrentNonce_WITH_LOCK( Address const& _a ) const;
     void setFuture_WITH_LOCK( h256 const& _t );
@@ -341,31 +389,29 @@ private:
     mutable boost::condition_variable_any m_cond;  // for wait/notify
     Handler<> m_readyCondNotifier;
 
-    h256Hash m_known;  ///< Headers of transactions in both sets.
+    h256Hash m_known;  ///< Hashes of transactions in CTQ and FTQ.
 
     std::unordered_map< h256, std::function< void( ImportResult ) > > m_callbacks;  ///< Called
                                                                                     ///< once.
     LruCache< h256, bool > m_dropped;  ///< Transactions that have previously been dropped
 
     PriorityQueue m_current;
-    std::unordered_map< h256, PriorityQueue::iterator > m_currentByHash;  ///< Transaction hash to
-                                                                          ///< set ref
+    std::unordered_map< h256, PriorityQueue::iterator > m_currentByHash;  ///< CTQ hash to iterator.
 
     std::unordered_map< Address, std::map< u256, PriorityQueue::iterator > >
-        m_currentByAddressAndNonce;  ///< Transactions grouped by account and nonce
-    std::unordered_map< Address, std::map< u256, VerifiedTransaction > > m_future;  /// Future
-                                                                                    /// transactions
+        m_currentByAddressAndNonce;  ///< CTQ transactions grouped by account and nonce.
+    std::unordered_map< Address, std::map< u256, VerifiedTransaction > >
+        m_future;  ///< FTQ transactions grouped by account and nonce.
 
-    // Holds the nonce of the first future tx that could not be promoted to CTQ due to capacity limits.
-    // whenever CTQ gets free space, we check this map and try to promote the blocked transaction and
-    // following ones if any.
+    // For each sender, stores the first FTQ nonce that was ready for CTQ but could not be promoted
+    // because CTQ was full. Entries are retried when CTQ capacity may have become available.
     std::unordered_map< Address, u256 > m_blockedPromotions;
 
     Signal<> m_onReady;  ///< Called when a subsequent call to import transactions will return a
                          ///< non-empty container. Be nice and exit fast.
     Signal< ImportResult, h256 const&, h512 const& > m_onImport;  ///< Called for each import
                                                                   ///< attempt. Arguments are
-                                                                  ///< result, transaction id an
+                                                                  ///< result, transaction id, and
                                                                   ///< node id. Be nice and exit
                                                                   ///< fast.
     Signal< h256 const& > m_onReplaced;  ///< Called when transaction is dropped during a call to

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -47,13 +47,24 @@ namespace eth {
 
 /**
  * @brief Queue of verified transactions.
- * Maintains a current transaction queue (CTQ) sorted by nonce distance and gas price, plus a
- * future transaction queue (FTQ) for valid transactions whose nonce is not executable yet.
- * Keeps track of a 'blockedPromotions' mapping used to keep track of txs that were tried
- * to be promoted from FTQ to CTQ, but CTQ was full at the time.
- * This is needed since we only promote FTQ txs from a specific sender that must be in CTQ.
- * blockedPromotions solves the case where a FTQ that hasn't same sender in CTQ to be promoted.
- * @threadsafe
+ *
+ * Maintains two sub-queues:
+ *   - CTQ (current queue): transactions whose nonce equals the next expected nonce for their
+ *     sender, ordered by nonce distance and gas price.
+ *   - FTQ (future queue): transactions whose nonce is ahead of the next expected nonce and
+ *     therefore not yet executable. Requires allowFutureQueue to be enabled at import time.
+ *
+ * FTQ transactions are promoted to CTQ automatically once the preceding nonce becomes current
+ * (via makeCurrent_WITH_LOCK). However, if CTQ is at capacity when a promotion is attempted,
+ * the transaction stays in FTQ and the blocked nonce is recorded in m_blockedPromotions.
+ * Promotions for that sender are retried whenever CTQ capacity is freed (e.g. on drop or
+ * dropGood).
+ *
+ * Example: sender A has nonce 5 in FTQ. Transaction with nonce 4 is accepted (dropGood).
+ * makeCurrent_WITH_LOCK tries to promote nonce 5 to CTQ, but CTQ is full.
+ * m_blockedPromotions[A] = 5 is recorded. Later, an unrelated transaction is dropped from CTQ,
+ * freeing a slot. retryBlockedPromotions_WITH_LOCK fires and promotes nonce 5 successfully.
+ *
  */
 class TransactionQueue {
 public:
@@ -265,19 +276,16 @@ public:
             else if ( !_first.transaction && !_second.transaction )
                 return false;
 
-            auto it1 = queue.m_currentByAddressAndNonce.find(_first.transaction.sender());
-            auto it2 = queue.m_currentByAddressAndNonce.find(_second.transaction.sender());
+            auto it1 = queue.m_currentByAddressAndNonce.find( _first.transaction.sender() );
+            auto it2 = queue.m_currentByAddressAndNonce.find( _second.transaction.sender() );
 
-            if (it1 == queue.m_currentByAddressAndNonce.end() || it2 == queue.m_currentByAddressAndNonce.end())
+            if ( it1 == queue.m_currentByAddressAndNonce.end() ||
+                 it2 == queue.m_currentByAddressAndNonce.end() )
                 return _first.creationTimeMs < _second.creationTimeMs;
 
-            u256 const& height1 =
-                _first.transaction.nonce() -
-                it1->second.begin()->first;
+            u256 const& height1 = _first.transaction.nonce() - it1->second.begin()->first;
 
-            u256 const& height2 =
-                _second.transaction.nonce() -
-                it2->second.begin()->first;
+            u256 const& height2 = _second.transaction.nonce() - it2->second.begin()->first;
 
             if ( height1 != height2 ) {
                 // Prefer transactions closer to the sender's lowest current queued nonce.
@@ -400,8 +408,11 @@ private:
 
     std::unordered_map< Address, std::map< u256, PriorityQueue::iterator > >
         m_currentByAddressAndNonce;  ///< CTQ transactions grouped by account and nonce.
-    std::unordered_map< Address, std::map< u256, VerifiedTransaction > >
-        m_future;  ///< FTQ transactions grouped by account and nonce.
+    std::unordered_map< Address, std::map< u256, VerifiedTransaction > > m_future;  ///< FTQ
+                                                                                    ///< transactions
+                                                                                    ///< grouped by
+                                                                                    ///< account and
+                                                                                    ///< nonce.
 
     // For each sender, stores the first FTQ nonce that was ready for CTQ but could not be promoted
     // because CTQ was full. Entries are retried when CTQ capacity may have become available.

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -261,14 +261,19 @@ public:
             else if ( !_first.transaction && !_second.transaction )
                 return false;
 
+            auto it1 = queue.m_currentByAddressAndNonce.find(_first.transaction.sender());
+            auto it2 = queue.m_currentByAddressAndNonce.find(_second.transaction.sender());
+
+            if (it1 == queue.m_currentByAddressAndNonce.end() || it2 == queue.m_currentByAddressAndNonce.end())
+                return _first.creationTimeMs < _second.creationTimeMs;
+
             u256 const& height1 =
                 _first.transaction.nonce() -
-                queue.m_currentByAddressAndNonce[_first.transaction.sender()].begin()->first;
+                it1->second.begin()->first;
 
             u256 const& height2 =
                 _second.transaction.nonce() -
-                queue.m_currentByAddressAndNonce[_second.transaction.sender()].begin()->first;
-
+                it2->second.begin()->first;
 
             if ( height1 != height2 ) {
                 // transactions with smaller nonce difference vs the current account nonce go first

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -297,6 +297,8 @@ private:
     ImportResult check_WITH_LOCK( h256 const& _h, IfDropped _ik );
     ImportResult manageImport_WITH_LOCK( h256 const& _h, Transaction const& _transaction,
         bool _allowFutureQueue, u256 const& _stateNonce );
+    bool isExactFutureTransactionQueued_WITH_LOCK(
+        h256 const& _h, Transaction const& _transaction ) const;
 
     Transactions topTransactions_WITH_LOCK(
         unsigned _limit, h256Hash const& _avoid = h256Hash() ) const;
@@ -304,13 +306,28 @@ private:
     Transactions topTransactions_WITH_LOCK( unsigned _limit, Pred _pred ) const;
     Transactions topTransactions_WITH_LOCK( unsigned _limit );
 
+    /**
+     * Tries inserting a transaction into CTQ.
+     * @returns Success if tx was inserted, or there was already a tx with same hash.
+     *          QueueIsFull if tx is valid but there is no room in CTQ.
+     */
     ImportResult insertCurrent_WITH_LOCK( std::pair< h256, Transaction > const& _p );
+
+    /**
+     * Tries inserting a transaction into the future queue.
+     * @returns Success if tx was inserted, or there was already a tx with same hash.
+     *          QueueIsFull if tx is valid but there is no room in the future queue.
+     */
     ImportResult insertFuture_WITH_LOCK( std::pair< h256, Transaction > const& _p );
     bool hasCurrentCapacity_WITH_LOCK( Transaction const& _transaction ) const;
     bool isCurrentNonceCompatible_WITH_LOCK(
         Transaction const& _transaction, u256 const& _stateNonce ) const;
+    bool promoteFutureTransactions_WITH_LOCK( Address const& _from, u256 const& _nonce );
+    void retryBlockedPromotions_WITH_LOCK();
+    void invalidateBlockedPromotion_WITH_LOCK( Address const& _from, u256 const& _nonce );
     void makeCurrent_WITH_LOCK( Transaction const& _t );
     bool remove_WITH_LOCK( h256 const& _txHash );
+    bool removeFuture_WITH_LOCK( Transaction const& _transaction );
     u256 maxNonce_WITH_LOCK( Address const& _a ) const;
     u256 maxCurrentNonce_WITH_LOCK( Address const& _a ) const;
     void setFuture_WITH_LOCK( h256 const& _t );
@@ -333,6 +350,11 @@ private:
         m_currentByAddressAndNonce;  ///< Transactions grouped by account and nonce
     std::unordered_map< Address, std::map< u256, VerifiedTransaction > > m_future;  /// Future
                                                                                     /// transactions
+
+    // Holds the nonce of the first future tx that could not be promoted to CTQ due to capacity limits.
+    // whenever CTQ gets free space, we check this map and try to promote the blocked transaction and
+    // following ones if any.
+    std::unordered_map< Address, u256 > m_blockedPromotions;
 
     Signal<> m_onReady;  ///< Called when a subsequent call to import transactions will return a
                          ///< non-empty container. Be nice and exit fast.

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -82,20 +82,24 @@ public:
     /// Verify and add transaction to the queue synchronously.
     /// @param _tx RLP encoded transaction data.
     /// @param _ik Set to Retry to force re-adding a transaction that was previously dropped.
-    /// @param _isFuture True if transaction should be put in future queue
+    /// @param _allowFutureQueue True if the future queue may be used when the transaction cannot be
+    /// put in the current queue.
+    /// @param _stateNonce Current committed nonce for the transaction sender.
     /// @returns Import result code.
-    ImportResult import(
-        bytes const& _tx, IfDropped _ik = IfDropped::Ignore, bool _isFuture = false ) {
-        return import( &_tx, _ik, _isFuture );
+    ImportResult import( bytes const& _tx, IfDropped _ik, bool _allowFutureQueue,
+        u256 const& _stateNonce ) {
+        return import( &_tx, _ik, _allowFutureQueue, _stateNonce );
     }
 
     /// Verify and add transaction to the queue synchronously.
     /// @param _tx Transaction data.
     /// @param _ik Set to Retry to force re-adding a transaction that was previously dropped.
-    /// @param _isFuture True if transaction should be put in future queue
+    /// @param _allowFutureQueue True if the future queue may be used when the transaction cannot be
+    /// put in the current queue.
+    /// @param _stateNonce Current committed nonce for the transaction sender.
     /// @returns Import result code.
-    ImportResult import(
-        Transaction const& _tx, IfDropped _ik = IfDropped::Ignore, bool _isFuture = false );
+    ImportResult import( Transaction const& _tx, IfDropped _ik, bool _allowFutureQueue,
+        u256 const& _stateNonce );
 
     /// Remove transaction from the queue
     /// @param _txHash Transaction hash
@@ -337,10 +341,11 @@ private:
     // account min account nonce. Updating it does not affect the order.
     using PriorityQueue = boost::container::multiset< VerifiedTransaction, PriorityCompare >;
 
-    ImportResult import(
-        bytesConstRef _tx, IfDropped _ik = IfDropped::Ignore, bool _isFuture = false );
+    ImportResult import( bytesConstRef _tx, IfDropped _ik, bool _allowFutureQueue,
+        u256 const& _stateNonce );
     ImportResult check_WITH_LOCK( h256 const& _h, IfDropped _ik );
-    ImportResult manageImport_WITH_LOCK( h256 const& _h, Transaction const& _transaction );
+    ImportResult manageImport_WITH_LOCK( h256 const& _h, Transaction const& _transaction,
+        bool _allowFutureQueue, u256 const& _stateNonce );
 
     Transactions topTransactions_WITH_LOCK(
         unsigned _limit, h256Hash const& _avoid = h256Hash() ) const;
@@ -348,7 +353,17 @@ private:
     Transactions topTransactions_WITH_LOCK( unsigned _limit, Pred _pred ) const;
     Transactions topTransactions_WITH_LOCK( unsigned _limit );
 
-    void insertCurrent_WITH_LOCK( std::pair< h256, Transaction > const& _p );
+    ImportResult tryInsertCurrent_WITH_LOCK( std::pair< h256, Transaction > const& _p );
+    ImportResult tryInsertFuture_WITH_LOCK( std::pair< h256, Transaction > const& _p );
+    bool isCurrentNonceCompatible_WITH_LOCK(
+        Transaction const& _transaction, u256 const& _stateNonce ) const;
+
+    /**
+     * Checks if a transaction is already present in Future queue.
+     * Uses tx from, nonce and hash for the check.
+     */
+    bool isKnownFuture_WITH_LOCK( h256 const& _h, Transaction const& _transaction ) const;
+    void removeFuture_WITH_LOCK( Address const& _from, u256 const& _nonce );
     void makeCurrent_WITH_LOCK( Transaction const& _t );
     bool remove_WITH_LOCK( h256 const& _txHash );
     u256 maxNonce_WITH_LOCK( Address const& _a ) const;
@@ -382,8 +397,7 @@ private:
                                                                   ///< result, transaction id an
                                                                   ///< node id. Be nice and exit
                                                                   ///< fast.
-    Signal< h256 const& > m_onReplaced;  ///< Called when transaction is dropped during a call to
-                                         ///< import() to make room for another transaction.
+    Signal< h256 const& > m_onReplaced;  ///< Called when a queued transaction is replaced.
     unsigned m_limit;                    ///< Max number of pending transactions
     unsigned m_futureLimit;              ///< Max number of future transactions
     unsigned m_futureSize = 0;           ///< Current number of future transactions

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -73,11 +73,6 @@ public:
         : TransactionQueue(
               _l.currentLimit, _l.futureLimit, _l.currentLimitBytes, _l.futureLimitBytes ) {}
     ~TransactionQueue();
-    void HandleDestruction();
-    /// Add transaction to the queue to be verified and imported.
-    /// @param _data RLP encoded transaction data.
-    /// @param _nodeId Optional network identified of a node transaction comes from.
-    void enqueue( RLP const& _data, h512 const& _nodeId );
 
     /// Verify and add transaction to the queue synchronously.
     /// @param _tx RLP encoded transaction data.
@@ -187,7 +182,6 @@ public:
     struct Status {
         size_t current;
         size_t future;
-        size_t unverified;
         size_t dropped;
         size_t currentBytes;
         size_t futureBytes;
@@ -195,7 +189,6 @@ public:
     /// @returns the status of the transaction queue.
     Status status() const {
         Status ret;
-        DEV_GUARDED( x_queue ) { ret.unverified = m_unverified.size(); }
         ReadGuard l( m_lock );
         ret.dropped = m_dropped.size();
         ret.current = m_currentByHash.size();
@@ -369,7 +362,6 @@ private:
     u256 maxNonce_WITH_LOCK( Address const& _a ) const;
     u256 maxCurrentNonce_WITH_LOCK( Address const& _a ) const;
     void setFuture_WITH_LOCK( h256 const& _t );
-    void verifierBody();
 
     mutable SharedMutex m_lock;                    ///< General lock.
     mutable boost::condition_variable_any m_cond;  // for wait/notify
@@ -406,12 +398,6 @@ private:
     unsigned m_currentSizeBytes = 0;       // current pending queue size in bytes
     unsigned m_futureSizeBytesLimit = 0;   // max future queue size in bytes
     unsigned m_futureSizeBytes = 0;        // current future queue size in bytes
-
-    std::condition_variable m_queueReady;  ///< Signaled when m_unverified has a new entry.
-    std::vector< std::thread > m_verifiers;
-    std::deque< UnverifiedTransaction > m_unverified;  ///< Pending verification queue
-    mutable Mutex x_queue;                             ///< Verification queue mutex
-    std::atomic_bool m_aborting;                       ///< Exit condition for verifier.
 
 #ifdef BITE
     BITE2TransactionQueue m_bite2Queue;

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -86,8 +86,8 @@ public:
     /// put in the current queue.
     /// @param _stateNonce Current committed nonce for the transaction sender.
     /// @returns Import result code.
-    ImportResult import( bytes const& _tx, IfDropped _ik, bool _allowFutureQueue,
-        u256 const& _stateNonce ) {
+    ImportResult import(
+        bytes const& _tx, IfDropped _ik, bool _allowFutureQueue, u256 const& _stateNonce ) {
         return import( &_tx, _ik, _allowFutureQueue, _stateNonce );
     }
 
@@ -98,8 +98,8 @@ public:
     /// put in the current queue.
     /// @param _stateNonce Current committed nonce for the transaction sender.
     /// @returns Import result code.
-    ImportResult import( Transaction const& _tx, IfDropped _ik, bool _allowFutureQueue,
-        u256 const& _stateNonce );
+    ImportResult import(
+        Transaction const& _tx, IfDropped _ik, bool _allowFutureQueue, u256 const& _stateNonce );
 
     /// Remove transaction from the queue
     /// @param _txHash Transaction hash
@@ -341,8 +341,8 @@ private:
     // account min account nonce. Updating it does not affect the order.
     using PriorityQueue = boost::container::multiset< VerifiedTransaction, PriorityCompare >;
 
-    ImportResult import( bytesConstRef _tx, IfDropped _ik, bool _allowFutureQueue,
-        u256 const& _stateNonce );
+    ImportResult import(
+        bytesConstRef _tx, IfDropped _ik, bool _allowFutureQueue, u256 const& _stateNonce );
     ImportResult check_WITH_LOCK( h256 const& _h, IfDropped _ik );
     ImportResult manageImport_WITH_LOCK( h256 const& _h, Transaction const& _transaction,
         bool _allowFutureQueue, u256 const& _stateNonce );

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -408,11 +408,12 @@ private:
 
     std::unordered_map< Address, std::map< u256, PriorityQueue::iterator > >
         m_currentByAddressAndNonce;  ///< CTQ transactions grouped by account and nonce.
-    std::unordered_map< Address, std::map< u256, VerifiedTransaction > > m_future;  ///< FTQ
-                                                                                    ///< transactions
-                                                                                    ///< grouped by
-                                                                                    ///< account and
-                                                                                    ///< nonce.
+    std::unordered_map< Address, std::map< u256, VerifiedTransaction > >
+        m_future;  ///< FTQ
+                   ///< transactions
+                   ///< grouped by
+                   ///< account and
+                   ///< nonce.
 
     // For each sender, stores the first FTQ nonce that was ready for CTQ but could not be promoted
     // because CTQ was full. Entries are retried when CTQ capacity may have become available.

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -34,12 +34,9 @@
 #include <libdevcore/Log.h>
 #include <libdevcore/LruCache.h>
 #include <libethcore/Common.h>
-#include <atomic>
-#include <condition_variable>
 #include <deque>
 #include <functional>
 #include <mutex>
-#include <thread>
 
 #ifdef BITE
 #include "BITE2TransactionQueue.h"
@@ -77,10 +74,12 @@ public:
     /// Verify and add transaction to the queue synchronously.
     /// @param _tx RLP encoded transaction data.
     /// @param _ik Set to Retry to force re-adding a transaction that was previously dropped.
-    /// @param _allowFutureQueue True if the future queue may be used when the transaction cannot be
-    /// put in the current queue.
-    /// @param _stateNonce Current committed nonce for the transaction sender.
+    /// @param _isFuture True if transaction should be put in future queue
     /// @returns Import result code.
+    ImportResult import(
+        bytes const& _tx, IfDropped _ik = IfDropped::Ignore, bool _isFuture = false ) {
+        return import( &_tx, _ik, _isFuture );
+    }
     ImportResult import(
         bytes const& _tx, IfDropped _ik, bool _allowFutureQueue, u256 const& _stateNonce ) {
         return import( &_tx, _ik, _allowFutureQueue, _stateNonce );
@@ -89,10 +88,10 @@ public:
     /// Verify and add transaction to the queue synchronously.
     /// @param _tx Transaction data.
     /// @param _ik Set to Retry to force re-adding a transaction that was previously dropped.
-    /// @param _allowFutureQueue True if the future queue may be used when the transaction cannot be
-    /// put in the current queue.
-    /// @param _stateNonce Current committed nonce for the transaction sender.
+    /// @param _isFuture True if transaction should be put in future queue
     /// @returns Import result code.
+    ImportResult import(
+        Transaction const& _tx, IfDropped _ik = IfDropped::Ignore, bool _isFuture = false );
     ImportResult import(
         Transaction const& _tx, IfDropped _ik, bool _allowFutureQueue, u256 const& _stateNonce );
 
@@ -182,13 +181,15 @@ public:
     struct Status {
         size_t current;
         size_t future;
+        size_t unverified;
         size_t dropped;
         size_t currentBytes;
         size_t futureBytes;
     };
     /// @returns the status of the transaction queue.
     Status status() const {
-        Status ret;
+        Status ret{};
+        ret.unverified = 0;
         ReadGuard l( m_lock );
         ret.dropped = m_dropped.size();
         ret.current = m_currentByHash.size();
@@ -259,33 +260,6 @@ public:
         static uint64_t howMany() { return Counter< VerifiedTransaction >::howMany(); }
     };
 
-    /// Transaction pending verification
-    struct UnverifiedTransaction {
-        UnverifiedTransaction() {}
-        UnverifiedTransaction( bytesConstRef const& _t, h512 const& _nodeId )
-            : transaction( _t.toBytes() ), nodeId( _nodeId ) {}
-        UnverifiedTransaction( UnverifiedTransaction&& _t )
-            : transaction( std::move( _t.transaction ) ), nodeId( std::move( _t.nodeId ) ) {}
-        UnverifiedTransaction& operator=( UnverifiedTransaction&& _other ) {
-            assert( &_other != this );
-
-            transaction = std::move( _other.transaction );
-            nodeId = std::move( _other.nodeId );
-            return *this;
-        }
-
-        UnverifiedTransaction( UnverifiedTransaction const& ) = delete;
-        UnverifiedTransaction& operator=( UnverifiedTransaction const& ) = delete;
-
-        bytes transaction;  ///< RLP encoded transaction data
-        h512 nodeId;        ///< Network Id of the peer transaction comes from
-
-        Counter< UnverifiedTransaction > c;
-
-    public:
-        static uint64_t howMany() { return Counter< UnverifiedTransaction >::howMany(); }
-    };
-
     // private:
     // HACK for IS-348
     struct PriorityCompare {
@@ -335,8 +309,11 @@ private:
     using PriorityQueue = boost::container::multiset< VerifiedTransaction, PriorityCompare >;
 
     ImportResult import(
+        bytesConstRef _tx, IfDropped _ik = IfDropped::Ignore, bool _isFuture = false );
+    ImportResult import(
         bytesConstRef _tx, IfDropped _ik, bool _allowFutureQueue, u256 const& _stateNonce );
     ImportResult check_WITH_LOCK( h256 const& _h, IfDropped _ik );
+    ImportResult manageImport_WITH_LOCK( h256 const& _h, Transaction const& _transaction );
     ImportResult manageImport_WITH_LOCK( h256 const& _h, Transaction const& _transaction,
         bool _allowFutureQueue, u256 const& _stateNonce );
 
@@ -346,17 +323,11 @@ private:
     Transactions topTransactions_WITH_LOCK( unsigned _limit, Pred _pred ) const;
     Transactions topTransactions_WITH_LOCK( unsigned _limit );
 
-    ImportResult tryInsertCurrent_WITH_LOCK( std::pair< h256, Transaction > const& _p );
-    ImportResult tryInsertFuture_WITH_LOCK( std::pair< h256, Transaction > const& _p );
+    ImportResult insertCurrent_WITH_LOCK( std::pair< h256, Transaction > const& _p );
+    ImportResult insertFuture_WITH_LOCK( std::pair< h256, Transaction > const& _p );
+    bool hasCurrentCapacity_WITH_LOCK( Transaction const& _transaction ) const;
     bool isCurrentNonceCompatible_WITH_LOCK(
         Transaction const& _transaction, u256 const& _stateNonce ) const;
-
-    /**
-     * Checks if a transaction is already present in Future queue.
-     * Uses tx from, nonce and hash for the check.
-     */
-    bool isKnownFuture_WITH_LOCK( h256 const& _h, Transaction const& _transaction ) const;
-    void removeFuture_WITH_LOCK( Address const& _from, u256 const& _nonce );
     void makeCurrent_WITH_LOCK( Transaction const& _t );
     bool remove_WITH_LOCK( h256 const& _txHash );
     u256 maxNonce_WITH_LOCK( Address const& _a ) const;
@@ -389,7 +360,8 @@ private:
                                                                   ///< result, transaction id an
                                                                   ///< node id. Be nice and exit
                                                                   ///< fast.
-    Signal< h256 const& > m_onReplaced;  ///< Called when a queued transaction is replaced.
+    Signal< h256 const& > m_onReplaced;  ///< Called when transaction is dropped during a call to
+                                         ///< import() to make room for another transaction.
     unsigned m_limit;                    ///< Max number of pending transactions
     unsigned m_futureLimit;              ///< Max number of future transactions
     unsigned m_futureSize = 0;           ///< Current number of future transactions

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -163,8 +163,8 @@ public:
     /// Remove a transaction consumed by block execution and promote following future transactions
     /// when possible.
     /// @param _t Accepted transaction
-    DropGoodResult dropGood( Transaction const& _t,
-        ReadyNotification _notification = ReadyNotification::Notify );
+    DropGoodResult dropGood(
+        Transaction const& _t, ReadyNotification _notification = ReadyNotification::Notify );
 
     /// Notify ready listeners after a caller deferred queue-ready notification.
     void notifyReady();

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -71,27 +71,11 @@ public:
               _l.currentLimit, _l.futureLimit, _l.currentLimitBytes, _l.futureLimitBytes ) {}
     ~TransactionQueue();
 
-    /// Verify and add transaction to the queue synchronously.
-    /// @param _tx RLP encoded transaction data.
-    /// @param _ik Set to Retry to force re-adding a transaction that was previously dropped.
-    /// @param _isFuture True if transaction should be put in future queue
-    /// @returns Import result code.
-    ImportResult import(
-        bytes const& _tx, IfDropped _ik = IfDropped::Ignore, bool _isFuture = false ) {
-        return import( &_tx, _ik, _isFuture );
-    }
     ImportResult import(
         bytes const& _tx, IfDropped _ik, bool _allowFutureQueue, u256 const& _stateNonce ) {
         return import( &_tx, _ik, _allowFutureQueue, _stateNonce );
     }
 
-    /// Verify and add transaction to the queue synchronously.
-    /// @param _tx Transaction data.
-    /// @param _ik Set to Retry to force re-adding a transaction that was previously dropped.
-    /// @param _isFuture True if transaction should be put in future queue
-    /// @returns Import result code.
-    ImportResult import(
-        Transaction const& _tx, IfDropped _ik = IfDropped::Ignore, bool _isFuture = false );
     ImportResult import(
         Transaction const& _tx, IfDropped _ik, bool _allowFutureQueue, u256 const& _stateNonce );
 
@@ -309,11 +293,8 @@ private:
     using PriorityQueue = boost::container::multiset< VerifiedTransaction, PriorityCompare >;
 
     ImportResult import(
-        bytesConstRef _tx, IfDropped _ik = IfDropped::Ignore, bool _isFuture = false );
-    ImportResult import(
         bytesConstRef _tx, IfDropped _ik, bool _allowFutureQueue, u256 const& _stateNonce );
     ImportResult check_WITH_LOCK( h256 const& _h, IfDropped _ik );
-    ImportResult manageImport_WITH_LOCK( h256 const& _h, Transaction const& _transaction );
     ImportResult manageImport_WITH_LOCK( h256 const& _h, Transaction const& _transaction,
         bool _allowFutureQueue, u256 const& _stateNonce );
 

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -37,6 +37,7 @@
 #include <deque>
 #include <functional>
 #include <mutex>
+#include <optional>
 
 #ifdef BITE
 #include "BITE2TransactionQueue.h"
@@ -68,6 +69,13 @@ namespace eth {
  */
 class TransactionQueue {
 public:
+    enum class ReadyNotification { Notify, Defer };
+
+    struct DropGoodResult {
+        bool removed = false;
+        bool readyChanged = false;
+    };
+
     struct Limits {
         size_t currentLimit;
         size_t futureLimit;
@@ -152,9 +160,14 @@ public:
     /// @param _t Transaction hash
     void setFuture( h256 const& _t );
 
-    /// Remove an accepted transaction and promote following future transactions when possible.
+    /// Remove a transaction consumed by block execution and promote following future transactions
+    /// when possible.
     /// @param _t Accepted transaction
-    void dropGood( Transaction const& _t );
+    DropGoodResult dropGood( Transaction const& _t,
+        ReadyNotification _notification = ReadyNotification::Notify );
+
+    /// Notify ready listeners after a caller deferred queue-ready notification.
+    void notifyReady();
 
 #ifdef BITE
     /// Get all pending BITE2 transactions. Returned transactions are not removed from the queue
@@ -173,6 +186,10 @@ public:
     void commitTempBITE2Transactions();
     /// Get origin for first N CTXs in queue
     std::vector< dev::h256 > getNCTXOrigins( size_t _n ) const;
+
+    /// Verifies CTXs exactly match the next expected pending BITE2 CTXs and returns their origins.
+    std::optional< std::vector< dev::h256 > > validateNextExpectedBITE2CTXsAndGetOrigins(
+        std::vector< Transaction > const& _ctxs ) const;
 
     void clearTempBITE2Transactions();
 
@@ -372,7 +389,8 @@ private:
     bool promoteFutureTransactions_WITH_LOCK( Address const& _from, u256 const& _nonce );
 
     /// Retries cached FTQ-to-CTQ promotions after CTQ capacity may have been freed.
-    void retryBlockedPromotions_WITH_LOCK();
+    /// @returns true if at least one transaction was moved to CTQ.
+    bool retryBlockedPromotions_WITH_LOCK();
 
     /**
      * Clears _from's cached promotion when dropping _nonce breaks the contiguous path to the cached
@@ -381,7 +399,10 @@ private:
     void invalidateBlockedPromotion_WITH_LOCK( Address const& _from, u256 const& _nonce );
 
     /// Promotes future transactions that immediately follow the newly current transaction _t.
-    void makeCurrent_WITH_LOCK( Transaction const& _t );
+    /// @returns true if at least one transaction was moved to CTQ.
+    bool makeCurrent_WITH_LOCK( Transaction const& _t );
+
+    DropGoodResult dropGood_WITH_LOCK( Transaction const& _t );
 
     /// Removes a transaction from CTQ and its secondary indexes.
     bool remove_WITH_LOCK( h256 const& _txHash );
@@ -391,7 +412,7 @@ private:
 
     u256 maxNonce_WITH_LOCK( Address const& _a ) const;
     u256 maxCurrentNonce_WITH_LOCK( Address const& _a ) const;
-    void setFuture_WITH_LOCK( h256 const& _t );
+    bool setFuture_WITH_LOCK( h256 const& _t );
 
     mutable SharedMutex m_lock;                    ///< General lock.
     mutable boost::condition_variable_any m_cond;  // for wait/notify

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -1202,6 +1202,8 @@ string dev::rpc::exceptionToErrorMessage() {
         ret = "Same transaction already exists in the pending transaction queue.";
     } catch ( TransactionAlreadyInChain const& ) {
         ret = "Transaction is already in the blockchain.";
+    } catch ( TransactionQueueIsFull const& ) {
+        ret = "Transaction queue is full.";
     } catch ( NotEnoughCash const& ) {
         ret = "Account balance is too low (balance < value + gas * gas price).";
     } catch ( InvalidSignature const& ) {

--- a/test/tools/libtesteth/BlockChainHelper.cpp
+++ b/test/tools/libtesteth/BlockChainHelper.cpp
@@ -72,7 +72,7 @@ TestBlock::TestBlock( std::string const& _blockRLP ) : TestBlock() {
     for ( auto const& tr : root[1] ) {
         Transaction tx( tr.data(), CheckTransaction::Everything );
         TestTransaction testTx( tx );
-        m_transactionQueue.import( tx.toBytes() );
+        m_transactionQueue.import( tx, IfDropped::Ignore, false, tx.nonce() );
         m_testTransactions.push_back( testTx );
     }
 
@@ -125,7 +125,8 @@ void TestBlock::setState( State const& _state ) {
 
 void TestBlock::addTransaction( TestTransaction const& _tr ) {
     m_testTransactions.push_back( _tr );
-    if ( m_transactionQueue.import( _tr.transaction().toBytes() ) != ImportResult::Success )
+    if ( m_transactionQueue.import( _tr.transaction(), IfDropped::Ignore, false,
+             _tr.transaction().nonce() ) != ImportResult::Success )
         cnote << TestOutputHelper::get().testName() + " Test block failed importing transaction";
     recalcBlockHeaderBytes();
 }
@@ -215,7 +216,8 @@ void TestBlock::mine( TestBlockChain const& _bc ) {
         // renew the TestBlock transactions
         m_transactionQueue.clear();
         for ( size_t i = 0; i < block.pending().size(); i++ )
-            m_transactionQueue.import( block.pending()[i] );
+            m_transactionQueue.import(
+                block.pending()[i], IfDropped::Ignore, false, block.pending()[i].nonce() );
     } catch ( Exception const& _e ) {
         cnote << TestOutputHelper::get().testName() +
                      " block sync or mining did throw an exception: "
@@ -445,7 +447,7 @@ void TestBlock::populateFrom( TestBlock const& _original ) {
     m_transactionQueue.clear();
     TransactionQueue const& trQueue = _original.transactionQueue();
     for ( auto const& txi : trQueue.topTransactions( std::numeric_limits< unsigned >::max() ) )
-        m_transactionQueue.import( txi.toBytes() );
+        m_transactionQueue.import( txi, IfDropped::Ignore, false, txi.nonce() );
 
     m_uncles = _original.uncles();
     m_blockHeader = _original.blockHeader();

--- a/test/unittests/libethereum/SkaleHost.cpp
+++ b/test/unittests/libethereum/SkaleHost.cpp
@@ -1211,7 +1211,7 @@ BOOST_AUTO_TEST_CASE( transactionDropReceive
 #endif
 
     // submit it!
-    tq->import( tx1 );
+    tq->import( tx1, IfDropped::Ignore, true, 0 );
 
     // 2nd tx
     u256 value2 = 20000 * dev::eth::szabo;
@@ -1289,7 +1289,7 @@ BOOST_AUTO_TEST_CASE(
 #endif
 
     // submit it!
-    tq->import( tx1 );
+    tq->import( tx1, IfDropped::Ignore, true, 0 );
 
     sleep( 1 );
     BOOST_REQUIRE_EQUAL( tq->knownTransactions().size(), 1 );
@@ -1365,7 +1365,7 @@ BOOST_AUTO_TEST_CASE( transactionDropByGasPrice
 #endif
 
     // submit it!
-    tq->import( tx1 );
+    tq->import( tx1, IfDropped::Ignore, true, 0 );
 
     sleep( 1 );
     BOOST_REQUIRE_EQUAL( tq->knownTransactions().size(), 1 );

--- a/test/unittests/libethereum/TransactionQueue.cpp
+++ b/test/unittests/libethereum/TransactionQueue.cpp
@@ -31,19 +31,6 @@ using namespace dev;
 using namespace dev::eth;
 using namespace dev::test;
 
-namespace {
-
-ImportResult importCurrent( TransactionQueue& _queue, Transaction const& _transaction ) {
-    return _queue.import( _transaction, IfDropped::Ignore, false, _transaction.nonce() );
-}
-
-ImportResult importCurrent( TransactionQueue& _queue, bytes const& _transactionRLP ) {
-    Transaction transaction( _transactionRLP, CheckTransaction::Everything );
-    return _queue.import( _transactionRLP, IfDropped::Ignore, false, transaction.nonce() );
-}
-
-}
-
 BOOST_FIXTURE_TEST_SUITE( TransactionQueueSuite, TestOutputHelperFixture )
 
 BOOST_AUTO_TEST_CASE( TransactionEIP86 ) {
@@ -54,7 +41,7 @@ BOOST_AUTO_TEST_CASE( TransactionEIP86 ) {
     streamRLP << 0 << 10 * szabo << 25000;
     streamRLP << to << 0 << bytes() << 0 << 0 << 0;
     Transaction tx0( streamRLP.out(), CheckTransaction::Everything );
-    ImportResult result = importCurrent( txq, tx0 );
+    ImportResult result = txq.import( tx0 );
     BOOST_CHECK( result == ImportResult::ZeroSignature );
     BOOST_CHECK( txq.knownTransactions().size() == 0 );
 }
@@ -74,35 +61,17 @@ BOOST_AUTO_TEST_CASE( tqMaxNonce ) {
     Transaction tx2( 0, gasCost, gas, dest, bytes(), 2, sec );
     Transaction tx9( 0, gasCost, gas, dest, bytes(), 9, sec );
 
-    // 1st tx - should import fine
-    auto result = importCurrent( txq, tx0 );
-    BOOST_CHECK( result == ImportResult::Success );
+    txq.import( tx0 );
     BOOST_CHECK( 1 == txq.maxNonce( to ) );
-
-    // same tx - should not increase nonce
-    result = importCurrent( txq, tx0 );
-    BOOST_CHECK( result == ImportResult::AlreadyKnown );
-
+    txq.import( tx0 );
     BOOST_CHECK( 1 == txq.maxNonce( to ) );
-
-    // different tx for same nonce - should not increase nonce
-    result = importCurrent( txq, tx0_1 );
-    BOOST_CHECK( result == ImportResult::SameNonceAlreadyInQueue );
+    txq.import( tx0_1 );
     BOOST_CHECK( 1 == txq.maxNonce( to ) );
-
-    // 2nd tx - should import fine
-    result = importCurrent( txq, tx1 );
-    BOOST_CHECK( result == ImportResult::Success );
+    txq.import( tx1 );
     BOOST_CHECK( 2 == txq.maxNonce( to ) );
-
-    // nonce is not contiguous - should go to future queue (only if available)
-    result = txq.import( tx9, IfDropped::Ignore, true, 0 );
-    BOOST_CHECK( result == ImportResult::Success );
+    txq.import( tx9 );
     BOOST_CHECK( 10 == txq.maxNonce( to ) );
-
-    // tx2 also gets inserted - max nonce should not change as tx9 is still in future
-    result = importCurrent( txq, tx2 );
-    BOOST_CHECK( result == ImportResult::Success );
+    txq.import( tx2 );
     BOOST_CHECK( 10 == txq.maxNonce( to ) );
 }
 
@@ -124,21 +93,21 @@ BOOST_AUTO_TEST_CASE( tqPriority ) {
     Transaction tx4( 0, gasCostMed, gas, dest, bytes(), 2, sender1 );
     Transaction tx5( 0, gasCostHigh, gas, dest, bytes(), 2, sender2 );
 
-    importCurrent( txq, tx0 );
+    txq.import( tx0 );
     BOOST_CHECK( Transactions{tx0} == txq.topTransactions( 256 ) );
-    importCurrent( txq, tx0 );
+    txq.import( tx0 );
     BOOST_CHECK( Transactions{tx0} == txq.topTransactions( 256 ) );
-    importCurrent( txq, tx0_1 );
+    txq.import( tx0_1 );
     BOOST_CHECK( Transactions{tx0} == txq.topTransactions( 256 ) );  // no replacement any more!
-    importCurrent( txq, tx1 );
+    txq.import( tx1 );
     BOOST_CHECK( ( Transactions{tx0, tx1} ) == txq.topTransactions( 256 ) );
-    importCurrent( txq, tx2 );
+    txq.import( tx2 );
     BOOST_CHECK( ( Transactions{tx2, tx0, tx1} ) == txq.topTransactions( 256 ) );
-    importCurrent( txq, tx3 );
+    txq.import( tx3 );
     BOOST_CHECK( ( Transactions{tx2, tx0, tx1, tx3} ) == txq.topTransactions( 256 ) );
-    importCurrent( txq, tx4 );
+    txq.import( tx4 );
     BOOST_CHECK( ( Transactions{tx2, tx0, tx1, tx3, tx4} ) == txq.topTransactions( 256 ) );
-    importCurrent( txq, tx5 );
+    txq.import( tx5 );
     BOOST_CHECK( ( Transactions{tx2, tx0, tx1, tx3, tx5, tx4} ) == txq.topTransactions( 256 ) );
 
     txq.drop( tx0.sha3() );
@@ -151,13 +120,13 @@ BOOST_AUTO_TEST_CASE( tqPriority ) {
     BOOST_CHECK( ( Transactions{tx2, tx4, tx3} ) == txq.topTransactions( 256 ) );
 
     Transaction tx6( 0, gasCostMed, gas, dest, bytes(), 20, sender1 );
-    txq.import( tx6, IfDropped::Ignore, true, 0 );
-    BOOST_CHECK( ( Transactions{tx2, tx4, tx3} ) == txq.topTransactions( 256 ) );
+    txq.import( tx6 );
+    BOOST_CHECK( ( Transactions{tx2, tx4, tx3, tx6} ) == txq.topTransactions( 256 ) );
 
     Transaction tx7( 0, gasCostHigh, gas, dest, bytes(), 2, sender2 );
-    importCurrent( txq, tx7 );
+    txq.import( tx7 );
     // deterministic signature: hash of tx5 and tx7 will be same
-    BOOST_CHECK( ( Transactions{tx2, tx4, tx3} ) == txq.topTransactions( 256 ) );
+    BOOST_CHECK( ( Transactions{tx2, tx4, tx3, tx6} ) == txq.topTransactions( 256 ) );
 }
 
 BOOST_AUTO_TEST_CASE( tqNonceChange ) {
@@ -180,20 +149,20 @@ BOOST_AUTO_TEST_CASE( tqNonceChange ) {
     Transaction tx23( 0, gasCost, gas, dest, bytes(), 3, sender2 );
 
     // 1 insert 0,1,2 for both senders
-    importCurrent( txq, tx20 ); // h = 0
-    importCurrent( txq, tx21 ); // h = 1
-    importCurrent( txq, tx22 ); // h = 2
-    importCurrent( txq, tx10 ); // h = 0
-    importCurrent( txq, tx11 ); // h = 1
-    importCurrent( txq, tx12 ); // h = 2
-    importCurrent( txq, tx13 ); // h = 3
+    txq.import( tx20 ); // h = 0
+    txq.import( tx21 ); // h = 1
+    txq.import( tx22 ); // h = 2
+    txq.import( tx10 ); // h = 0
+    txq.import( tx11 ); // h = 1
+    txq.import( tx12 ); // h = 2
+    txq.import( tx13 ); // h = 3
 
     // 2 increase nonce for account 2
     txq.dropGood( tx20 );
     txq.dropGood( tx21 );
 
     // 3 insert tx with height = 3-2=1
-    importCurrent( txq, tx23 ); // h = 1 => goes with tx11
+    txq.import( tx23 ); // h = 1 => goes with tx11
 
     Transactions top6 = txq.topTransactions(6);
     for(auto tx: top6){
@@ -219,11 +188,11 @@ BOOST_AUTO_TEST_CASE( tqFuture ) {
     Transaction tx3( 0, gasCostMed, gas, dest, bytes(), 3, sender );
     Transaction tx4( 0, gasCostMed, gas, dest, bytes(), 4, sender );
 
-    importCurrent( txq, tx0 );
-    importCurrent( txq, tx1 );
-    importCurrent( txq, tx2 );
-    importCurrent( txq, tx3 );
-    importCurrent( txq, tx4 );
+    txq.import( tx0 );
+    txq.import( tx1 );
+    txq.import( tx2 );
+    txq.import( tx3 );
+    txq.import( tx4 );
     BOOST_CHECK( ( Transactions{tx0, tx1, tx2, tx3, tx4} ) == txq.topTransactions( 256 ) );
 
     txq.setFuture( tx2.sha3() );
@@ -231,13 +200,14 @@ BOOST_AUTO_TEST_CASE( tqFuture ) {
 
     // TODO disabled it temporarily!!
     //    Transaction tx2_2( 1, gasCostMed, gas, dest, bytes(), 2, sender );
-    //    importCurrent( txq, tx2_2 );
+    //    txq.import( tx2_2 );
     //    BOOST_CHECK( ( Transactions{tx0, tx1, tx2_2, tx3, tx4} ) == txq.topTransactions( 256 ) );
     //    // no replacement
 }
 
 
 BOOST_AUTO_TEST_CASE( tqLimits ) {
+    dev::eth::TransactionQueue txq( 3, 3 );
     const u256 gasCostMed = 20 * szabo;
     const u256 gas = 25000;
     Address dest = Address( "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" );
@@ -250,16 +220,39 @@ BOOST_AUTO_TEST_CASE( tqLimits ) {
     Transaction tx4( 0, gasCostMed, gas, dest, bytes(), 4, sender );
     Transaction tx5( 0, gasCostMed + 1, gas, dest, bytes(), 0, sender2 );
 
-    // CTQ limit with no Future queue
-    dev::eth::TransactionQueue txq( 3, 3 );
-    BOOST_REQUIRE( importCurrent( txq, tx0 ) == ImportResult::Success );
-    BOOST_REQUIRE( importCurrent( txq, tx1 ) == ImportResult::Success );
-    BOOST_REQUIRE( importCurrent( txq, tx2 ) == ImportResult::Success );
-    BOOST_REQUIRE( importCurrent( txq, tx3 ) == ImportResult::QueueIsFull );
-    BOOST_REQUIRE( importCurrent( txq, tx4 ) == ImportResult::QueueIsFull );
-    BOOST_REQUIRE( importCurrent( txq, tx5 ) == ImportResult::QueueIsFull );
+    BOOST_REQUIRE( txq.import( tx0 ) == ImportResult::Success );
+    BOOST_REQUIRE( txq.import( tx1 ) == ImportResult::Success );
+    BOOST_REQUIRE( txq.import( tx2 ) == ImportResult::Success );
+    BOOST_REQUIRE( txq.import( tx3 ) == ImportResult::QueueIsFull );
+    BOOST_REQUIRE( txq.import( tx4 ) == ImportResult::QueueIsFull );
+    BOOST_REQUIRE( txq.import( tx5 ) == ImportResult::QueueIsFull );
     BOOST_CHECK( ( Transactions{tx0, tx1, tx2} ) == txq.topTransactions( 256 ) );
+}
 
+BOOST_AUTO_TEST_CASE( tqCurrentFullDoesNotFallBackToFuture ) {
+    dev::eth::TransactionQueue tq( 1, 3 );
+
+    const u256 gasCostMed = 20 * szabo;
+    const u256 gas = 25000;
+    Address dest = Address( "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" );
+    Secret sender1 = Secret( "0x3333333333333333333333333333333333333333333333333333333333333333" );
+    Secret sender2 = Secret( "0x4444444444444444444444444444444444444444444444444444444444444444" );
+    Transaction tx0( 0, gasCostMed, gas, dest, bytes(), 0, sender1 );
+    Transaction tx1( 0, gasCostMed, gas, dest, bytes(), 1, sender1 );
+    Transaction tx2( 0, gasCostMed, gas, dest, bytes(), 2, sender1 );
+    Transaction otherCurrent( 0, gasCostMed, gas, dest, bytes(), 0, sender2 );
+
+    BOOST_REQUIRE( tq.import( tx0, IfDropped::Ignore, true, 0 ) == ImportResult::Success );
+    BOOST_REQUIRE(
+        tq.import( otherCurrent, IfDropped::Ignore, true, 0 ) == ImportResult::QueueIsFull );
+    BOOST_REQUIRE( tq.import( tx1, IfDropped::Ignore, true, 0 ) == ImportResult::QueueIsFull );
+    BOOST_REQUIRE( tq.status().current == 1 );
+    BOOST_REQUIRE( tq.status().future == 0 );
+
+    BOOST_REQUIRE( tq.import( tx2, IfDropped::Ignore, true, 0 ) == ImportResult::Success );
+    BOOST_REQUIRE( tq.status().current == 1 );
+    BOOST_REQUIRE( tq.status().future == 1 );
+    BOOST_CHECK( ( Transactions{tx0} ) == tq.topTransactions( 256 ) );
 }
 
 BOOST_AUTO_TEST_CASE( tqImport ) {
@@ -268,17 +261,17 @@ BOOST_AUTO_TEST_CASE( tqImport ) {
     h256Hash known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 0 );
     
-    ImportResult ir = importCurrent( tq, testTransaction.transaction().toBytes() );
+    ImportResult ir = tq.import( testTransaction.transaction().toBytes() );
     BOOST_REQUIRE( ir == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 1 );
     
-    ir = importCurrent( tq, testTransaction.transaction().toBytes() );
+    ir = tq.import( testTransaction.transaction().toBytes() );
     BOOST_REQUIRE( ir == ImportResult::AlreadyKnown );
     
     bytes rlp = testTransaction.transaction().toBytes();
     rlp.at( 0 ) = 03;
-    ir = tq.import( rlp, IfDropped::Ignore, false, testTransaction.transaction().nonce() );
+    ir = tq.import( rlp );
     BOOST_REQUIRE( ir == ImportResult::Malformed );
 
     known = tq.knownTransactions();
@@ -288,13 +281,13 @@ BOOST_AUTO_TEST_CASE( tqImport ) {
     TestTransaction testTransaction3 = TestTransaction::defaultTransaction( 1, 1 );
     TestTransaction testTransaction4 = TestTransaction::defaultTransaction( 1, 4 );
     
-    ir = importCurrent( tq, testTransaction2.transaction().toBytes() );
+    ir = tq.import( testTransaction2.transaction().toBytes() );
     BOOST_REQUIRE( ir == ImportResult::SameNonceAlreadyInQueue );
     
-    ir = importCurrent( tq, testTransaction3.transaction().toBytes() );
+    ir = tq.import( testTransaction3.transaction().toBytes() );
     BOOST_REQUIRE( ir == ImportResult::AlreadyKnown );
     
-    ir = importCurrent( tq, testTransaction4.transaction().toBytes() );
+    ir = tq.import( testTransaction4.transaction().toBytes() );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 1 );
     Transactions ts = tq.topTransactions( 4 );
@@ -323,7 +316,7 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     u256 waiting = tq.waiting(sender);
     BOOST_REQUIRE( waiting == 0 );
     
-    ImportResult ir1 = tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
+    ImportResult ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true );
     BOOST_REQUIRE( ir1 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 1 );
@@ -334,8 +327,8 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     waiting = tq.waiting(sender);
     BOOST_REQUIRE( waiting == 1 );
 
-    // HACK it's allowed to repeat a future transaction without a duplicate error.
-    ir1 = tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
+    // HACK it's now allowed to repeat future transaction (can put it to current)
+    ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true );
     BOOST_REQUIRE( ir1 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 1 );
@@ -348,11 +341,11 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     
     bytes rlp = tx1.transaction().toBytes();
     rlp.at( 0 ) = 03;
-    ir1 = tq.import( rlp, IfDropped::Ignore, true, 0 );
+    ir1 = tq.import( rlp, IfDropped::Ignore, true );
     BOOST_REQUIRE( ir1 == ImportResult::Malformed );
 
     TestTransaction tx2 = TestTransaction::defaultTransaction(2);
-    ImportResult ir2 = tq.import( tx2.transaction(), IfDropped::Ignore, true, 0 );
+    ImportResult ir2 = tq.import( tx2.transaction().toBytes(), IfDropped::Ignore, true );
     BOOST_REQUIRE( ir2 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 2 );
@@ -363,7 +356,7 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     BOOST_CHECK( ( Transactions{} ) == tq.topTransactions( 256 ) );
 
     TestTransaction tx3 = TestTransaction::defaultTransaction(1);
-    ImportResult ir3 = tq.import( tx3.transaction(), IfDropped::Ignore, true, 0 );
+    ImportResult ir3 = tq.import( tx3.transaction().toBytes(), IfDropped::Ignore, true );
     BOOST_REQUIRE( ir3 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 3 );
@@ -374,7 +367,7 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     BOOST_CHECK( ( Transactions{} ) == tq.topTransactions( 256 ) );
 
     TestTransaction tx4 = TestTransaction::defaultTransaction(0);
-    ImportResult ir4 = tq.import( tx4.transaction().toBytes(), IfDropped::Ignore, false, 0 );
+    ImportResult ir4 = tq.import( tx4.transaction().toBytes(), IfDropped::Ignore );
     BOOST_REQUIRE( ir4 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 4 );
@@ -388,7 +381,7 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     BOOST_CHECK( ( Transactions{ tx4.transaction(), tx3.transaction(), tx2.transaction() } ) == tq.topTransactions( 256 ) );
 
     TestTransaction tx5 = TestTransaction::defaultTransaction(3);
-    ImportResult ir5 = tq.import( tx5.transaction().toBytes(), IfDropped::Ignore, false, 0 );
+    ImportResult ir5 = tq.import( tx5.transaction().toBytes(), IfDropped::Ignore );
     BOOST_REQUIRE( ir5 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 5 );
@@ -406,7 +399,7 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     Address dest = Address( "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" );
     Secret sender2 = Secret( "0x4444444444444444444444444444444444444444444444444444444444444444" );
     Transaction tx0( 0, gasCostMed, gas, dest, bytes(), 4, sender2 );
-    ImportResult ir0 = tq.import( tx0, IfDropped::Ignore, true, 0 );
+    ImportResult ir0 = tq.import( tx0, IfDropped::Ignore, true );
     BOOST_REQUIRE( ir0 == ImportResult::Success );
     waiting = tq.waiting(dev::toAddress(sender2));
     BOOST_REQUIRE( waiting == 1 );
@@ -420,115 +413,25 @@ BOOST_AUTO_TEST_CASE( dropFromFutureToCurrent ) {
     TestTransaction tx1 = TestTransaction::defaultTransaction(1);
 
     // put transaction to future
-    ImportResult ir1 = tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
+    ImportResult ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true );
     BOOST_REQUIRE( ir1 == ImportResult::Success );
     TransactionQueue::Status status = tq.status();
     BOOST_REQUIRE( status.current == 0 && status.future == 1 );
 
     // push it to current and see it fall back from future to current
-    ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, false, 1 );
+    ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, false );
     BOOST_REQUIRE( ir1 == ImportResult::Success );
     status = tq.status();
     BOOST_REQUIRE( status.current == 1 && status.future == 0 );
 }
 
-BOOST_AUTO_TEST_CASE( tqFutureAllowedStillTriesCurrentFirst ) {
-    TransactionQueue tq;
-
-    TestTransaction tx0 = TestTransaction::defaultTransaction( 0 );
-    ImportResult res = tq.import( tx0.transaction(), IfDropped::Ignore, true, 0 );
-    BOOST_REQUIRE( res == ImportResult::Success );
-    BOOST_REQUIRE( tq.status().current == 1 );
-    BOOST_REQUIRE( tq.status().future == 0 );
-
-    TestTransaction tx1 = TestTransaction::defaultTransaction( 1 );
-    res = tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
-    BOOST_REQUIRE( res == ImportResult::Success );
-    BOOST_REQUIRE( tq.status().current == 2 );
-    BOOST_REQUIRE( tq.status().future == 0 );
-}
-
-BOOST_AUTO_TEST_CASE( tqFutureRejectsDifferentTransactionWithSameNonce ) {
-    TransactionQueue tq;
-
-    TestTransaction tx1 = TestTransaction::defaultTransaction( 3, 1 );
-    ImportResult res = tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
-    BOOST_REQUIRE( res == ImportResult::Success );
-
-    TestTransaction replacement = TestTransaction::defaultTransaction( 3, 2 );
-    res = tq.import( replacement.transaction(), IfDropped::Ignore, true, 0 );
-    BOOST_REQUIRE( res == ImportResult::SameNonceAlreadyInQueue );
-    BOOST_REQUIRE( tq.status().future == 1 );
-    BOOST_CHECK( ( h256Hash{ tx1.transaction().sha3() } ) == tq.knownTransactions() );
-}
-
-BOOST_AUTO_TEST_CASE( tqCurrentFullFallsBackToFutureWhenAllowed ) {
-    TransactionQueue tq( 1, 1 );
-
-    TestTransaction tx0 = TestTransaction::defaultTransaction( 0 );
-    ImportResult res = tq.import( tx0.transaction(), IfDropped::Ignore, true, 0 );
-    BOOST_REQUIRE( res == ImportResult::Success );
-
-    TestTransaction tx1 = TestTransaction::defaultTransaction( 1 );
-    res = tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
-    BOOST_REQUIRE( res == ImportResult::Success );
-    BOOST_REQUIRE( tq.status().current == 1 );
-    BOOST_REQUIRE( tq.status().future == 1 );
-
-    TestTransaction tx2 = TestTransaction::defaultTransaction( 2 );
-    res = tq.import( tx2.transaction(), IfDropped::Ignore, true, 0 );
-    BOOST_REQUIRE( res == ImportResult::QueueIsFull );
-    BOOST_REQUIRE( tq.status().current == 1 );
-    BOOST_REQUIRE( tq.status().future == 1 );
-}
-
-BOOST_AUTO_TEST_CASE( tqDropGoodPromotesFutureWhenCurrentWasFull ) {
-    TransactionQueue tq( 1, 1 );
-
-    TestTransaction tx0 = TestTransaction::defaultTransaction( 0 );
-    ImportResult res = tq.import( tx0.transaction(), IfDropped::Ignore, true, 0 );
-    BOOST_REQUIRE( res == ImportResult::Success );
-
-    TestTransaction tx1 = TestTransaction::defaultTransaction( 1 );
-    res = tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
-    BOOST_REQUIRE( res == ImportResult::Success );
-    BOOST_REQUIRE( tq.status().current == 1 );
-    BOOST_REQUIRE( tq.status().future == 1 );
-
-    tq.dropGood( tx0.transaction() );
-    BOOST_REQUIRE( tq.status().current == 1 );
-    BOOST_REQUIRE( tq.status().future == 0 );
-    BOOST_CHECK( ( Transactions{ tx1.transaction() } ) == tq.topTransactions( 256 ) );
-}
-
-BOOST_AUTO_TEST_CASE( tqFutureDisabledRejectsNonCurrentTransactions ) {
-    TransactionQueue tq( 1, 1 );
-
-    TestTransaction tx0 = TestTransaction::defaultTransaction( 0 );
-    ImportResult res = tq.import( tx0.transaction(), IfDropped::Ignore, false, 0 );
-    BOOST_REQUIRE( res == ImportResult::Success );
-
-    TestTransaction tx1 = TestTransaction::defaultTransaction( 1 );
-    res = tq.import( tx1.transaction(), IfDropped::Ignore, false, 0 );
-    BOOST_REQUIRE( res == ImportResult::QueueIsFull );
-    BOOST_REQUIRE( tq.status().current == 1 );
-    BOOST_REQUIRE( tq.status().future == 0 );
-
-    TransactionQueue emptyTq( 1, 1 );
-    TestTransaction tx2 = TestTransaction::defaultTransaction( 2 );
-    res = emptyTq.import( tx2.transaction(), IfDropped::Ignore, false, 0 );
-    BOOST_REQUIRE( res == ImportResult::QueueIsFull );
-    BOOST_REQUIRE( emptyTq.status().current == 0 );
-    BOOST_REQUIRE( emptyTq.status().future == 0 );
-}
-
 BOOST_AUTO_TEST_CASE( tqImportFutureLimits ) {
     dev::eth::TransactionQueue tq( 1024, 2 );
     TestTransaction tx1 = TestTransaction::defaultTransaction(3);
-    tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
+    tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true );
 
     TestTransaction tx2 = TestTransaction::defaultTransaction(2);
-    tq.import( tx2.transaction(), IfDropped::Ignore, true, 0 );
+    tq.import( tx2.transaction().toBytes(), IfDropped::Ignore, true );
 
     auto waiting = tq.waiting(tx1.transaction().sender());
     BOOST_REQUIRE( waiting == 2 );
@@ -536,21 +439,21 @@ BOOST_AUTO_TEST_CASE( tqImportFutureLimits ) {
     BOOST_REQUIRE( known.size() == 2 );
 
     TestTransaction tx3 = TestTransaction::defaultTransaction(1);
-    ImportResult ir = tq.import( tx3.transaction(), IfDropped::Ignore, true, 0 );
-    BOOST_REQUIRE( ir == ImportResult::QueueIsFull );
+    ImportResult ir = tq.import( tx3.transaction().toBytes(), IfDropped::Ignore, true );
+    BOOST_REQUIRE( ir == ImportResult::Success );
 
     waiting = tq.waiting(tx1.transaction().sender());
     BOOST_REQUIRE( waiting == 2 );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 2 );
-    BOOST_CHECK( ( h256Hash{ tx1.transaction().sha3(), tx2.transaction().sha3() } ) == known );
+    BOOST_CHECK( ( h256Hash{ tx3.transaction().sha3(), tx2.transaction().sha3() } ) == known );
 }
 
 BOOST_AUTO_TEST_CASE( tqImportFutureLimits2 ) {
     dev::eth::TransactionQueue tq( 1024, 2 );
 
     TestTransaction tx1 = TestTransaction::defaultTransaction(3);
-    tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
+    tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true );
 
     auto waiting = tq.waiting(tx1.transaction().sender());
     BOOST_REQUIRE( waiting == 1 );
@@ -564,7 +467,7 @@ BOOST_AUTO_TEST_CASE( tqImportFutureLimits2 ) {
     Address dest = Address( "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" );
     Secret sender2 = Secret( "0x1111111111111111111111111111111111111111111111111111111111111111" );
     Transaction tx0( 0, gasCostMed, gas, dest, bytes(), 4, sender2 );
-    ImportResult ir0 = tq.import( tx0, IfDropped::Ignore, true, 0 );
+    ImportResult ir0 = tq.import( tx0, IfDropped::Ignore, true );
     BOOST_REQUIRE( ir0 == ImportResult::Success );
 
     waiting = tq.waiting(tx1.transaction().sender());
@@ -577,8 +480,7 @@ BOOST_AUTO_TEST_CASE( tqImportFutureLimits2 ) {
     BOOST_REQUIRE( status.future == 2 );  
 
     TestTransaction tx2 = TestTransaction::defaultTransaction(2);
-    ImportResult ir2 = tq.import( tx2.transaction(), IfDropped::Ignore, true, 0 );
-    BOOST_REQUIRE( ir2 == ImportResult::QueueIsFull );
+    tq.import( tx2.transaction().toBytes(), IfDropped::Ignore, true );
 
     waiting = tq.waiting(tx1.transaction().sender());
     BOOST_REQUIRE( waiting == 1 );
@@ -589,14 +491,14 @@ BOOST_AUTO_TEST_CASE( tqImportFutureLimits2 ) {
     status = tq.status();
     BOOST_REQUIRE( status.future == 2 );  
  
-    BOOST_CHECK( ( h256Hash{ tx1.transaction().sha3(), tx0.sha3() } ) == known );
+    BOOST_CHECK( ( h256Hash{ tx0.sha3(), tx2.transaction().sha3() } ) == known );
 }
 
 BOOST_AUTO_TEST_CASE( tqDrop ) {
     TransactionQueue tq;
     TestTransaction testTransaction = TestTransaction::defaultTransaction();
     tq.dropGood( testTransaction.transaction() );
-    importCurrent( tq, testTransaction.transaction().toBytes() );
+    tq.import( testTransaction.transaction().toBytes() );
     BOOST_REQUIRE( tq.topTransactions( 4 ).size() == 1 );
     tq.dropGood( testTransaction.transaction() );
     BOOST_REQUIRE( tq.topTransactions( 4 ).size() == 0 );
@@ -607,15 +509,15 @@ BOOST_AUTO_TEST_CASE( tqLimit ) {
     Address from;
     for ( size_t i = 1; i < 7; i++ ) {
         TestTransaction testTransaction = TestTransaction::defaultTransaction( i );
-        ImportResult res = importCurrent( tq, testTransaction.transaction() );
+        ImportResult res = tq.import( testTransaction.transaction() );
         from = testTransaction.transaction().from();
-        if ( i < 6 )
+        if ( i <= 5 )
             BOOST_REQUIRE( res == ImportResult::Success );
         else
             BOOST_REQUIRE( res == ImportResult::QueueIsFull );
     }
 
-    // 5 are imported and the 6th is rejected.
+    // 5 are imported and the 6th is rejected
     BOOST_REQUIRE( tq.waiting( from ) == 5 );
 
     Transactions topTr = tq.topTransactions( 10 );
@@ -631,7 +533,7 @@ BOOST_AUTO_TEST_CASE( tqLimit ) {
     BOOST_REQUIRE( tq.waiting( from ) == 3 );
 
     // Drop out of bound feauture
-    ImportResult res = importCurrent( tq, testTransaction.transaction() );
+    ImportResult res = tq.import( testTransaction.transaction() );
     BOOST_REQUIRE( res == ImportResult::Success );
 
     // future list size is now 3  + 1 imported transaction
@@ -647,11 +549,11 @@ BOOST_AUTO_TEST_CASE( tqLimitBytes ) {
     unsigned maxTxCount = 250 / TestTransaction::defaultTransaction( 1 ).transaction().toBytes().size();
 
     TestTransaction testTransaction = TestTransaction::defaultTransaction( 2 );
-    ImportResult res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true, 0 );
+    ImportResult res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true );
     BOOST_REQUIRE( res == ImportResult::Success );
 
     testTransaction = TestTransaction::defaultTransaction( 3 );
-    res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true, 0 );
+    res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true );
     BOOST_REQUIRE( res == ImportResult::Success );
 
     BOOST_REQUIRE( tq.status().current == 0 );
@@ -659,25 +561,19 @@ BOOST_AUTO_TEST_CASE( tqLimitBytes ) {
     BOOST_REQUIRE( tq.status().future == maxTxCount );
 
     testTransaction = TestTransaction::defaultTransaction( 4 );
-    res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true, 0 );
-    BOOST_REQUIRE( res == ImportResult::QueueIsFull );
+    res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true );
+    BOOST_REQUIRE( res == ImportResult::Success );
 
     BOOST_REQUIRE( tq.status().current == 0 );
 
     BOOST_REQUIRE( tq.status().future == maxTxCount );
 
-    bool currentAccepted = false;
     for ( size_t i = 1; i < 10; i++ ) {
         if (i == 2 || i == 3)
             continue;
         testTransaction = TestTransaction::defaultTransaction( i );
-        res = importCurrent( tq, testTransaction.transaction() );
-        if ( !currentAccepted ) {
-            BOOST_REQUIRE( res == ImportResult::Success );
-            currentAccepted = true;
-        } else {
-            BOOST_REQUIRE( res == ImportResult::QueueIsFull );
-        }
+        res = tq.import( testTransaction.transaction() );
+        BOOST_REQUIRE( res == ImportResult::Success || res == ImportResult::QueueIsFull );
     }
 
     BOOST_REQUIRE( tq.status().current == maxTxCount );

--- a/test/unittests/libethereum/TransactionQueue.cpp
+++ b/test/unittests/libethereum/TransactionQueue.cpp
@@ -74,17 +74,17 @@ BOOST_AUTO_TEST_CASE( tqMaxNonce ) {
     Transaction tx2( 0, gasCost, gas, dest, bytes(), 2, sec );
     Transaction tx9( 0, gasCost, gas, dest, bytes(), 9, sec );
 
-    importCurrent( txq, tx0 );
+    BOOST_REQUIRE( importCurrent( txq, tx0 ) == ImportResult::Success );
     BOOST_CHECK( 1 == txq.maxNonce( to ) );
-    importCurrent( txq, tx0 );
+    BOOST_REQUIRE( importCurrent( txq, tx0 ) == ImportResult::AlreadyKnown );
     BOOST_CHECK( 1 == txq.maxNonce( to ) );
-    importCurrent( txq, tx0_1 );
+    BOOST_REQUIRE( importCurrent( txq, tx0_1 ) == ImportResult::SameNonceAlreadyInQueue );
     BOOST_CHECK( 1 == txq.maxNonce( to ) );
-    importCurrent( txq, tx1 );
+    BOOST_REQUIRE( importCurrent( txq, tx1 ) == ImportResult::Success );
     BOOST_CHECK( 2 == txq.maxNonce( to ) );
-    importCurrent( txq, tx9 );
+    BOOST_REQUIRE( txq.import( tx9, IfDropped::Ignore, true, 0 ) == ImportResult::Success );
     BOOST_CHECK( 10 == txq.maxNonce( to ) );
-    importCurrent( txq, tx2 );
+    BOOST_REQUIRE( txq.import( tx2, IfDropped::Ignore, false, 0 ) == ImportResult::Success );
     BOOST_CHECK( 10 == txq.maxNonce( to ) );
 }
 

--- a/test/unittests/libethereum/TransactionQueue.cpp
+++ b/test/unittests/libethereum/TransactionQueue.cpp
@@ -81,12 +81,13 @@ BOOST_AUTO_TEST_CASE( tqMaxNonce ) {
 
     // same tx - should not increase nonce
     result = importCurrent( txq, tx0 );
-    BOOST_CHECK( result == ImportResult::Success );
+    BOOST_CHECK( result == ImportResult::AlreadyKnown );
+
     BOOST_CHECK( 1 == txq.maxNonce( to ) );
 
     // different tx for same nonce - should not increase nonce
     result = importCurrent( txq, tx0_1 );
-    BOOST_CHECK( result == ImportResult::Success );
+    BOOST_CHECK( result == ImportResult::SameNonceAlreadyInQueue );
     BOOST_CHECK( 1 == txq.maxNonce( to ) );
 
     // 2nd tx - should import fine
@@ -258,21 +259,6 @@ BOOST_AUTO_TEST_CASE( tqLimits ) {
     BOOST_REQUIRE( importCurrent( txq, tx4 ) == ImportResult::QueueIsFull );
     BOOST_REQUIRE( importCurrent( txq, tx5 ) == ImportResult::QueueIsFull );
     BOOST_CHECK( ( Transactions{tx0, tx1, tx2} ) == txq.topTransactions( 256 ) );
-
-    // CTQ limit -> goes to FTQ until FTQ limit is reached
-    dev::eth::TransactionQueue txq2( 3, 2 );
-    BOOST_REQUIRE( importCurrent( txq2, tx0 ) == ImportResult::Success );
-    BOOST_REQUIRE( importCurrent( txq2, tx1 ) == ImportResult::Success );
-    BOOST_REQUIRE( importCurrent( txq2, tx2 ) == ImportResult::Success );
-    BOOST_REQUIRE( importCurrent( txq2, tx3 ) == ImportResult::Success ); // goes to future
-    BOOST_REQUIRE( importCurrent( txq2, tx4 ) == ImportResult::Success ); // goes to future
-    BOOST_REQUIRE( importCurrent( txq2, tx5 ) == ImportResult::QueueIsFull ); // future is full
-    // t0, t1, t2 in CTQ
-    BOOST_CHECK( ( Transactions{tx0, tx1, tx2 } ) == txq2.topTransactions( 256 ) );
-
-    // t3, t4 in FTQ
-    BOOST_CHECK( ( Transactions{tx3, tx4} ) == txq2.debugGetFutureTransactions() );
-
 
 }
 

--- a/test/unittests/libethereum/TransactionQueue.cpp
+++ b/test/unittests/libethereum/TransactionQueue.cpp
@@ -31,6 +31,19 @@ using namespace dev;
 using namespace dev::eth;
 using namespace dev::test;
 
+namespace {
+
+ImportResult importCurrent( TransactionQueue& _queue, Transaction const& _transaction ) {
+    return _queue.import( _transaction, IfDropped::Ignore, false, _transaction.nonce() );
+}
+
+ImportResult importCurrent( TransactionQueue& _queue, bytes const& _transactionRLP ) {
+    Transaction transaction( _transactionRLP, CheckTransaction::Everything );
+    return _queue.import( _transactionRLP, IfDropped::Ignore, false, transaction.nonce() );
+}
+
+}
+
 BOOST_FIXTURE_TEST_SUITE( TransactionQueueSuite, TestOutputHelperFixture )
 
 BOOST_AUTO_TEST_CASE( TransactionEIP86 ) {
@@ -41,7 +54,7 @@ BOOST_AUTO_TEST_CASE( TransactionEIP86 ) {
     streamRLP << 0 << 10 * szabo << 25000;
     streamRLP << to << 0 << bytes() << 0 << 0 << 0;
     Transaction tx0( streamRLP.out(), CheckTransaction::Everything );
-    ImportResult result = txq.import( tx0 );
+    ImportResult result = importCurrent( txq, tx0 );
     BOOST_CHECK( result == ImportResult::ZeroSignature );
     BOOST_CHECK( txq.knownTransactions().size() == 0 );
 }
@@ -61,17 +74,34 @@ BOOST_AUTO_TEST_CASE( tqMaxNonce ) {
     Transaction tx2( 0, gasCost, gas, dest, bytes(), 2, sec );
     Transaction tx9( 0, gasCost, gas, dest, bytes(), 9, sec );
 
-    txq.import( tx0 );
+    // 1st tx - should import fine
+    auto result = importCurrent( txq, tx0 );
+    BOOST_CHECK( result == ImportResult::Success );
     BOOST_CHECK( 1 == txq.maxNonce( to ) );
-    txq.import( tx0 );
+
+    // same tx - should not increase nonce
+    result = importCurrent( txq, tx0 );
+    BOOST_CHECK( result == ImportResult::Success );
     BOOST_CHECK( 1 == txq.maxNonce( to ) );
-    txq.import( tx0_1 );
+
+    // different tx for same nonce - should not increase nonce
+    result = importCurrent( txq, tx0_1 );
+    BOOST_CHECK( result == ImportResult::Success );
     BOOST_CHECK( 1 == txq.maxNonce( to ) );
-    txq.import( tx1 );
+
+    // 2nd tx - should import fine
+    result = importCurrent( txq, tx1 );
+    BOOST_CHECK( result == ImportResult::Success );
     BOOST_CHECK( 2 == txq.maxNonce( to ) );
-    txq.import( tx9 );
+
+    // nonce is not contiguous - should go to future queue (only if available)
+    result = txq.import( tx9, IfDropped::Ignore, true, 0 );
+    BOOST_CHECK( result == ImportResult::Success );
     BOOST_CHECK( 10 == txq.maxNonce( to ) );
-    txq.import( tx2 );
+
+    // tx2 also gets inserted - max nonce should not change as tx9 is still in future
+    result = importCurrent( txq, tx2 );
+    BOOST_CHECK( result == ImportResult::Success );
     BOOST_CHECK( 10 == txq.maxNonce( to ) );
 }
 
@@ -93,21 +123,21 @@ BOOST_AUTO_TEST_CASE( tqPriority ) {
     Transaction tx4( 0, gasCostMed, gas, dest, bytes(), 2, sender1 );
     Transaction tx5( 0, gasCostHigh, gas, dest, bytes(), 2, sender2 );
 
-    txq.import( tx0 );
+    importCurrent( txq, tx0 );
     BOOST_CHECK( Transactions{tx0} == txq.topTransactions( 256 ) );
-    txq.import( tx0 );
+    importCurrent( txq, tx0 );
     BOOST_CHECK( Transactions{tx0} == txq.topTransactions( 256 ) );
-    txq.import( tx0_1 );
+    importCurrent( txq, tx0_1 );
     BOOST_CHECK( Transactions{tx0} == txq.topTransactions( 256 ) );  // no replacement any more!
-    txq.import( tx1 );
+    importCurrent( txq, tx1 );
     BOOST_CHECK( ( Transactions{tx0, tx1} ) == txq.topTransactions( 256 ) );
-    txq.import( tx2 );
+    importCurrent( txq, tx2 );
     BOOST_CHECK( ( Transactions{tx2, tx0, tx1} ) == txq.topTransactions( 256 ) );
-    txq.import( tx3 );
+    importCurrent( txq, tx3 );
     BOOST_CHECK( ( Transactions{tx2, tx0, tx1, tx3} ) == txq.topTransactions( 256 ) );
-    txq.import( tx4 );
+    importCurrent( txq, tx4 );
     BOOST_CHECK( ( Transactions{tx2, tx0, tx1, tx3, tx4} ) == txq.topTransactions( 256 ) );
-    txq.import( tx5 );
+    importCurrent( txq, tx5 );
     BOOST_CHECK( ( Transactions{tx2, tx0, tx1, tx3, tx5, tx4} ) == txq.topTransactions( 256 ) );
 
     txq.drop( tx0.sha3() );
@@ -120,13 +150,13 @@ BOOST_AUTO_TEST_CASE( tqPriority ) {
     BOOST_CHECK( ( Transactions{tx2, tx4, tx3} ) == txq.topTransactions( 256 ) );
 
     Transaction tx6( 0, gasCostMed, gas, dest, bytes(), 20, sender1 );
-    txq.import( tx6 );
-    BOOST_CHECK( ( Transactions{tx2, tx4, tx3, tx6} ) == txq.topTransactions( 256 ) );
+    txq.import( tx6, IfDropped::Ignore, true, 0 );
+    BOOST_CHECK( ( Transactions{tx2, tx4, tx3} ) == txq.topTransactions( 256 ) );
 
     Transaction tx7( 0, gasCostHigh, gas, dest, bytes(), 2, sender2 );
-    txq.import( tx7 );
+    importCurrent( txq, tx7 );
     // deterministic signature: hash of tx5 and tx7 will be same
-    BOOST_CHECK( ( Transactions{tx2, tx4, tx3, tx6} ) == txq.topTransactions( 256 ) );
+    BOOST_CHECK( ( Transactions{tx2, tx4, tx3} ) == txq.topTransactions( 256 ) );
 }
 
 BOOST_AUTO_TEST_CASE( tqNonceChange ) {
@@ -149,20 +179,20 @@ BOOST_AUTO_TEST_CASE( tqNonceChange ) {
     Transaction tx23( 0, gasCost, gas, dest, bytes(), 3, sender2 );
 
     // 1 insert 0,1,2 for both senders
-    txq.import( tx20 ); // h = 0
-    txq.import( tx21 ); // h = 1
-    txq.import( tx22 ); // h = 2
-    txq.import( tx10 ); // h = 0
-    txq.import( tx11 ); // h = 1
-    txq.import( tx12 ); // h = 2
-    txq.import( tx13 ); // h = 3
+    importCurrent( txq, tx20 ); // h = 0
+    importCurrent( txq, tx21 ); // h = 1
+    importCurrent( txq, tx22 ); // h = 2
+    importCurrent( txq, tx10 ); // h = 0
+    importCurrent( txq, tx11 ); // h = 1
+    importCurrent( txq, tx12 ); // h = 2
+    importCurrent( txq, tx13 ); // h = 3
 
     // 2 increase nonce for account 2
     txq.dropGood( tx20 );
     txq.dropGood( tx21 );
 
     // 3 insert tx with height = 3-2=1
-    txq.import( tx23 ); // h = 1 => goes with tx11
+    importCurrent( txq, tx23 ); // h = 1 => goes with tx11
 
     Transactions top6 = txq.topTransactions(6);
     for(auto tx: top6){
@@ -188,11 +218,11 @@ BOOST_AUTO_TEST_CASE( tqFuture ) {
     Transaction tx3( 0, gasCostMed, gas, dest, bytes(), 3, sender );
     Transaction tx4( 0, gasCostMed, gas, dest, bytes(), 4, sender );
 
-    txq.import( tx0 );
-    txq.import( tx1 );
-    txq.import( tx2 );
-    txq.import( tx3 );
-    txq.import( tx4 );
+    importCurrent( txq, tx0 );
+    importCurrent( txq, tx1 );
+    importCurrent( txq, tx2 );
+    importCurrent( txq, tx3 );
+    importCurrent( txq, tx4 );
     BOOST_CHECK( ( Transactions{tx0, tx1, tx2, tx3, tx4} ) == txq.topTransactions( 256 ) );
 
     txq.setFuture( tx2.sha3() );
@@ -200,14 +230,13 @@ BOOST_AUTO_TEST_CASE( tqFuture ) {
 
     // TODO disabled it temporarily!!
     //    Transaction tx2_2( 1, gasCostMed, gas, dest, bytes(), 2, sender );
-    //    txq.import( tx2_2 );
+    //    importCurrent( txq, tx2_2 );
     //    BOOST_CHECK( ( Transactions{tx0, tx1, tx2_2, tx3, tx4} ) == txq.topTransactions( 256 ) );
     //    // no replacement
 }
 
 
 BOOST_AUTO_TEST_CASE( tqLimits ) {
-    dev::eth::TransactionQueue txq( 3, 3 );
     const u256 gasCostMed = 20 * szabo;
     const u256 gas = 25000;
     Address dest = Address( "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" );
@@ -220,13 +249,31 @@ BOOST_AUTO_TEST_CASE( tqLimits ) {
     Transaction tx4( 0, gasCostMed, gas, dest, bytes(), 4, sender );
     Transaction tx5( 0, gasCostMed + 1, gas, dest, bytes(), 0, sender2 );
 
-    txq.import( tx0 );
-    txq.import( tx1 );
-    txq.import( tx2 );
-    txq.import( tx3 );
-    txq.import( tx4 );
-    txq.import( tx5 );
-    BOOST_CHECK( ( Transactions{tx5, tx0, tx1} ) == txq.topTransactions( 256 ) );
+    // CTQ limit with no Future queue
+    dev::eth::TransactionQueue txq( 3, 3 );
+    BOOST_REQUIRE( importCurrent( txq, tx0 ) == ImportResult::Success );
+    BOOST_REQUIRE( importCurrent( txq, tx1 ) == ImportResult::Success );
+    BOOST_REQUIRE( importCurrent( txq, tx2 ) == ImportResult::Success );
+    BOOST_REQUIRE( importCurrent( txq, tx3 ) == ImportResult::QueueIsFull );
+    BOOST_REQUIRE( importCurrent( txq, tx4 ) == ImportResult::QueueIsFull );
+    BOOST_REQUIRE( importCurrent( txq, tx5 ) == ImportResult::QueueIsFull );
+    BOOST_CHECK( ( Transactions{tx0, tx1, tx2} ) == txq.topTransactions( 256 ) );
+
+    // CTQ limit -> goes to FTQ until FTQ limit is reached
+    dev::eth::TransactionQueue txq2( 3, 2 );
+    BOOST_REQUIRE( importCurrent( txq2, tx0 ) == ImportResult::Success );
+    BOOST_REQUIRE( importCurrent( txq2, tx1 ) == ImportResult::Success );
+    BOOST_REQUIRE( importCurrent( txq2, tx2 ) == ImportResult::Success );
+    BOOST_REQUIRE( importCurrent( txq2, tx3 ) == ImportResult::Success ); // goes to future
+    BOOST_REQUIRE( importCurrent( txq2, tx4 ) == ImportResult::Success ); // goes to future
+    BOOST_REQUIRE( importCurrent( txq2, tx5 ) == ImportResult::QueueIsFull ); // future is full
+    // t0, t1, t2 in CTQ
+    BOOST_CHECK( ( Transactions{tx0, tx1, tx2 } ) == txq2.topTransactions( 256 ) );
+
+    // t3, t4 in FTQ
+    BOOST_CHECK( ( Transactions{tx3, tx4} ) == txq2.debugGetFutureTransactions() );
+
+
 }
 
 BOOST_AUTO_TEST_CASE( tqImport ) {
@@ -235,17 +282,17 @@ BOOST_AUTO_TEST_CASE( tqImport ) {
     h256Hash known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 0 );
     
-    ImportResult ir = tq.import( testTransaction.transaction().toBytes() );
+    ImportResult ir = importCurrent( tq, testTransaction.transaction().toBytes() );
     BOOST_REQUIRE( ir == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 1 );
     
-    ir = tq.import( testTransaction.transaction().toBytes() );
+    ir = importCurrent( tq, testTransaction.transaction().toBytes() );
     BOOST_REQUIRE( ir == ImportResult::AlreadyKnown );
     
     bytes rlp = testTransaction.transaction().toBytes();
     rlp.at( 0 ) = 03;
-    ir = tq.import( rlp );
+    ir = tq.import( rlp, IfDropped::Ignore, false, testTransaction.transaction().nonce() );
     BOOST_REQUIRE( ir == ImportResult::Malformed );
 
     known = tq.knownTransactions();
@@ -255,13 +302,13 @@ BOOST_AUTO_TEST_CASE( tqImport ) {
     TestTransaction testTransaction3 = TestTransaction::defaultTransaction( 1, 1 );
     TestTransaction testTransaction4 = TestTransaction::defaultTransaction( 1, 4 );
     
-    ir = tq.import( testTransaction2.transaction().toBytes() );
+    ir = importCurrent( tq, testTransaction2.transaction().toBytes() );
     BOOST_REQUIRE( ir == ImportResult::SameNonceAlreadyInQueue );
     
-    ir = tq.import( testTransaction3.transaction().toBytes() );
+    ir = importCurrent( tq, testTransaction3.transaction().toBytes() );
     BOOST_REQUIRE( ir == ImportResult::AlreadyKnown );
     
-    ir = tq.import( testTransaction4.transaction().toBytes() );
+    ir = importCurrent( tq, testTransaction4.transaction().toBytes() );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 1 );
     Transactions ts = tq.topTransactions( 4 );
@@ -290,7 +337,7 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     u256 waiting = tq.waiting(sender);
     BOOST_REQUIRE( waiting == 0 );
     
-    ImportResult ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true );
+    ImportResult ir1 = tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir1 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 1 );
@@ -301,8 +348,8 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     waiting = tq.waiting(sender);
     BOOST_REQUIRE( waiting == 1 );
 
-    // HACK it's now allowed to repeat future transaction (can put it to current)
-    ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true );
+    // HACK it's allowed to repeat a future transaction without a duplicate error.
+    ir1 = tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir1 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 1 );
@@ -315,11 +362,11 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     
     bytes rlp = tx1.transaction().toBytes();
     rlp.at( 0 ) = 03;
-    ir1 = tq.import( rlp, IfDropped::Ignore, true );
+    ir1 = tq.import( rlp, IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir1 == ImportResult::Malformed );
 
     TestTransaction tx2 = TestTransaction::defaultTransaction(2);
-    ImportResult ir2 = tq.import( tx2.transaction().toBytes(), IfDropped::Ignore, true );
+    ImportResult ir2 = tq.import( tx2.transaction(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir2 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 2 );
@@ -330,7 +377,7 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     BOOST_CHECK( ( Transactions{} ) == tq.topTransactions( 256 ) );
 
     TestTransaction tx3 = TestTransaction::defaultTransaction(1);
-    ImportResult ir3 = tq.import( tx3.transaction().toBytes(), IfDropped::Ignore, true );
+    ImportResult ir3 = tq.import( tx3.transaction(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir3 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 3 );
@@ -341,7 +388,7 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     BOOST_CHECK( ( Transactions{} ) == tq.topTransactions( 256 ) );
 
     TestTransaction tx4 = TestTransaction::defaultTransaction(0);
-    ImportResult ir4 = tq.import( tx4.transaction().toBytes(), IfDropped::Ignore );
+    ImportResult ir4 = tq.import( tx4.transaction().toBytes(), IfDropped::Ignore, false, 0 );
     BOOST_REQUIRE( ir4 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 4 );
@@ -355,7 +402,7 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     BOOST_CHECK( ( Transactions{ tx4.transaction(), tx3.transaction(), tx2.transaction() } ) == tq.topTransactions( 256 ) );
 
     TestTransaction tx5 = TestTransaction::defaultTransaction(3);
-    ImportResult ir5 = tq.import( tx5.transaction().toBytes(), IfDropped::Ignore );
+    ImportResult ir5 = tq.import( tx5.transaction().toBytes(), IfDropped::Ignore, false, 0 );
     BOOST_REQUIRE( ir5 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 5 );
@@ -373,7 +420,7 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     Address dest = Address( "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" );
     Secret sender2 = Secret( "0x4444444444444444444444444444444444444444444444444444444444444444" );
     Transaction tx0( 0, gasCostMed, gas, dest, bytes(), 4, sender2 );
-    ImportResult ir0 = tq.import( tx0, IfDropped::Ignore, true );
+    ImportResult ir0 = tq.import( tx0, IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir0 == ImportResult::Success );
     waiting = tq.waiting(dev::toAddress(sender2));
     BOOST_REQUIRE( waiting == 1 );
@@ -387,25 +434,115 @@ BOOST_AUTO_TEST_CASE( dropFromFutureToCurrent ) {
     TestTransaction tx1 = TestTransaction::defaultTransaction(1);
 
     // put transaction to future
-    ImportResult ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true );
+    ImportResult ir1 = tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir1 == ImportResult::Success );
     TransactionQueue::Status status = tq.status();
     BOOST_REQUIRE( status.current == 0 && status.future == 1 );
 
     // push it to current and see it fall back from future to current
-    ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, false );
+    ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, false, 1 );
     BOOST_REQUIRE( ir1 == ImportResult::Success );
     status = tq.status();
     BOOST_REQUIRE( status.current == 1 && status.future == 0 );
 }
 
+BOOST_AUTO_TEST_CASE( tqFutureAllowedStillTriesCurrentFirst ) {
+    TransactionQueue tq;
+
+    TestTransaction tx0 = TestTransaction::defaultTransaction( 0 );
+    ImportResult res = tq.import( tx0.transaction(), IfDropped::Ignore, true, 0 );
+    BOOST_REQUIRE( res == ImportResult::Success );
+    BOOST_REQUIRE( tq.status().current == 1 );
+    BOOST_REQUIRE( tq.status().future == 0 );
+
+    TestTransaction tx1 = TestTransaction::defaultTransaction( 1 );
+    res = tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
+    BOOST_REQUIRE( res == ImportResult::Success );
+    BOOST_REQUIRE( tq.status().current == 2 );
+    BOOST_REQUIRE( tq.status().future == 0 );
+}
+
+BOOST_AUTO_TEST_CASE( tqFutureRejectsDifferentTransactionWithSameNonce ) {
+    TransactionQueue tq;
+
+    TestTransaction tx1 = TestTransaction::defaultTransaction( 3, 1 );
+    ImportResult res = tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
+    BOOST_REQUIRE( res == ImportResult::Success );
+
+    TestTransaction replacement = TestTransaction::defaultTransaction( 3, 2 );
+    res = tq.import( replacement.transaction(), IfDropped::Ignore, true, 0 );
+    BOOST_REQUIRE( res == ImportResult::SameNonceAlreadyInQueue );
+    BOOST_REQUIRE( tq.status().future == 1 );
+    BOOST_CHECK( ( h256Hash{ tx1.transaction().sha3() } ) == tq.knownTransactions() );
+}
+
+BOOST_AUTO_TEST_CASE( tqCurrentFullFallsBackToFutureWhenAllowed ) {
+    TransactionQueue tq( 1, 1 );
+
+    TestTransaction tx0 = TestTransaction::defaultTransaction( 0 );
+    ImportResult res = tq.import( tx0.transaction(), IfDropped::Ignore, true, 0 );
+    BOOST_REQUIRE( res == ImportResult::Success );
+
+    TestTransaction tx1 = TestTransaction::defaultTransaction( 1 );
+    res = tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
+    BOOST_REQUIRE( res == ImportResult::Success );
+    BOOST_REQUIRE( tq.status().current == 1 );
+    BOOST_REQUIRE( tq.status().future == 1 );
+
+    TestTransaction tx2 = TestTransaction::defaultTransaction( 2 );
+    res = tq.import( tx2.transaction(), IfDropped::Ignore, true, 0 );
+    BOOST_REQUIRE( res == ImportResult::QueueIsFull );
+    BOOST_REQUIRE( tq.status().current == 1 );
+    BOOST_REQUIRE( tq.status().future == 1 );
+}
+
+BOOST_AUTO_TEST_CASE( tqDropGoodPromotesFutureWhenCurrentWasFull ) {
+    TransactionQueue tq( 1, 1 );
+
+    TestTransaction tx0 = TestTransaction::defaultTransaction( 0 );
+    ImportResult res = tq.import( tx0.transaction(), IfDropped::Ignore, true, 0 );
+    BOOST_REQUIRE( res == ImportResult::Success );
+
+    TestTransaction tx1 = TestTransaction::defaultTransaction( 1 );
+    res = tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
+    BOOST_REQUIRE( res == ImportResult::Success );
+    BOOST_REQUIRE( tq.status().current == 1 );
+    BOOST_REQUIRE( tq.status().future == 1 );
+
+    tq.dropGood( tx0.transaction() );
+    BOOST_REQUIRE( tq.status().current == 1 );
+    BOOST_REQUIRE( tq.status().future == 0 );
+    BOOST_CHECK( ( Transactions{ tx1.transaction() } ) == tq.topTransactions( 256 ) );
+}
+
+BOOST_AUTO_TEST_CASE( tqFutureDisabledRejectsNonCurrentTransactions ) {
+    TransactionQueue tq( 1, 1 );
+
+    TestTransaction tx0 = TestTransaction::defaultTransaction( 0 );
+    ImportResult res = tq.import( tx0.transaction(), IfDropped::Ignore, false, 0 );
+    BOOST_REQUIRE( res == ImportResult::Success );
+
+    TestTransaction tx1 = TestTransaction::defaultTransaction( 1 );
+    res = tq.import( tx1.transaction(), IfDropped::Ignore, false, 0 );
+    BOOST_REQUIRE( res == ImportResult::QueueIsFull );
+    BOOST_REQUIRE( tq.status().current == 1 );
+    BOOST_REQUIRE( tq.status().future == 0 );
+
+    TransactionQueue emptyTq( 1, 1 );
+    TestTransaction tx2 = TestTransaction::defaultTransaction( 2 );
+    res = emptyTq.import( tx2.transaction(), IfDropped::Ignore, false, 0 );
+    BOOST_REQUIRE( res == ImportResult::QueueIsFull );
+    BOOST_REQUIRE( emptyTq.status().current == 0 );
+    BOOST_REQUIRE( emptyTq.status().future == 0 );
+}
+
 BOOST_AUTO_TEST_CASE( tqImportFutureLimits ) {
     dev::eth::TransactionQueue tq( 1024, 2 );
     TestTransaction tx1 = TestTransaction::defaultTransaction(3);
-    tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true );
+    tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
 
     TestTransaction tx2 = TestTransaction::defaultTransaction(2);
-    tq.import( tx2.transaction().toBytes(), IfDropped::Ignore, true );
+    tq.import( tx2.transaction(), IfDropped::Ignore, true, 0 );
 
     auto waiting = tq.waiting(tx1.transaction().sender());
     BOOST_REQUIRE( waiting == 2 );
@@ -413,21 +550,21 @@ BOOST_AUTO_TEST_CASE( tqImportFutureLimits ) {
     BOOST_REQUIRE( known.size() == 2 );
 
     TestTransaction tx3 = TestTransaction::defaultTransaction(1);
-    ImportResult ir = tq.import( tx3.transaction().toBytes(), IfDropped::Ignore, true );
-    BOOST_REQUIRE( ir == ImportResult::Success );
+    ImportResult ir = tq.import( tx3.transaction(), IfDropped::Ignore, true, 0 );
+    BOOST_REQUIRE( ir == ImportResult::QueueIsFull );
 
     waiting = tq.waiting(tx1.transaction().sender());
     BOOST_REQUIRE( waiting == 2 );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 2 );
-    BOOST_CHECK( ( h256Hash{ tx3.transaction().sha3(), tx2.transaction().sha3() } ) == known );
+    BOOST_CHECK( ( h256Hash{ tx1.transaction().sha3(), tx2.transaction().sha3() } ) == known );
 }
 
 BOOST_AUTO_TEST_CASE( tqImportFutureLimits2 ) {
     dev::eth::TransactionQueue tq( 1024, 2 );
 
     TestTransaction tx1 = TestTransaction::defaultTransaction(3);
-    tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true );
+    tq.import( tx1.transaction(), IfDropped::Ignore, true, 0 );
 
     auto waiting = tq.waiting(tx1.transaction().sender());
     BOOST_REQUIRE( waiting == 1 );
@@ -441,7 +578,7 @@ BOOST_AUTO_TEST_CASE( tqImportFutureLimits2 ) {
     Address dest = Address( "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" );
     Secret sender2 = Secret( "0x1111111111111111111111111111111111111111111111111111111111111111" );
     Transaction tx0( 0, gasCostMed, gas, dest, bytes(), 4, sender2 );
-    ImportResult ir0 = tq.import( tx0, IfDropped::Ignore, true );
+    ImportResult ir0 = tq.import( tx0, IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir0 == ImportResult::Success );
 
     waiting = tq.waiting(tx1.transaction().sender());
@@ -454,7 +591,8 @@ BOOST_AUTO_TEST_CASE( tqImportFutureLimits2 ) {
     BOOST_REQUIRE( status.future == 2 );  
 
     TestTransaction tx2 = TestTransaction::defaultTransaction(2);
-    tq.import( tx2.transaction().toBytes(), IfDropped::Ignore, true );
+    ImportResult ir2 = tq.import( tx2.transaction(), IfDropped::Ignore, true, 0 );
+    BOOST_REQUIRE( ir2 == ImportResult::QueueIsFull );
 
     waiting = tq.waiting(tx1.transaction().sender());
     BOOST_REQUIRE( waiting == 1 );
@@ -465,14 +603,14 @@ BOOST_AUTO_TEST_CASE( tqImportFutureLimits2 ) {
     status = tq.status();
     BOOST_REQUIRE( status.future == 2 );  
  
-    BOOST_CHECK( ( h256Hash{ tx0.sha3(), tx2.transaction().sha3() } ) == known );
+    BOOST_CHECK( ( h256Hash{ tx1.transaction().sha3(), tx0.sha3() } ) == known );
 }
 
 BOOST_AUTO_TEST_CASE( tqDrop ) {
     TransactionQueue tq;
     TestTransaction testTransaction = TestTransaction::defaultTransaction();
     tq.dropGood( testTransaction.transaction() );
-    tq.import( testTransaction.transaction().toBytes() );
+    importCurrent( tq, testTransaction.transaction().toBytes() );
     BOOST_REQUIRE( tq.topTransactions( 4 ).size() == 1 );
     tq.dropGood( testTransaction.transaction() );
     BOOST_REQUIRE( tq.topTransactions( 4 ).size() == 0 );
@@ -483,12 +621,15 @@ BOOST_AUTO_TEST_CASE( tqLimit ) {
     Address from;
     for ( size_t i = 1; i < 7; i++ ) {
         TestTransaction testTransaction = TestTransaction::defaultTransaction( i );
-        ImportResult res = tq.import( testTransaction.transaction() );
+        ImportResult res = importCurrent( tq, testTransaction.transaction() );
         from = testTransaction.transaction().from();
-        BOOST_REQUIRE( res == ImportResult::Success );
+        if ( i < 6 )
+            BOOST_REQUIRE( res == ImportResult::Success );
+        else
+            BOOST_REQUIRE( res == ImportResult::QueueIsFull );
     }
 
-    // 5 is imported and 6th is dropped
+    // 5 are imported and the 6th is rejected.
     BOOST_REQUIRE( tq.waiting( from ) == 5 );
 
     Transactions topTr = tq.topTransactions( 10 );
@@ -504,7 +645,7 @@ BOOST_AUTO_TEST_CASE( tqLimit ) {
     BOOST_REQUIRE( tq.waiting( from ) == 3 );
 
     // Drop out of bound feauture
-    ImportResult res = tq.import( testTransaction.transaction() );
+    ImportResult res = importCurrent( tq, testTransaction.transaction() );
     BOOST_REQUIRE( res == ImportResult::Success );
 
     // future list size is now 3  + 1 imported transaction
@@ -520,11 +661,11 @@ BOOST_AUTO_TEST_CASE( tqLimitBytes ) {
     unsigned maxTxCount = 250 / TestTransaction::defaultTransaction( 1 ).transaction().toBytes().size();
 
     TestTransaction testTransaction = TestTransaction::defaultTransaction( 2 );
-    ImportResult res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true );
+    ImportResult res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( res == ImportResult::Success );
 
     testTransaction = TestTransaction::defaultTransaction( 3 );
-    res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true );
+    res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( res == ImportResult::Success );
 
     BOOST_REQUIRE( tq.status().current == 0 );
@@ -532,23 +673,29 @@ BOOST_AUTO_TEST_CASE( tqLimitBytes ) {
     BOOST_REQUIRE( tq.status().future == maxTxCount );
 
     testTransaction = TestTransaction::defaultTransaction( 4 );
-    res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true );
-    BOOST_REQUIRE( res == ImportResult::Success );
+    res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true, 0 );
+    BOOST_REQUIRE( res == ImportResult::QueueIsFull );
 
     BOOST_REQUIRE( tq.status().current == 0 );
 
     BOOST_REQUIRE( tq.status().future == maxTxCount );
 
+    bool currentAccepted = false;
     for ( size_t i = 1; i < 10; i++ ) {
         if (i == 2 || i == 3)
             continue;
         testTransaction = TestTransaction::defaultTransaction( i );
-        res = tq.import( testTransaction.transaction() );
-        BOOST_REQUIRE( res == ImportResult::Success );
+        res = importCurrent( tq, testTransaction.transaction() );
+        if ( !currentAccepted ) {
+            BOOST_REQUIRE( res == ImportResult::Success );
+            currentAccepted = true;
+        } else {
+            BOOST_REQUIRE( res == ImportResult::QueueIsFull );
+        }
     }
 
     BOOST_REQUIRE( tq.status().current == maxTxCount );
-    BOOST_REQUIRE( tq.status().future == 0 );
+    BOOST_REQUIRE( tq.status().future <= maxTxCount );
 }
 
 BOOST_AUTO_TEST_CASE( tqEqueue ) {

--- a/test/unittests/libethereum/TransactionQueue.cpp
+++ b/test/unittests/libethereum/TransactionQueue.cpp
@@ -31,6 +31,19 @@ using namespace dev;
 using namespace dev::eth;
 using namespace dev::test;
 
+namespace {
+
+ImportResult importCurrent( TransactionQueue& _queue, Transaction const& _transaction ) {
+    return _queue.import( _transaction, IfDropped::Ignore, false, _transaction.nonce() );
+}
+
+ImportResult importCurrent( TransactionQueue& _queue, bytes const& _transactionRLP ) {
+    Transaction transaction( _transactionRLP, CheckTransaction::Everything );
+    return _queue.import( _transactionRLP, IfDropped::Ignore, false, transaction.nonce() );
+}
+
+}
+
 BOOST_FIXTURE_TEST_SUITE( TransactionQueueSuite, TestOutputHelperFixture )
 
 BOOST_AUTO_TEST_CASE( TransactionEIP86 ) {
@@ -41,7 +54,7 @@ BOOST_AUTO_TEST_CASE( TransactionEIP86 ) {
     streamRLP << 0 << 10 * szabo << 25000;
     streamRLP << to << 0 << bytes() << 0 << 0 << 0;
     Transaction tx0( streamRLP.out(), CheckTransaction::Everything );
-    ImportResult result = txq.import( tx0 );
+    ImportResult result = importCurrent( txq, tx0 );
     BOOST_CHECK( result == ImportResult::ZeroSignature );
     BOOST_CHECK( txq.knownTransactions().size() == 0 );
 }
@@ -61,17 +74,17 @@ BOOST_AUTO_TEST_CASE( tqMaxNonce ) {
     Transaction tx2( 0, gasCost, gas, dest, bytes(), 2, sec );
     Transaction tx9( 0, gasCost, gas, dest, bytes(), 9, sec );
 
-    txq.import( tx0 );
+    importCurrent( txq, tx0 );
     BOOST_CHECK( 1 == txq.maxNonce( to ) );
-    txq.import( tx0 );
+    importCurrent( txq, tx0 );
     BOOST_CHECK( 1 == txq.maxNonce( to ) );
-    txq.import( tx0_1 );
+    importCurrent( txq, tx0_1 );
     BOOST_CHECK( 1 == txq.maxNonce( to ) );
-    txq.import( tx1 );
+    importCurrent( txq, tx1 );
     BOOST_CHECK( 2 == txq.maxNonce( to ) );
-    txq.import( tx9 );
+    importCurrent( txq, tx9 );
     BOOST_CHECK( 10 == txq.maxNonce( to ) );
-    txq.import( tx2 );
+    importCurrent( txq, tx2 );
     BOOST_CHECK( 10 == txq.maxNonce( to ) );
 }
 
@@ -93,21 +106,21 @@ BOOST_AUTO_TEST_CASE( tqPriority ) {
     Transaction tx4( 0, gasCostMed, gas, dest, bytes(), 2, sender1 );
     Transaction tx5( 0, gasCostHigh, gas, dest, bytes(), 2, sender2 );
 
-    txq.import( tx0 );
+    importCurrent( txq, tx0 );
     BOOST_CHECK( Transactions{tx0} == txq.topTransactions( 256 ) );
-    txq.import( tx0 );
+    importCurrent( txq, tx0 );
     BOOST_CHECK( Transactions{tx0} == txq.topTransactions( 256 ) );
-    txq.import( tx0_1 );
+    importCurrent( txq, tx0_1 );
     BOOST_CHECK( Transactions{tx0} == txq.topTransactions( 256 ) );  // no replacement any more!
-    txq.import( tx1 );
+    importCurrent( txq, tx1 );
     BOOST_CHECK( ( Transactions{tx0, tx1} ) == txq.topTransactions( 256 ) );
-    txq.import( tx2 );
+    importCurrent( txq, tx2 );
     BOOST_CHECK( ( Transactions{tx2, tx0, tx1} ) == txq.topTransactions( 256 ) );
-    txq.import( tx3 );
+    importCurrent( txq, tx3 );
     BOOST_CHECK( ( Transactions{tx2, tx0, tx1, tx3} ) == txq.topTransactions( 256 ) );
-    txq.import( tx4 );
+    importCurrent( txq, tx4 );
     BOOST_CHECK( ( Transactions{tx2, tx0, tx1, tx3, tx4} ) == txq.topTransactions( 256 ) );
-    txq.import( tx5 );
+    importCurrent( txq, tx5 );
     BOOST_CHECK( ( Transactions{tx2, tx0, tx1, tx3, tx5, tx4} ) == txq.topTransactions( 256 ) );
 
     txq.drop( tx0.sha3() );
@@ -120,11 +133,11 @@ BOOST_AUTO_TEST_CASE( tqPriority ) {
     BOOST_CHECK( ( Transactions{tx2, tx4, tx3} ) == txq.topTransactions( 256 ) );
 
     Transaction tx6( 0, gasCostMed, gas, dest, bytes(), 20, sender1 );
-    txq.import( tx6 );
+    importCurrent( txq, tx6 );
     BOOST_CHECK( ( Transactions{tx2, tx4, tx3, tx6} ) == txq.topTransactions( 256 ) );
 
     Transaction tx7( 0, gasCostHigh, gas, dest, bytes(), 2, sender2 );
-    txq.import( tx7 );
+    importCurrent( txq, tx7 );
     // deterministic signature: hash of tx5 and tx7 will be same
     BOOST_CHECK( ( Transactions{tx2, tx4, tx3, tx6} ) == txq.topTransactions( 256 ) );
 }
@@ -149,20 +162,20 @@ BOOST_AUTO_TEST_CASE( tqNonceChange ) {
     Transaction tx23( 0, gasCost, gas, dest, bytes(), 3, sender2 );
 
     // 1 insert 0,1,2 for both senders
-    txq.import( tx20 ); // h = 0
-    txq.import( tx21 ); // h = 1
-    txq.import( tx22 ); // h = 2
-    txq.import( tx10 ); // h = 0
-    txq.import( tx11 ); // h = 1
-    txq.import( tx12 ); // h = 2
-    txq.import( tx13 ); // h = 3
+    importCurrent( txq, tx20 ); // h = 0
+    importCurrent( txq, tx21 ); // h = 1
+    importCurrent( txq, tx22 ); // h = 2
+    importCurrent( txq, tx10 ); // h = 0
+    importCurrent( txq, tx11 ); // h = 1
+    importCurrent( txq, tx12 ); // h = 2
+    importCurrent( txq, tx13 ); // h = 3
 
     // 2 increase nonce for account 2
     txq.dropGood( tx20 );
     txq.dropGood( tx21 );
 
     // 3 insert tx with height = 3-2=1
-    txq.import( tx23 ); // h = 1 => goes with tx11
+    importCurrent( txq, tx23 ); // h = 1 => goes with tx11
 
     Transactions top6 = txq.topTransactions(6);
     for(auto tx: top6){
@@ -188,11 +201,11 @@ BOOST_AUTO_TEST_CASE( tqFuture ) {
     Transaction tx3( 0, gasCostMed, gas, dest, bytes(), 3, sender );
     Transaction tx4( 0, gasCostMed, gas, dest, bytes(), 4, sender );
 
-    txq.import( tx0 );
-    txq.import( tx1 );
-    txq.import( tx2 );
-    txq.import( tx3 );
-    txq.import( tx4 );
+    importCurrent( txq, tx0 );
+    importCurrent( txq, tx1 );
+    importCurrent( txq, tx2 );
+    importCurrent( txq, tx3 );
+    importCurrent( txq, tx4 );
     BOOST_CHECK( ( Transactions{tx0, tx1, tx2, tx3, tx4} ) == txq.topTransactions( 256 ) );
 
     txq.setFuture( tx2.sha3() );
@@ -200,7 +213,7 @@ BOOST_AUTO_TEST_CASE( tqFuture ) {
 
     // TODO disabled it temporarily!!
     //    Transaction tx2_2( 1, gasCostMed, gas, dest, bytes(), 2, sender );
-    //    txq.import( tx2_2 );
+    //    importCurrent( txq, tx2_2 );
     //    BOOST_CHECK( ( Transactions{tx0, tx1, tx2_2, tx3, tx4} ) == txq.topTransactions( 256 ) );
     //    // no replacement
 }
@@ -220,12 +233,12 @@ BOOST_AUTO_TEST_CASE( tqLimits ) {
     Transaction tx4( 0, gasCostMed, gas, dest, bytes(), 4, sender );
     Transaction tx5( 0, gasCostMed + 1, gas, dest, bytes(), 0, sender2 );
 
-    BOOST_REQUIRE( txq.import( tx0 ) == ImportResult::Success );
-    BOOST_REQUIRE( txq.import( tx1 ) == ImportResult::Success );
-    BOOST_REQUIRE( txq.import( tx2 ) == ImportResult::Success );
-    BOOST_REQUIRE( txq.import( tx3 ) == ImportResult::QueueIsFull );
-    BOOST_REQUIRE( txq.import( tx4 ) == ImportResult::QueueIsFull );
-    BOOST_REQUIRE( txq.import( tx5 ) == ImportResult::QueueIsFull );
+    BOOST_REQUIRE( importCurrent( txq, tx0 ) == ImportResult::Success );
+    BOOST_REQUIRE( importCurrent( txq, tx1 ) == ImportResult::Success );
+    BOOST_REQUIRE( importCurrent( txq, tx2 ) == ImportResult::Success );
+    BOOST_REQUIRE( importCurrent( txq, tx3 ) == ImportResult::QueueIsFull );
+    BOOST_REQUIRE( importCurrent( txq, tx4 ) == ImportResult::QueueIsFull );
+    BOOST_REQUIRE( importCurrent( txq, tx5 ) == ImportResult::QueueIsFull );
     BOOST_CHECK( ( Transactions{tx0, tx1, tx2} ) == txq.topTransactions( 256 ) );
 }
 
@@ -261,17 +274,17 @@ BOOST_AUTO_TEST_CASE( tqImport ) {
     h256Hash known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 0 );
     
-    ImportResult ir = tq.import( testTransaction.transaction().toBytes() );
+    ImportResult ir = importCurrent( tq, testTransaction.transaction().toBytes() );
     BOOST_REQUIRE( ir == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 1 );
     
-    ir = tq.import( testTransaction.transaction().toBytes() );
+    ir = importCurrent( tq, testTransaction.transaction().toBytes() );
     BOOST_REQUIRE( ir == ImportResult::AlreadyKnown );
     
     bytes rlp = testTransaction.transaction().toBytes();
     rlp.at( 0 ) = 03;
-    ir = tq.import( rlp );
+    ir = tq.import( rlp, IfDropped::Ignore, false, 0 );
     BOOST_REQUIRE( ir == ImportResult::Malformed );
 
     known = tq.knownTransactions();
@@ -281,13 +294,13 @@ BOOST_AUTO_TEST_CASE( tqImport ) {
     TestTransaction testTransaction3 = TestTransaction::defaultTransaction( 1, 1 );
     TestTransaction testTransaction4 = TestTransaction::defaultTransaction( 1, 4 );
     
-    ir = tq.import( testTransaction2.transaction().toBytes() );
+    ir = importCurrent( tq, testTransaction2.transaction().toBytes() );
     BOOST_REQUIRE( ir == ImportResult::SameNonceAlreadyInQueue );
     
-    ir = tq.import( testTransaction3.transaction().toBytes() );
+    ir = importCurrent( tq, testTransaction3.transaction().toBytes() );
     BOOST_REQUIRE( ir == ImportResult::AlreadyKnown );
     
-    ir = tq.import( testTransaction4.transaction().toBytes() );
+    ir = importCurrent( tq, testTransaction4.transaction().toBytes() );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 1 );
     Transactions ts = tq.topTransactions( 4 );
@@ -316,7 +329,7 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     u256 waiting = tq.waiting(sender);
     BOOST_REQUIRE( waiting == 0 );
     
-    ImportResult ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true );
+    ImportResult ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir1 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 1 );
@@ -327,8 +340,8 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     waiting = tq.waiting(sender);
     BOOST_REQUIRE( waiting == 1 );
 
-    // HACK it's now allowed to repeat future transaction (can put it to current)
-    ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true );
+    // HACK it's now allowed to repeat future transaction
+    ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir1 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 1 );
@@ -341,11 +354,11 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     
     bytes rlp = tx1.transaction().toBytes();
     rlp.at( 0 ) = 03;
-    ir1 = tq.import( rlp, IfDropped::Ignore, true );
+    ir1 = tq.import( rlp, IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir1 == ImportResult::Malformed );
 
     TestTransaction tx2 = TestTransaction::defaultTransaction(2);
-    ImportResult ir2 = tq.import( tx2.transaction().toBytes(), IfDropped::Ignore, true );
+    ImportResult ir2 = tq.import( tx2.transaction().toBytes(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir2 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 2 );
@@ -356,7 +369,7 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     BOOST_CHECK( ( Transactions{} ) == tq.topTransactions( 256 ) );
 
     TestTransaction tx3 = TestTransaction::defaultTransaction(1);
-    ImportResult ir3 = tq.import( tx3.transaction().toBytes(), IfDropped::Ignore, true );
+    ImportResult ir3 = tq.import( tx3.transaction().toBytes(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir3 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 3 );
@@ -367,7 +380,7 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     BOOST_CHECK( ( Transactions{} ) == tq.topTransactions( 256 ) );
 
     TestTransaction tx4 = TestTransaction::defaultTransaction(0);
-    ImportResult ir4 = tq.import( tx4.transaction().toBytes(), IfDropped::Ignore );
+    ImportResult ir4 = importCurrent( tq, tx4.transaction().toBytes() );
     BOOST_REQUIRE( ir4 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 4 );
@@ -381,7 +394,7 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     BOOST_CHECK( ( Transactions{ tx4.transaction(), tx3.transaction(), tx2.transaction() } ) == tq.topTransactions( 256 ) );
 
     TestTransaction tx5 = TestTransaction::defaultTransaction(3);
-    ImportResult ir5 = tq.import( tx5.transaction().toBytes(), IfDropped::Ignore );
+    ImportResult ir5 = importCurrent( tq, tx5.transaction().toBytes() );
     BOOST_REQUIRE( ir5 == ImportResult::Success );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 5 );
@@ -399,7 +412,7 @@ BOOST_AUTO_TEST_CASE( tqImportFuture ) {
     Address dest = Address( "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" );
     Secret sender2 = Secret( "0x4444444444444444444444444444444444444444444444444444444444444444" );
     Transaction tx0( 0, gasCostMed, gas, dest, bytes(), 4, sender2 );
-    ImportResult ir0 = tq.import( tx0, IfDropped::Ignore, true );
+    ImportResult ir0 = tq.import( tx0, IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir0 == ImportResult::Success );
     waiting = tq.waiting(dev::toAddress(sender2));
     BOOST_REQUIRE( waiting == 1 );
@@ -413,13 +426,13 @@ BOOST_AUTO_TEST_CASE( dropFromFutureToCurrent ) {
     TestTransaction tx1 = TestTransaction::defaultTransaction(1);
 
     // put transaction to future
-    ImportResult ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true );
+    ImportResult ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir1 == ImportResult::Success );
     TransactionQueue::Status status = tq.status();
     BOOST_REQUIRE( status.current == 0 && status.future == 1 );
 
     // push it to current and see it fall back from future to current
-    ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, false );
+    ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, false, 1 );
     BOOST_REQUIRE( ir1 == ImportResult::Success );
     status = tq.status();
     BOOST_REQUIRE( status.current == 1 && status.future == 0 );
@@ -428,10 +441,10 @@ BOOST_AUTO_TEST_CASE( dropFromFutureToCurrent ) {
 BOOST_AUTO_TEST_CASE( tqImportFutureLimits ) {
     dev::eth::TransactionQueue tq( 1024, 2 );
     TestTransaction tx1 = TestTransaction::defaultTransaction(3);
-    tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true );
+    tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true, 0 );
 
     TestTransaction tx2 = TestTransaction::defaultTransaction(2);
-    tq.import( tx2.transaction().toBytes(), IfDropped::Ignore, true );
+    tq.import( tx2.transaction().toBytes(), IfDropped::Ignore, true, 0 );
 
     auto waiting = tq.waiting(tx1.transaction().sender());
     BOOST_REQUIRE( waiting == 2 );
@@ -439,7 +452,7 @@ BOOST_AUTO_TEST_CASE( tqImportFutureLimits ) {
     BOOST_REQUIRE( known.size() == 2 );
 
     TestTransaction tx3 = TestTransaction::defaultTransaction(1);
-    ImportResult ir = tq.import( tx3.transaction().toBytes(), IfDropped::Ignore, true );
+    ImportResult ir = tq.import( tx3.transaction().toBytes(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir == ImportResult::Success );
 
     waiting = tq.waiting(tx1.transaction().sender());
@@ -453,7 +466,7 @@ BOOST_AUTO_TEST_CASE( tqImportFutureLimits2 ) {
     dev::eth::TransactionQueue tq( 1024, 2 );
 
     TestTransaction tx1 = TestTransaction::defaultTransaction(3);
-    tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true );
+    tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, true, 0 );
 
     auto waiting = tq.waiting(tx1.transaction().sender());
     BOOST_REQUIRE( waiting == 1 );
@@ -467,7 +480,7 @@ BOOST_AUTO_TEST_CASE( tqImportFutureLimits2 ) {
     Address dest = Address( "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" );
     Secret sender2 = Secret( "0x1111111111111111111111111111111111111111111111111111111111111111" );
     Transaction tx0( 0, gasCostMed, gas, dest, bytes(), 4, sender2 );
-    ImportResult ir0 = tq.import( tx0, IfDropped::Ignore, true );
+    ImportResult ir0 = tq.import( tx0, IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( ir0 == ImportResult::Success );
 
     waiting = tq.waiting(tx1.transaction().sender());
@@ -480,7 +493,7 @@ BOOST_AUTO_TEST_CASE( tqImportFutureLimits2 ) {
     BOOST_REQUIRE( status.future == 2 );  
 
     TestTransaction tx2 = TestTransaction::defaultTransaction(2);
-    tq.import( tx2.transaction().toBytes(), IfDropped::Ignore, true );
+    tq.import( tx2.transaction().toBytes(), IfDropped::Ignore, true, 0 );
 
     waiting = tq.waiting(tx1.transaction().sender());
     BOOST_REQUIRE( waiting == 1 );
@@ -498,7 +511,7 @@ BOOST_AUTO_TEST_CASE( tqDrop ) {
     TransactionQueue tq;
     TestTransaction testTransaction = TestTransaction::defaultTransaction();
     tq.dropGood( testTransaction.transaction() );
-    tq.import( testTransaction.transaction().toBytes() );
+    importCurrent( tq, testTransaction.transaction().toBytes() );
     BOOST_REQUIRE( tq.topTransactions( 4 ).size() == 1 );
     tq.dropGood( testTransaction.transaction() );
     BOOST_REQUIRE( tq.topTransactions( 4 ).size() == 0 );
@@ -509,7 +522,7 @@ BOOST_AUTO_TEST_CASE( tqLimit ) {
     Address from;
     for ( size_t i = 1; i < 7; i++ ) {
         TestTransaction testTransaction = TestTransaction::defaultTransaction( i );
-        ImportResult res = tq.import( testTransaction.transaction() );
+        ImportResult res = importCurrent( tq, testTransaction.transaction() );
         from = testTransaction.transaction().from();
         if ( i <= 5 )
             BOOST_REQUIRE( res == ImportResult::Success );
@@ -533,7 +546,7 @@ BOOST_AUTO_TEST_CASE( tqLimit ) {
     BOOST_REQUIRE( tq.waiting( from ) == 3 );
 
     // Drop out of bound feauture
-    ImportResult res = tq.import( testTransaction.transaction() );
+    ImportResult res = importCurrent( tq, testTransaction.transaction() );
     BOOST_REQUIRE( res == ImportResult::Success );
 
     // future list size is now 3  + 1 imported transaction
@@ -549,11 +562,11 @@ BOOST_AUTO_TEST_CASE( tqLimitBytes ) {
     unsigned maxTxCount = 250 / TestTransaction::defaultTransaction( 1 ).transaction().toBytes().size();
 
     TestTransaction testTransaction = TestTransaction::defaultTransaction( 2 );
-    ImportResult res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true );
+    ImportResult res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( res == ImportResult::Success );
 
     testTransaction = TestTransaction::defaultTransaction( 3 );
-    res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true );
+    res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( res == ImportResult::Success );
 
     BOOST_REQUIRE( tq.status().current == 0 );
@@ -561,7 +574,7 @@ BOOST_AUTO_TEST_CASE( tqLimitBytes ) {
     BOOST_REQUIRE( tq.status().future == maxTxCount );
 
     testTransaction = TestTransaction::defaultTransaction( 4 );
-    res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true );
+    res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true, 0 );
     BOOST_REQUIRE( res == ImportResult::Success );
 
     BOOST_REQUIRE( tq.status().current == 0 );
@@ -572,7 +585,7 @@ BOOST_AUTO_TEST_CASE( tqLimitBytes ) {
         if (i == 2 || i == 3)
             continue;
         testTransaction = TestTransaction::defaultTransaction( i );
-        res = tq.import( testTransaction.transaction() );
+        res = importCurrent( tq, testTransaction.transaction() );
         BOOST_REQUIRE( res == ImportResult::Success || res == ImportResult::QueueIsFull );
     }
 

--- a/test/unittests/libethereum/TransactionQueue.cpp
+++ b/test/unittests/libethereum/TransactionQueue.cpp
@@ -268,6 +268,101 @@ BOOST_AUTO_TEST_CASE( tqCurrentFullDoesNotFallBackToFuture ) {
     BOOST_CHECK( ( Transactions{tx0} ) == tq.topTransactions( 256 ) );
 }
 
+BOOST_AUTO_TEST_CASE( tqCurrentGapCanBeFilled ) {
+    dev::eth::TransactionQueue tq;
+
+    const u256 gasCostMed = 20 * szabo;
+    const u256 gas = 25000;
+    Address dest = Address( "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" );
+    Secret sender = Secret( "0x3333333333333333333333333333333333333333333333333333333333333333" );
+    Transaction tx0( 0, gasCostMed, gas, dest, bytes(), 0, sender );
+    Transaction tx1( 0, gasCostMed, gas, dest, bytes(), 1, sender );
+    Transaction tx2( 0, gasCostMed, gas, dest, bytes(), 2, sender );
+    Transaction tx3( 0, gasCostMed, gas, dest, bytes(), 3, sender );
+
+    BOOST_REQUIRE( tq.import( tx0, IfDropped::Ignore, false, 0 ) == ImportResult::Success );
+    BOOST_REQUIRE( tq.import( tx1, IfDropped::Ignore, false, 0 ) == ImportResult::Success );
+    BOOST_REQUIRE( tq.import( tx3, IfDropped::Ignore, false, 3 ) == ImportResult::Success );
+
+    BOOST_REQUIRE( tq.import( tx2, IfDropped::Ignore, false, 0 ) == ImportResult::Success );
+    BOOST_REQUIRE( tq.status().current == 4 );
+    BOOST_REQUIRE( tq.status().future == 0 );
+    BOOST_CHECK( ( Transactions{tx0, tx1, tx2, tx3} ) == tq.topTransactions( 256 ) );
+}
+
+BOOST_AUTO_TEST_CASE( tqBlockedFuturePromotionRetriesWhenCapacityFrees ) {
+    dev::eth::TransactionQueue tq( 1, 3 );
+
+    const u256 gasCostMed = 20 * szabo;
+    const u256 gas = 25000;
+    Address dest = Address( "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" );
+    Secret sender1 = Secret( "0x3333333333333333333333333333333333333333333333333333333333333333" );
+    Secret sender2 = Secret( "0x4444444444444444444444444444444444444444444444444444444444444444" );
+    Transaction a0( 0, gasCostMed, gas, dest, bytes(), 0, sender1 );
+    Transaction a1( 0, gasCostMed, gas, dest, bytes(), 1, sender1 );
+    Transaction b0( 0, gasCostMed, gas, dest, bytes(), 0, sender2 );
+
+    BOOST_REQUIRE( tq.import( b0, IfDropped::Ignore, true, 0 ) == ImportResult::Success );
+    BOOST_REQUIRE( tq.import( a1, IfDropped::Ignore, true, 0 ) == ImportResult::Success );
+
+    tq.dropGood( a0 );
+    BOOST_REQUIRE( tq.status().current == 1 );
+    BOOST_REQUIRE( tq.status().future == 1 );
+    BOOST_CHECK( ( Transactions{b0} ) == tq.topTransactions( 256 ) );
+
+    tq.drop( b0.sha3() );
+    BOOST_REQUIRE( tq.status().current == 1 );
+    BOOST_REQUIRE( tq.status().future == 0 );
+    BOOST_CHECK( ( Transactions{a1} ) == tq.topTransactions( 256 ) );
+}
+
+BOOST_AUTO_TEST_CASE( tqBlockedFuturePromotionInvalidatesWhenPredecessorDrops ) {
+    dev::eth::TransactionQueue tq( 1, 3 );
+
+    const u256 gasCostMed = 20 * szabo;
+    const u256 gas = 25000;
+    Address dest = Address( "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" );
+    Secret sender = Secret( "0x3333333333333333333333333333333333333333333333333333333333333333" );
+    Transaction tx0( 0, gasCostMed, gas, dest, bytes(), 0, sender );
+    Transaction tx1( 0, gasCostMed, gas, dest, bytes(), 1, sender );
+
+    BOOST_REQUIRE( tq.import( tx1, IfDropped::Ignore, true, 0 ) == ImportResult::Success );
+    BOOST_REQUIRE( tq.import( tx0, IfDropped::Ignore, false, 0 ) == ImportResult::Success );
+    BOOST_REQUIRE( tq.status().current == 1 );
+    BOOST_REQUIRE( tq.status().future == 1 );
+
+    tq.drop( tx0.sha3() );
+    BOOST_REQUIRE( tq.status().current == 0 );
+    BOOST_REQUIRE( tq.status().future == 1 );
+    BOOST_CHECK( tq.topTransactions( 256 ).empty() );
+}
+
+BOOST_AUTO_TEST_CASE( tqDropGoodRemovesBlockedFutureTransaction ) {
+    dev::eth::TransactionQueue tq( 1, 3 );
+
+    const u256 gasCostMed = 20 * szabo;
+    const u256 gas = 25000;
+    Address dest = Address( "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" );
+    Secret sender1 = Secret( "0x3333333333333333333333333333333333333333333333333333333333333333" );
+    Secret sender2 = Secret( "0x4444444444444444444444444444444444444444444444444444444444444444" );
+    Transaction a1( 0, gasCostMed, gas, dest, bytes(), 1, sender1 );
+    Transaction b0( 0, gasCostMed, gas, dest, bytes(), 0, sender2 );
+
+    BOOST_REQUIRE( tq.import( b0, IfDropped::Ignore, true, 0 ) == ImportResult::Success );
+    BOOST_REQUIRE( tq.import( a1, IfDropped::Ignore, true, 0 ) == ImportResult::Success );
+    BOOST_REQUIRE( tq.import( a1, IfDropped::Ignore, false, 1 ) == ImportResult::QueueIsFull );
+
+    tq.dropGood( a1 );
+    BOOST_REQUIRE( tq.status().current == 1 );
+    BOOST_REQUIRE( tq.status().future == 0 );
+    BOOST_CHECK( ( Transactions{b0} ) == tq.topTransactions( 256 ) );
+
+    tq.drop( b0.sha3() );
+    BOOST_REQUIRE( tq.status().current == 0 );
+    BOOST_REQUIRE( tq.status().future == 0 );
+    BOOST_CHECK( tq.topTransactions( 256 ).empty() );
+}
+
 BOOST_AUTO_TEST_CASE( tqImport ) {
     TestTransaction testTransaction = TestTransaction::defaultTransaction();
     TransactionQueue tq;
@@ -431,6 +526,12 @@ BOOST_AUTO_TEST_CASE( dropFromFutureToCurrent ) {
     TransactionQueue::Status status = tq.status();
     BOOST_REQUIRE( status.current == 0 && status.future == 1 );
 
+    // Re-importing while it is still future should not remove it from FTQ.
+    ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, false, 0 );
+    BOOST_REQUIRE( ir1 == ImportResult::Success );
+    status = tq.status();
+    BOOST_REQUIRE( status.current == 0 && status.future == 1 );
+
     // push it to current and see it fall back from future to current
     ir1 = tq.import( tx1.transaction().toBytes(), IfDropped::Ignore, false, 1 );
     BOOST_REQUIRE( ir1 == ImportResult::Success );
@@ -453,13 +554,13 @@ BOOST_AUTO_TEST_CASE( tqImportFutureLimits ) {
 
     TestTransaction tx3 = TestTransaction::defaultTransaction(1);
     ImportResult ir = tq.import( tx3.transaction().toBytes(), IfDropped::Ignore, true, 0 );
-    BOOST_REQUIRE( ir == ImportResult::Success );
+    BOOST_REQUIRE( ir == ImportResult::QueueIsFull );
 
     waiting = tq.waiting(tx1.transaction().sender());
     BOOST_REQUIRE( waiting == 2 );
     known = tq.knownTransactions();
     BOOST_REQUIRE( known.size() == 2 );
-    BOOST_CHECK( ( h256Hash{ tx3.transaction().sha3(), tx2.transaction().sha3() } ) == known );
+    BOOST_CHECK( ( h256Hash{ tx1.transaction().sha3(), tx2.transaction().sha3() } ) == known );
 }
 
 BOOST_AUTO_TEST_CASE( tqImportFutureLimits2 ) {
@@ -493,7 +594,8 @@ BOOST_AUTO_TEST_CASE( tqImportFutureLimits2 ) {
     BOOST_REQUIRE( status.future == 2 );  
 
     TestTransaction tx2 = TestTransaction::defaultTransaction(2);
-    tq.import( tx2.transaction().toBytes(), IfDropped::Ignore, true, 0 );
+    ImportResult ir2 = tq.import( tx2.transaction().toBytes(), IfDropped::Ignore, true, 0 );
+    BOOST_REQUIRE( ir2 == ImportResult::QueueIsFull );
 
     waiting = tq.waiting(tx1.transaction().sender());
     BOOST_REQUIRE( waiting == 1 );
@@ -504,7 +606,7 @@ BOOST_AUTO_TEST_CASE( tqImportFutureLimits2 ) {
     status = tq.status();
     BOOST_REQUIRE( status.future == 2 );  
  
-    BOOST_CHECK( ( h256Hash{ tx0.sha3(), tx2.transaction().sha3() } ) == known );
+    BOOST_CHECK( ( h256Hash{ tx0.sha3(), tx1.transaction().sha3() } ) == known );
 }
 
 BOOST_AUTO_TEST_CASE( tqDrop ) {
@@ -575,7 +677,7 @@ BOOST_AUTO_TEST_CASE( tqLimitBytes ) {
 
     testTransaction = TestTransaction::defaultTransaction( 4 );
     res = tq.import( testTransaction.transaction(), IfDropped::Ignore, true, 0 );
-    BOOST_REQUIRE( res == ImportResult::Success );
+    BOOST_REQUIRE( res == ImportResult::QueueIsFull );
 
     BOOST_REQUIRE( tq.status().current == 0 );
 

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -8183,10 +8183,16 @@ BOOST_AUTO_TEST_CASE( skip_invalid_transactions ) {
     pair< bool, Secret > ar4 = fixture.accountHolder->authenticate( ts4 );
     Transaction tx4( ts3, ar3.second );
 
+    // pause consensus to make sure all txs are imported at once, and 
+    // will all be placed in the same block
+    fixture.client->skaleHost()->pauseConsensus( true );
+
     h256 h4 = fixture.client->importTransaction( tx4 );  // ok
     h256 h2 = fixture.client->importTransaction( tx2 );  // invalid
     h256 h3 = fixture.client->importTransaction( tx3 );  // ok
     h256 h1 = fixture.client->importTransaction( tx1 );  // ok
+
+    fixture.client->skaleHost()->pauseConsensus( false );
 
     dev::eth::mineTransaction( *( fixture.client ), 1 );
     cout << "Balance3: "


### PR DESCRIPTION
# Description

This PR fixes a transaction queue issue where a transaction could be silently dropped when the current transaction queue (CTQ) was full. See #1621.

## Problem

In `v5.1.0`, CTQ admission was not explicit.

When a new transaction was imported, the queue inserted it into CTQ and then trimmed the queue if the configured CTQ limit was exceeded:

```text
insert transaction into CTQ
if CTQ is over limit:
    remove lowest-priority transaction
return Success
```

That meant the caller could receive `Success` even though either:

- the newly submitted transaction was not actually retained, or
- another pending transaction was evicted as a side effect.

The client/RPC layer had no reliable way to know that queue capacity caused a transaction to be dropped.

This was especially problematic because CTQ is the queue used for transactions that are executable now. Silently evicting from CTQ changes local pending state without surfacing a rejection to the transaction submitter.

## New Behavior

Queue admission is now explicit.

A transaction is routed based on its nonce and the current chain state:

```text
nonce-compatible:
    try CTQ

future nonce:
    try FTQ only if future queueing is allowed

old nonce:
    reject as already in chain
```

### CTQ

CTQ accepts only transactions whose nonce is currently executable or contiguous with already queued current transactions for the same sender.

If CTQ does not have capacity, the transaction is rejected immediately:

```text
CTQ full -> QueueIsFull
```

The transaction is not inserted and no existing CTQ transaction is evicted to make room.

There is intentionally no fallback from CTQ to FTQ for a CTQ-eligible transaction. FTQ is for future-nonce transactions, not overflow storage for current transactions.

As a result, this is valid behavior:

```text
CTQ full
FTQ has free space
tx is CTQ-eligible

result: QueueIsFull
```

### FTQ

FTQ accepts transactions whose nonce is greater than the next expected nonce, but only when future queueing is enabled.

If future queueing is disabled, or FTQ is at capacity, the transaction is rejected with `QueueIsFull`.

## Client / RPC Impact

`QueueIsFull` is now propagated to the caller instead of being hidden behind `Success`.

On the client side, `QueueIsFull` is converted into a `TransactionQueueIsFull` exception. The RPC layer can then return a clear error to the submitter instead of silently accepting a transaction that was not retained.

## Related Queue Semantics

This change makes the distinction between CTQ and FTQ stricter:

```text
CTQ:
    current, nonce-compatible transactions

FTQ:
    future-nonce transactions
```

However, CTQ capacity introduces one important edge case: a transaction may be nonce-compatible but still remain in FTQ if promotion from FTQ to CTQ was blocked by CTQ capacity.

This is because a tx in FTQ was already accepted, and client informed of its acceptance - meaning we should not drop this tx. Instead, we keep it in FTQ until CTQ has space for it to keep the **new invariant** that **if a tx is accepted, then it will eventually be executed**.

For example:

```text
CTQ is full
sender A has nonce 0 already consumed
sender A nonce 1 exists in FTQ
promotion of nonce 1 is blocked by CTQ capacity
```

That transaction is not logically a “future nonce” anymore, but it is still physically stored in FTQ until CTQ capacity opens.

Because of this, queue cleanup must handle consumed transactions in both CTQ and FTQ.

## Block Import Follow-up

Before this PR, `dropGood()` was called while parsing block payload transactions. That was safe only while `dropGood()` did not remove regular transactions from FTQ.

After CTQ capacity changes, `dropGood()` must be able to remove from FTQ, because a consumed transaction may be physically stored there due to blocked CTQ promotion.

That exposed a corner case:

```text
state nonce for A = 0
block payload contains tx A nonce 1 (stored in FTQ)
local execution returns WouldNotBeInBlock
```

In that case, the transaction appeared in the block payload but was not actually consumed. It must remain pending.

So block-import cleanup was adjusted:

```text
Do not remove a transaction merely because it appeared in a block payload.
Remove it only after execution/recovery determines it was consumed.
```

This preserves future-nonce transactions while still removing CTQ-capacity-blocked transactions from FTQ when they are genuinely consumed by a block.

## BITE2 / CTX Validation

Moving queue cleanup out of block parsing also affected BITE2 CTXs.

Previously, CTX parsing called `dropGood(ctx)`, and `BITE2TransactionQueue::dropGood()` implicitly validated that the CTX matched the front of the local BITE2 queue.

After cleanup moved to the consumed-transaction path, that validation needed to be explicit.

This PR adds a non-mutating validation step:

```cpp
validateNextExpectedBITE2CTXsAndGetOrigins(...)
```

It verifies that CTXs in the proposed block match the next expected pending BITE2 CTXs in FIFO order and returns their origins from the same queue snapshot.

This keeps the old safety property without mutating the queue during parsing.


## Summary

The main behavior change is explicit CTQ/FTQ admission.

```text
Before:
    CTQ could exceed capacity, evict internally, and still return Success.

After:
    CTQ capacity is checked before insertion.
    If CTQ is full, insertion fails with QueueIsFull.
    No transaction is silently evicted.
```

The queue now routes transactions more explicitly:

```text
CTQ:
    nonce-compatible transactions that can be proposed now.
    If CTQ is full, insertion fails with QueueIsFull.

FTQ:
    future-nonce transactions, when future queueing is allowed.
    If FTQ is disabled or full, insertion fails with QueueIsFull.
```

This PR intentionally keeps the existing two-queue model. A transaction that becomes nonce-compatible while CTQ is full can still remain physically stored in FTQ, with blocked promotion tracked separately. A dedicated blocked-current queue could make that distinction more explicit in the future, but queue changes were kept minimal here because broader transaction-queue refactoring is planned separately.

Block-import cleanup was also tightened. The node no longer removes transactions from the queue merely because they appear in a block payload that is about to be executed. Instead, queue cleanup happens only after execution or recovery determines that the transaction was actually consumed.

```text
Before:
    tx appears in proposed block payload
    -> remove from queue during parsing

After:
    tx is executed/recovered and determined consumed
    -> remove from queue
```

Fixes #1621