### PR TITLE
improve skaled custom, build, and publish workflows

### DIFF
--- a/.github/workflows/custom_build.yml
+++ b/.github/workflows/custom_build.yml
@@ -15,8 +15,8 @@ on:
         description: 'Additional cmake options'
         default: ''
         required: false
-      build_type:
-        description: 'Build type of skaled binary'
+      cmake_build_type:
+        description: 'CMake build type'
         type: choice
         required: true
         options: 
@@ -28,35 +28,48 @@ on:
         description: 'Node type'
         type: choice
         options: 
-          - Core
-          - Core+Historic
-          - Historic
+          - core
+          - core+historic
+          - historic
         required: false
-        default: Core
+        default: core
+      protocol_profile:
+        description: 'Protocol profile'
+        type: choice
+        options: 
+          - core
+          - bite
+          - fair
+        required: false
+        default: core
 
 jobs:
   core_build:
-    if: github.event.inputs.node_type != 'Historic'
+    if: github.event.inputs.node_type != 'historic'
     uses: ./.github/workflows/setup-build-publish.yml
     with:
       image_version: ${{ github.event.inputs.image_version }}
       branch_name: ${{ github.event.inputs.branch_name }}
       cmake_options: ${{ github.event.inputs.cmake_options }}
-      build_type: ${{ github.event.inputs.build_type }}
+      cmake_build_type: ${{ github.event.inputs.cmake_build_type }}
+      protocol_profile: ${{ github.event.inputs.protocol_profile }}
       node_type: core
+      version_suffix_mode: cmake_build_type_protocol_profile_and_node_type
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
   historic_build:
-    if: github.event.inputs.node_type != 'Core'
+    if: github.event.inputs.node_type != 'core'
     uses: ./.github/workflows/setup-build-publish.yml
     with:
       image_version: ${{ github.event.inputs.image_version }}
       branch_name: ${{ github.event.inputs.branch_name }}
       cmake_options: ${{ github.event.inputs.cmake_options }}
-      build_type: ${{ github.event.inputs.build_type }}
+      cmake_build_type: ${{ github.event.inputs.cmake_build_type }}
+      protocol_profile: ${{ github.event.inputs.protocol_profile }}
       node_type: historic
+      version_suffix_mode: cmake_build_type_protocol_profile_and_node_type
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/custom_build.yml
+++ b/.github/workflows/custom_build.yml
@@ -54,7 +54,7 @@ jobs:
       cmake_build_type: ${{ github.event.inputs.cmake_build_type }}
       protocol_profile: ${{ github.event.inputs.protocol_profile }}
       node_type: core
-      version_suffix_mode: cmake_build_type_protocol_profile_and_node_type
+      version_suffix_mode: cmake_protocol_node
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -69,7 +69,7 @@ jobs:
       cmake_build_type: ${{ github.event.inputs.cmake_build_type }}
       protocol_profile: ${{ github.event.inputs.protocol_profile }}
       node_type: historic
-      version_suffix_mode: cmake_build_type_protocol_profile_and_node_type
+      version_suffix_mode: cmake_protocol_node
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version_orig: ${{ steps.set-version.outputs.version_orig }}
-      version_historic: ${{ steps.set-version.outputs.version_historic }}
-      version_fair: ${{ steps.set-version.outputs.version_fair }}
-      version_fair_historic: ${{ steps.set-version.outputs.version_fair_historic }}
-      version_bite: ${{ steps.set-version.outputs.version_bite }}
-      version_bite_historic: ${{ steps.set-version.outputs.version_bite_historic }}
       release_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Checkout repository
@@ -39,17 +34,9 @@ jobs:
           echo "Calculated version: $VERSION"
 
           ( test "$BRANCH_NAME" = "stable" && export PRERELEASE=false ) || export PRERELEASE=true
-          echo "VERSION_ORIG=$VERSION" >> $GITHUB_ENV
-          echo "VERSION_HISTORIC=$VERSION-historic" >> $GITHUB_ENV
-          echo "VERSION_FAIR=$VERSION-fair" >> $GITHUB_ENV
           echo "PRERELEASE=$PRERELEASE" >> $GITHUB_ENV
 
           echo "::set-output name=version_orig::$VERSION"
-          echo "::set-output name=version_historic::$VERSION-historic"
-          echo "::set-output name=version_fair::$VERSION-fair"
-          echo "::set-output name=version_fair_historic::$VERSION-fair-historic"
-          echo "::set-output name=version_bite::$VERSION-bite"
-          echo "::set-output name=version_bite_historic::$VERSION-bite-historic"
           
       - name: Create GitHub Release
         id: create_release
@@ -68,10 +55,11 @@ jobs:
     with:
       branch_name: ${{ github.ref_name }}
       image_version: ${{ needs.configure.outputs.version_orig }}
-      build_type: "RelWithDebInfo"
+      cmake_build_type: "RelWithDebInfo"
+      protocol_profile: core
       node_type: core
       release_url: ${{ needs.configure.outputs.release_url }}
-      use_plain_version: true
+      version_suffix_mode: protocol_profile_and_node_type
     secrets: inherit
 
   build-historic:
@@ -79,11 +67,12 @@ jobs:
     uses: ./.github/workflows/setup-build-publish.yml
     with:
       branch_name: ${{ github.ref_name }}
-      image_version: ${{ needs.configure.outputs.version_historic }}
-      build_type: "RelWithDebInfo"
+      image_version: ${{ needs.configure.outputs.version_orig }}
+      cmake_build_type: "RelWithDebInfo"
+      protocol_profile: core
       node_type: historic
       release_url: ${{ needs.configure.outputs.release_url }}
-      use_plain_version: true
+      version_suffix_mode: protocol_profile_and_node_type
     secrets: inherit
   
   build-fair:
@@ -91,11 +80,12 @@ jobs:
     uses: ./.github/workflows/setup-build-publish.yml
     with:
       branch_name: ${{ github.ref_name }}
-      image_version: ${{ needs.configure.outputs.version_fair }}
-      build_type: "RelWithDebInfo"
-      node_type: fair
+      image_version: ${{ needs.configure.outputs.version_orig }}
+      cmake_build_type: "RelWithDebInfo"
+      protocol_profile: fair
+      node_type: core
       release_url: ${{ needs.configure.outputs.release_url }}
-      use_plain_version: true
+      version_suffix_mode: protocol_profile_and_node_type
     secrets: inherit
   
   build-fair-historic:
@@ -103,11 +93,12 @@ jobs:
     uses: ./.github/workflows/setup-build-publish.yml
     with:
       branch_name: ${{ github.ref_name }}
-      image_version: ${{ needs.configure.outputs.version_fair_historic }}
-      build_type: "RelWithDebInfo"
-      node_type: fair-historic
+      image_version: ${{ needs.configure.outputs.version_orig }}
+      cmake_build_type: "RelWithDebInfo"
+      protocol_profile: fair
+      node_type: historic
       release_url: ${{ needs.configure.outputs.release_url }}
-      use_plain_version: true
+      version_suffix_mode: protocol_profile_and_node_type
     secrets: inherit
   
   build-bite:
@@ -115,11 +106,12 @@ jobs:
     uses: ./.github/workflows/setup-build-publish.yml
     with:
       branch_name: ${{ github.ref_name }}
-      image_version: ${{ needs.configure.outputs.version_bite }}
-      build_type: "RelWithDebInfo"
-      node_type: bite
+      image_version: ${{ needs.configure.outputs.version_orig }}
+      cmake_build_type: "RelWithDebInfo"
+      protocol_profile: bite
+      node_type: core
       release_url: ${{ needs.configure.outputs.release_url }}
-      use_plain_version: true
+      version_suffix_mode: protocol_profile_and_node_type
     secrets: inherit
   
   build-bite-historic:
@@ -127,11 +119,12 @@ jobs:
     uses: ./.github/workflows/setup-build-publish.yml
     with:
       branch_name: ${{ github.ref_name }}
-      image_version: ${{ needs.configure.outputs.version_bite_historic }}
-      build_type: "RelWithDebInfo"
-      node_type: bite-historic
+      image_version: ${{ needs.configure.outputs.version_orig }}
+      cmake_build_type: "RelWithDebInfo"
+      protocol_profile: bite
+      node_type: historic
       release_url: ${{ needs.configure.outputs.release_url }}
-      use_plain_version: true
+      version_suffix_mode: protocol_profile_and_node_type
     secrets: inherit
   
   functional-tests:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           ( test "$BRANCH_NAME" = "stable" && export PRERELEASE=false ) || export PRERELEASE=true
           echo "PRERELEASE=$PRERELEASE" >> $GITHUB_ENV
 
-          echo "::set-output name=version_orig::$VERSION"
+          echo "version_orig=$VERSION" >> $GITHUB_OUTPUT
           
       - name: Create GitHub Release
         id: create_release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
       protocol_profile: core
       node_type: core
       release_url: ${{ needs.configure.outputs.release_url }}
-      version_suffix_mode: protocol_profile_and_node_type
+      version_suffix_mode: protocol_node
     secrets: inherit
 
   build-historic:
@@ -72,7 +72,7 @@ jobs:
       protocol_profile: core
       node_type: historic
       release_url: ${{ needs.configure.outputs.release_url }}
-      version_suffix_mode: protocol_profile_and_node_type
+      version_suffix_mode: protocol_node
     secrets: inherit
   
   build-fair:
@@ -85,7 +85,7 @@ jobs:
       protocol_profile: fair
       node_type: core
       release_url: ${{ needs.configure.outputs.release_url }}
-      version_suffix_mode: protocol_profile_and_node_type
+      version_suffix_mode: protocol_node
     secrets: inherit
   
   build-fair-historic:
@@ -98,7 +98,7 @@ jobs:
       protocol_profile: fair
       node_type: historic
       release_url: ${{ needs.configure.outputs.release_url }}
-      version_suffix_mode: protocol_profile_and_node_type
+      version_suffix_mode: protocol_node
     secrets: inherit
   
   build-bite:
@@ -111,7 +111,7 @@ jobs:
       protocol_profile: bite
       node_type: core
       release_url: ${{ needs.configure.outputs.release_url }}
-      version_suffix_mode: protocol_profile_and_node_type
+      version_suffix_mode: protocol_node
     secrets: inherit
   
   build-bite-historic:
@@ -124,7 +124,7 @@ jobs:
       protocol_profile: bite
       node_type: historic
       release_url: ${{ needs.configure.outputs.release_url }}
-      version_suffix_mode: protocol_profile_and_node_type
+      version_suffix_mode: protocol_node
     secrets: inherit
   
   functional-tests:

--- a/.github/workflows/setup-build-publish.yml
+++ b/.github/workflows/setup-build-publish.yml
@@ -14,9 +14,13 @@ on:
         type: string
         description: 'Additional cmake options'
         required: false
-      build_type:
+      cmake_build_type:
         type: string
-        description: 'Build type of skaled binary'
+        description: 'CMake build type of skaled binary'
+        required: true
+      protocol_profile:
+        type: string
+        description: 'Protocol profile of skaled build'
         required: true
       node_type:
         type: string
@@ -26,10 +30,10 @@ on:
         type: string
         description: 'URL of the GitHub release associated with this build (if applicable)'
         required: false
-      use_plain_version:
-        type: boolean
-        description: 'Use only the image version without appending the build type suffix'
-        default: false
+      version_suffix_mode:
+        type: string
+        description: 'Docker image version suffix mode: none, protocol_profile_and_node_type, or cmake_build_type_protocol_profile_and_node_type'
+        default: cmake_build_type_protocol_profile_and_node_type
     secrets:
       DOCKER_USERNAME:
         required: true
@@ -49,64 +53,78 @@ jobs:
       CC: gcc-11
       CXX: g++-11
       BRANCH: ${{ inputs.branch_name }}
-      BUILD_TYPE: ${{ inputs.build_type }}
+      CMAKE_BUILD_TYPE: ${{ inputs.cmake_build_type }}
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      PLAIN_VERSION: ${{ inputs.use_plain_version }}
+      VERSION_SUFFIX_MODE: ${{ inputs.version_suffix_mode }}
     steps:
+      - name: Prepare image version
+        run: |
+          if [[ "$CMAKE_BUILD_TYPE" = "Release" ]]; then
+            export CMAKE_BUILD_TYPE_SUFFIX=""
+          else
+            export CMAKE_BUILD_TYPE_SUFFIX="-$(echo "$CMAKE_BUILD_TYPE" | tr '[:upper:]' '[:lower:]')"
+          fi
+
+          case "${{ inputs.protocol_profile }}" in
+            core)
+              export PROTOCOL_PROFILE_SUFFIX=""
+              export BUILD_PROFILE="core"
+              ;;
+            bite)
+              export PROTOCOL_PROFILE_SUFFIX="-bite"
+              export BUILD_PROFILE="bite"
+              ;;
+            fair)
+              export PROTOCOL_PROFILE_SUFFIX="-fair"
+              export BUILD_PROFILE="fair"
+              ;;
+            *)
+              echo "Unsupported protocol_profile: ${{ inputs.protocol_profile }}"
+              exit 1
+              ;;
+          esac
+
+          case "${{ inputs.node_type }}" in
+            core)
+              export NODE_TYPE_SUFFIX=""
+              ;;
+            historic)
+              export NODE_TYPE_SUFFIX="-historic"
+              [[ "$BUILD_PROFILE" = "core" ]] && export BUILD_PROFILE="historic" || export BUILD_PROFILE="$BUILD_PROFILE-historic"
+              ;;
+            *)
+              echo "Unsupported node_type: ${{ inputs.node_type }}"
+              exit 1
+              ;;
+          esac
+
+          if [[ "$VERSION_SUFFIX_MODE" = "none" ]]; then
+            export VERSION=${{ inputs.image_version }}
+          elif [[ "$VERSION_SUFFIX_MODE" = "protocol_profile_and_node_type" ]]; then
+            export VERSION=${{ inputs.image_version }}$PROTOCOL_PROFILE_SUFFIX$NODE_TYPE_SUFFIX
+          elif [[ "$VERSION_SUFFIX_MODE" = "cmake_build_type_protocol_profile_and_node_type" ]]; then
+            export VERSION=${{ inputs.image_version }}$CMAKE_BUILD_TYPE_SUFFIX$PROTOCOL_PROFILE_SUFFIX$NODE_TYPE_SUFFIX
+          else
+            echo "Unsupported version_suffix_mode: $VERSION_SUFFIX_MODE"
+            exit 1
+          fi
+
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "BUILD_PROFILE=$BUILD_PROFILE" >> $GITHUB_ENV
+
       - name: Prepare workflow variables
-        if: inputs.node_type == 'core'
         run: |
-          export VERSION_SUFFIX=$(echo "$BUILD_TYPE" | tr '[:upper:]' '[:lower:]')
-          [[ $PLAIN_VERSION = "true" ]] && export VERSION=${{ inputs.image_version }} || \
-            export VERSION=${{ inputs.image_version }}-$VERSION_SUFFIX
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
           export CMAKE_OPTS="${{ inputs.cmake_options }}"
-          echo "CMAKE_OPTS=$CMAKE_OPTS" >> $GITHUB_ENV
-      - name: Prepare workflow variables (historic)
-        if: inputs.node_type == 'historic'
-        run: |
-          export VERSION_SUFFIX=$(echo "$BUILD_TYPE" | tr '[:upper:]' '[:lower:]')
-          [[ $PLAIN_VERSION = "true" ]] && export VERSION=${{ inputs.image_version }} || \
-            export VERSION=${{ inputs.image_version }}-$VERSION_SUFFIX-historic
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          export CMAKE_OPTS="-DHISTORIC_STATE=1 ${{ inputs.cmake_options }}"
-          echo "CMAKE_OPTS=$CMAKE_OPTS" >> $GITHUB_ENV
-      - name: Prepare workflow variables (BITE)
-        if: inputs.node_type == 'bite'
-        run: |
-          export VERSION_SUFFIX=$(echo "$BUILD_TYPE" | tr '[:upper:]' '[:lower:]')
-          [[ $PLAIN_VERSION = "true" ]] && export VERSION=${{ inputs.image_version }} || \
-            export VERSION=${{ inputs.image_version }}-$VERSION_SUFFIX
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          export CMAKE_OPTS="-DBITE=1 ${{ inputs.cmake_options }}"
-          echo "CMAKE_OPTS=$CMAKE_OPTS" >> $GITHUB_ENV
-      - name: Prepare workflow variables (BITE-HISTORIC)
-        if: inputs.node_type == 'bite-historic'
-        run: |
-          export VERSION_SUFFIX=$(echo "$BUILD_TYPE" | tr '[:upper:]' '[:lower:]')
-          [[ $PLAIN_VERSION = "true" ]] && export VERSION=${{ inputs.image_version }} || \
-            export VERSION=${{ inputs.image_version }}-$VERSION_SUFFIX
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          export CMAKE_OPTS="-DBITE=1 -DHISTORIC_STATE=1 ${{ inputs.cmake_options }}"
-          echo "CMAKE_OPTS=$CMAKE_OPTS" >> $GITHUB_ENV
-      - name: Prepare workflow variables (FAIR)
-        if: inputs.node_type == 'fair'
-        run: |
-          export VERSION_SUFFIX=$(echo "$BUILD_TYPE" | tr '[:upper:]' '[:lower:]')
-          [[ $PLAIN_VERSION = "true" ]] && export VERSION=${{ inputs.image_version }} || \
-            export VERSION=${{ inputs.image_version }}-$VERSION_SUFFIX
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          export CMAKE_OPTS="-DFAIR=1 ${{ inputs.cmake_options }}"
-          echo "CMAKE_OPTS=$CMAKE_OPTS" >> $GITHUB_ENV
-      - name: Prepare workflow variables (FAIR-HISTORIC)
-        if: inputs.node_type == 'fair-historic'
-        run: |
-          export VERSION_SUFFIX=$(echo "$BUILD_TYPE" | tr '[:upper:]' '[:lower:]')
-          [[ $PLAIN_VERSION = "true" ]] && export VERSION=${{ inputs.image_version }} || \
-            export VERSION=${{ inputs.image_version }}-$VERSION_SUFFIX
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          export CMAKE_OPTS="-DFAIR=1 -DHISTORIC_STATE=1 ${{ inputs.cmake_options }}"
+          if [[ "${{ inputs.protocol_profile }}" = "bite" ]]; then
+            export CMAKE_OPTS="-DBITE=1 $CMAKE_OPTS"
+          fi
+          if [[ "${{ inputs.protocol_profile }}" = "fair" ]]; then
+            export CMAKE_OPTS="-DFAIR=1 $CMAKE_OPTS"
+          fi
+          if [[ "${{ inputs.node_type }}" = "historic" ]]; then
+            export CMAKE_OPTS="-DHISTORIC_STATE=1 $CMAKE_OPTS"
+          fi
           echo "CMAKE_OPTS=$CMAKE_OPTS" >> $GITHUB_ENV
       - uses: actions/checkout@v6
         with:
@@ -126,7 +144,7 @@ jobs:
 
       - name: Build dependencies
         run: |
-          [[ $BUILD_TYPE = "Debug" ]] && export DEBUG_FLAG=1 || export DEBUG_FLAG=0
+          [[ $CMAKE_BUILD_TYPE = "Debug" ]] && export DEBUG_FLAG=1 || export DEBUG_FLAG=0
           cd deps
           ./build.sh PARALLEL_COUNT=$(nproc) DEBUG=$DEBUG_FLAG
           cd ..
@@ -135,21 +153,21 @@ jobs:
         uses: ./.github/actions/cmake-build
         with:
           build_dir: build
-          cmake_build_type: ${{ env.BUILD_TYPE }}
+          cmake_build_type: ${{ env.CMAKE_BUILD_TYPE }}
           cmake_args: ${{ env.CMAKE_OPTS }}
           make_target: skaled
           
       - name: Binary post-processing
         run: |
           cd build
-          if [[ "$BUILD_TYPE" = "Release" ]]; then
+          if [[ "$CMAKE_BUILD_TYPE" = "Release" ]]; then
               debug_wc=$(objdump -h skaled/skaled | grep -i debug | wc -l)
               sym_wc=$(readelf -s skaled/skaled | wc -l)
               if (( debug_wc != 0 || sym_wc > 10000 )); then
                   exit 1
               fi
           fi
-          if [[ "$BUILD_TYPE" = "RelWithDebInfo" ]]; then
+          if [[ "$CMAKE_BUILD_TYPE" = "RelWithDebInfo" ]]; then
               cp skaled/skaled skaled/skaled-debug
               strip --strip-all skaled/skaled
           fi
@@ -166,7 +184,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: inputs.release_url == ''
         with:
-          name: skaled-${{ inputs.node_type }}
+          name: skaled-${{ env.BUILD_PROFILE }}
           path: ./build/skaled/skaled
 
       - name: Upload skaled binary to Release
@@ -177,16 +195,16 @@ jobs:
         with:
           upload_url: ${{ inputs.release_url }}
           asset_path: ./build/skaled/skaled
-          asset_name: skaled-${{ inputs.node_type }}
+          asset_name: skaled-${{ env.BUILD_PROFILE }}
           asset_content_type: application/octet-stream
 
       - name: Upload debug binary to Release
-        if: inputs.release_url != '' && inputs.build_type == 'RelWithDebInfo'
+        if: inputs.release_url != '' && inputs.cmake_build_type == 'RelWithDebInfo'
         uses: actions/upload-release-asset@latest
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ inputs.release_url }}
           asset_path: ./build/skaled/skaled-debug
-          asset_name: skaled-debug-${{ inputs.node_type }}
+          asset_name: skaled-debug-${{ env.BUILD_PROFILE }}
           asset_content_type: application/octet-stream

--- a/.github/workflows/setup-build-publish.yml
+++ b/.github/workflows/setup-build-publish.yml
@@ -16,15 +16,15 @@ on:
         required: false
       cmake_build_type:
         type: string
-        description: 'CMake build type of skaled binary'
+        description: 'CMake build type of skaled binary: Debug, RelWithDebInfo, or Release'
         required: true
       protocol_profile:
         type: string
-        description: 'Protocol profile of skaled build'
+        description: 'Protocol profile of skaled build: core, bite, or fair'
         required: true
       node_type:
         type: string
-        description: 'Node type of skaled build'
+        description: 'Node type of skaled build: core or historic'
         required: true
       release_url:
         type: string
@@ -32,8 +32,8 @@ on:
         required: false
       version_suffix_mode:
         type: string
-        description: 'Docker image version suffix mode: none, protocol_profile_and_node_type, or cmake_build_type_protocol_profile_and_node_type'
-        default: cmake_build_type_protocol_profile_and_node_type
+        description: 'Docker image version suffix mode: none, protocol_node, or cmake_protocol_node'
+        default: cmake_protocol_node
     secrets:
       DOCKER_USERNAME:
         required: true
@@ -101,9 +101,9 @@ jobs:
 
           if [[ "$VERSION_SUFFIX_MODE" = "none" ]]; then
             export VERSION=${{ inputs.image_version }}
-          elif [[ "$VERSION_SUFFIX_MODE" = "protocol_profile_and_node_type" ]]; then
+          elif [[ "$VERSION_SUFFIX_MODE" = "protocol_node" ]]; then
             export VERSION=${{ inputs.image_version }}$PROTOCOL_PROFILE_SUFFIX$NODE_TYPE_SUFFIX
-          elif [[ "$VERSION_SUFFIX_MODE" = "cmake_build_type_protocol_profile_and_node_type" ]]; then
+          elif [[ "$VERSION_SUFFIX_MODE" = "cmake_protocol_node" ]]; then
             export VERSION=${{ inputs.image_version }}$CMAKE_BUILD_TYPE_SUFFIX$PROTOCOL_PROFILE_SUFFIX$NODE_TYPE_SUFFIX
           else
             echo "Unsupported version_suffix_mode: $VERSION_SUFFIX_MODE"


### PR DESCRIPTION
## Description

Updated the build workflows to separate previously overloaded concepts:

- `cmake_build_type`: CMake compilation mode, `Debug`, `RelWithDebInfo`, or `Release`.
- `protocol_profile`: protocol behavior profile, `core`, `bite`, or `fair`.
- `node_type`: node role/type, `core`, `core+historic`, or `historic` in the custom workflow


Docker image suffix generation is now centralized in `setup-build-publish.yml`

## Official releases

Official releases use:

```
version_suffix_mode: protocol_profile_and_node_type
```

so release images keep names like:
```
<version>
<version>-historic
<version>-bite
<version>-bite-historic
<version>-fair
<version>-fair-historic
```



## Custom Builds

Custom builds use:

```
version_suffix_mode: cmake_build_type_protocol_profile_and_node_type
```

so custom images include the CMake build type when relevant:
```
<version>-debug-bite
<version>-relwithdebinfo-fair-historic
<version>-bite
```

---

Release builds intentionally omit a `-release` suffix. Every other build may choose what suffixes to include. 

Currently we use `protocol_profile_and_node_type` for official release images, and `cmake_build_type_protocol_profile_and_node_type` for custom build images.


