### PR TITLE
2521 base fee missing

### DIFF
--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -59,6 +59,29 @@ const u256 MAX_BLOCK_RANGE = 1024;
 // Geth compatible error code for a revert
 const uint64_t REVERT_RPC_ERROR_CODE = 3;
 
+// Preserve the legacy RPC-only base fee until London starts storing it in block headers.
+static std::optional< u256 > baseFeePerGasForRpc(
+    eth::Client& _client, BlockHeader const& _blockInfo, Logger& _logger ) {
+    const auto blockNumber = static_cast< BlockNumber >( _blockInfo.number() );
+    if ( blockNumber == 0 )
+        return std::nullopt;
+
+    if ( LondonForkPatch::isEnabledWhen( static_cast< time_t >( _blockInfo.timestamp() ) ) )
+        return _blockInfo.baseFeePerGas();
+
+    const auto parentTimestamp = _client.blockInfo( blockNumber - 1 ).timestamp();
+    if ( !EIP1559TransactionsPatch::isEnabledWhen( parentTimestamp ) )
+        return std::nullopt;
+
+    try {
+        return _client.gasBidPrice( blockNumber - 1 );
+    } catch ( std::invalid_argument const& _e ) {
+        BOOST_LOG( _logger ) << "Cannot get gas price for block " << blockNumber;
+        BOOST_LOG( _logger ) << _e.what();
+        return _client.gasBidPrice();
+    }
+}
+
 #ifdef HISTORIC_STATE
 
 using namespace dev::rpc::_detail;
@@ -591,7 +614,7 @@ Json::Value Eth::eth_getBlockByHash( string const& _blockHash, bool _includeTran
             return Json::Value( Json::nullValue );
 
         BlockHeader blockInfo = client()->blockInfo( h );
-        u256 baseFeePerGas = blockInfo.baseFeePerGas();
+        auto baseFeePerGas = baseFeePerGasForRpc( *client(), blockInfo, m_loggerDebug );
 
 #ifdef HISTORIC_STATE
         BlockNumber bn = client()->numberFromHash( h );
@@ -652,7 +675,7 @@ Json::Value Eth::eth_getBlockByNumber( string const& _blockNumber, bool _include
         return eth_getBlockByHash( "0x" + bh.hex(), _includeTransactions );
 #else
         BlockHeader blockInfo = client()->blockInfo( h );
-        u256 baseFeePerGas = blockInfo.baseFeePerGas();
+        auto baseFeePerGas = baseFeePerGasForRpc( *client(), blockInfo, m_loggerDebug );
 
         if ( _includeTransactions )
             return toJson( blockInfo, client()->blockDetails( h ), client()->uncleHashes( h ),

--- a/libweb3jsonrpc/JsonHelper.cpp
+++ b/libweb3jsonrpc/JsonHelper.cpp
@@ -136,18 +136,15 @@ Json::Value toJson( dev::eth::Transaction const& _t, std::pair< h256, unsigned >
 }
 
 Json::Value toJson( dev::eth::BlockHeader const& _bi, BlockDetails const& _bd,
-    UncleHashes const& _us, Transactions const& _ts, SealEngineFace* _face, u256 _gasPrice ) {
+    UncleHashes const& _us, Transactions const& _ts, SealEngineFace* _face,
+    std::optional< u256 > _baseFeePerGas ) {
     Json::Value res = toJson( _bi, _face );
     if ( _bi ) {
         res["totalDifficulty"] = toJS( _bd.totalDifficulty );
         res["size"] = toJS( _bd.blockSizeBytes );
         res["uncles"] = Json::Value( Json::arrayValue );
-        // Genesis (block 0) has no baseFeePerGas (omitted from its header RLP), so expose it via
-        // RPC only for non-genesis London blocks (or a synthetic value).
-        if ( _bi.number() > 0 &&
-             ( _gasPrice > 0 ||
-                 LondonForkPatch::isEnabledWhen( static_cast< time_t >( _bi.timestamp() ) ) ) )
-            res["baseFeePerGas"] = toJS( _gasPrice );
+        if ( _bi.number() > 0 && _baseFeePerGas )
+            res["baseFeePerGas"] = toJS( *_baseFeePerGas );
         for ( h256 h : _us )
             res["uncles"].append( toJS( h ) );
         res["transactions"] = Json::Value( Json::arrayValue );
@@ -159,18 +156,15 @@ Json::Value toJson( dev::eth::BlockHeader const& _bi, BlockDetails const& _bd,
 }
 
 Json::Value toJson( dev::eth::BlockHeader const& _bi, BlockDetails const& _bd,
-    UncleHashes const& _us, TransactionHashes const& _ts, SealEngineFace* _face, u256 _gasPrice ) {
+    UncleHashes const& _us, TransactionHashes const& _ts, SealEngineFace* _face,
+    std::optional< u256 > _baseFeePerGas ) {
     Json::Value res = toJson( _bi, _face );
     if ( _bi ) {
         res["totalDifficulty"] = toJS( _bd.totalDifficulty );
         res["size"] = toJS( _bd.blockSizeBytes );
         res["uncles"] = Json::Value( Json::arrayValue );
-        // Genesis (block 0) has no baseFeePerGas (omitted from its header RLP), so expose it via
-        // RPC only for non-genesis London blocks (or a synthetic value).
-        if ( _bi.number() > 0 &&
-             ( _gasPrice > 0 ||
-                 LondonForkPatch::isEnabledWhen( static_cast< time_t >( _bi.timestamp() ) ) ) )
-            res["baseFeePerGas"] = toJS( _gasPrice );
+        if ( _bi.number() > 0 && _baseFeePerGas )
+            res["baseFeePerGas"] = toJS( *_baseFeePerGas );
         for ( h256 h : _us )
             res["uncles"].append( toJS( h ) );
         res["transactions"] = Json::Value( Json::arrayValue );

--- a/libweb3jsonrpc/JsonHelper.h
+++ b/libweb3jsonrpc/JsonHelper.h
@@ -29,6 +29,7 @@
 #include <libethcore/Common.h>
 #include <libethereum/LogFilter.h>
 
+#include <optional>
 #include <stdexcept>
 #ifndef RAPIDJSON_ASSERT
 #define RAPIDJSON_ASSERT( x )                                       \
@@ -61,9 +62,11 @@ Json::Value toJson( BlockHeader const& _bi, SealEngineFace* _face = nullptr );
 Json::Value toJson(
     Transaction const& _t, std::pair< h256, unsigned > _location, BlockNumber _blockNumber );
 Json::Value toJson( BlockHeader const& _bi, BlockDetails const& _bd, UncleHashes const& _us,
-    Transactions const& _ts, SealEngineFace* _face = nullptr, u256 _gasPrice = 0 );
+    Transactions const& _ts, SealEngineFace* _face = nullptr,
+    std::optional< u256 > _baseFeePerGas = std::nullopt );
 Json::Value toJson( BlockHeader const& _bi, BlockDetails const& _bd, UncleHashes const& _us,
-    TransactionHashes const& _ts, SealEngineFace* _face = nullptr, u256 _gasPrice = 0 );
+    TransactionHashes const& _ts, SealEngineFace* _face = nullptr,
+    std::optional< u256 > _baseFeePerGas = std::nullopt );
 Json::Value toJson( TransactionSkeleton const& _t );
 Json::Value toJson( Transaction const& _t );
 Json::Value toJson( Transaction const& _t, bytes const& _rlp );

--- a/test/api-tests/hardfork-compat/_basefee_compat.py
+++ b/test/api-tests/hardfork-compat/_basefee_compat.py
@@ -1,0 +1,261 @@
+"""Assertions for JSON-RPC baseFeePerGas behavior around London activation."""
+
+import time
+
+from eth_utils import keccak
+
+
+def _rpc(w3, method: str, params: list):
+    response = w3.provider.make_request(method, params)
+    if not isinstance(response, dict):
+        raise AssertionError(f"{method} returned a non-object response: {response!r}")
+    if "error" in response:
+        raise AssertionError(f"{method} failed: {response['error']}")
+    if "result" not in response:
+        raise AssertionError(f"{method} response has no result: {response}")
+    return response["result"]
+
+
+def _quantity(value) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        return int(value, 16) if value.startswith("0x") else int(value)
+    return int(value)
+
+
+def _hex_bytes(value: str) -> bytes:
+    raw = value[2:] if value.startswith("0x") else value
+    return bytes.fromhex(raw)
+
+
+def _uint_bytes(value: int) -> bytes:
+    if value == 0:
+        return b""
+    return value.to_bytes((value.bit_length() + 7) // 8, "big")
+
+
+def _rlp_item(data: bytes) -> bytes:
+    if len(data) == 1 and data[0] < 0x80:
+        return data
+    if len(data) < 56:
+        return bytes([0x80 + len(data)]) + data
+    size = _uint_bytes(len(data))
+    return bytes([0xB7 + len(size)]) + size + data
+
+
+def _rlp_list(items: list[bytes]) -> bytes:
+    payload = b"".join(_rlp_item(item) for item in items)
+    if len(payload) < 56:
+        return bytes([0xC0 + len(payload)]) + payload
+    size = _uint_bytes(len(payload))
+    return bytes([0xF7 + len(size)]) + size + payload
+
+
+def _header_hash_variants(block: dict, base_fee: int | None) -> dict[str, bytes]:
+    fields = [
+        _hex_bytes(block["parentHash"]),
+        _hex_bytes(block["sha3Uncles"]),
+        _hex_bytes(block["miner"]),
+        _hex_bytes(block["stateRoot"]),
+        _hex_bytes(block["transactionsRoot"]),
+        _hex_bytes(block["receiptsRoot"]),
+        _hex_bytes(block["logsBloom"]),
+        _uint_bytes(_quantity(block["difficulty"])),
+        _uint_bytes(_quantity(block["number"])),
+        _uint_bytes(_quantity(block["gasLimit"])),
+        _uint_bytes(_quantity(block["gasUsed"])),
+        _uint_bytes(_quantity(block["timestamp"])),
+        _hex_bytes(block["extraData"]),
+    ]
+
+    no_seal = list(fields)
+    if base_fee is not None:
+        no_seal.append(_uint_bytes(base_fee))
+    variants = {"no-seal": keccak(_rlp_list(no_seal))}
+
+    if block.get("mixHash") is not None and block.get("nonce") is not None:
+        two_seal = fields + [
+            _hex_bytes(block["mixHash"]),
+            _hex_bytes(block["nonce"]).rjust(8, b"\x00"),
+        ]
+        if base_fee is not None:
+            two_seal.append(_uint_bytes(base_fee))
+        variants["two-seal"] = keccak(_rlp_list(two_seal))
+
+    return variants
+
+
+def _find_era_blocks(
+    w3, eip1559: int, london: int, timeout_sec: float, poll_interval_sec: float
+) -> dict[str, int]:
+    deadline = time.time() + timeout_sec
+    timestamps: dict[int, int] = {}
+    next_block = 0
+
+    while time.time() < deadline:
+        latest = int(w3.eth.block_number)
+        for number in range(next_block, latest + 1):
+            timestamps[number] = _quantity(w3.eth.get_block(number)["timestamp"])
+        next_block = max(next_block, latest + 1)
+
+        if timestamps.get(latest, 0) >= london:
+            break
+        time.sleep(poll_interval_sec)
+    else:
+        latest_timestamp = timestamps.get(max(timestamps, default=0), 0)
+        raise AssertionError(
+            f"No London block within {timeout_sec}s; latest timestamp={latest_timestamp}, "
+            f"activation={london}"
+        )
+
+    pre_eip1559 = [
+        number
+        for number, timestamp in timestamps.items()
+        if number > 0
+        and timestamp < eip1559
+        and timestamps.get(number - 1, eip1559) < eip1559
+    ]
+    compatibility = [
+        number
+        for number, timestamp in timestamps.items()
+        if number > 0
+        and timestamps.get(number - 1, 0) >= eip1559
+        and timestamp < london
+    ]
+    post_london = [
+        number
+        for number, timestamp in timestamps.items()
+        if number > 0 and timestamp >= london
+    ]
+
+    missing = [
+        name
+        for name, candidates in (
+            ("pre-EIP-1559", pre_eip1559),
+            ("EIP-1559/pre-London", compatibility),
+            ("post-London", post_london),
+        )
+        if not candidates
+    ]
+    if missing:
+        raise AssertionError(
+            f"No block observed in era(s): {', '.join(missing)}; "
+            f"EIP-1559={eip1559}, London={london}, timestamps={timestamps}"
+        )
+
+    return {
+        "pre-eip1559": pre_eip1559[-1],
+        "compatibility": compatibility[len(compatibility) // 2],
+        "post-london": post_london[0],
+    }
+
+
+def _block_rpc_variants(w3, block_number: int) -> dict[str, dict]:
+    number = hex(block_number)
+    by_number = _rpc(w3, "eth_getBlockByNumber", [number, False])
+    if not isinstance(by_number, dict):
+        raise AssertionError(f"eth_getBlockByNumber({number}) returned {by_number!r}")
+    block_hash = by_number.get("hash")
+    if not block_hash:
+        raise AssertionError(f"Block {number} has no hash")
+
+    variants = {
+        "number-hashes": by_number,
+        "number-transactions": _rpc(w3, "eth_getBlockByNumber", [number, True]),
+        "hash-hashes": _rpc(w3, "eth_getBlockByHash", [block_hash, False]),
+        "hash-transactions": _rpc(w3, "eth_getBlockByHash", [block_hash, True]),
+    }
+    for route, block in variants.items():
+        if not isinstance(block, dict):
+            raise AssertionError(f"{route} returned {block!r}")
+        if _quantity(block.get("number")) != block_number:
+            raise AssertionError(f"{route} returned the wrong block: {block.get('number')}")
+        if block.get("hash", "").lower() != block_hash.lower():
+            raise AssertionError(f"{route} returned a different hash: {block.get('hash')}")
+    return variants
+
+
+def _assert_rpc_field(variants: dict[str, dict], expected_presence: bool) -> int | None:
+    values = {}
+    for route, block in variants.items():
+        present = "baseFeePerGas" in block
+        if present != expected_presence:
+            expectation = "present" if expected_presence else "omitted"
+            raise AssertionError(f"baseFeePerGas must be {expectation} for {route}")
+        if present:
+            values[route] = _quantity(block["baseFeePerGas"])
+
+    if not values:
+        return None
+    if len(set(values.values())) != 1:
+        raise AssertionError(f"baseFeePerGas differs across block RPC routes: {values}")
+    return next(iter(values.values()))
+
+
+def _assert_hash_uses_base_fee(block: dict, base_fee: int, expected: bool) -> None:
+    reported_hash = _hex_bytes(block["hash"])
+    with_base_fee = _header_hash_variants(block, base_fee)
+    without_base_fee = _header_hash_variants(block, None)
+    matches_with = [name for name, value in with_base_fee.items() if value == reported_hash]
+    matches_without = [name for name, value in without_base_fee.items() if value == reported_hash]
+
+    if expected and (not matches_with or matches_without):
+        raise AssertionError(
+            "London block hash does not exclusively commit to baseFeePerGas: "
+            f"with={matches_with}, without={matches_without}"
+        )
+    if not expected and (not matches_without or matches_with):
+        raise AssertionError(
+            "Pre-London block hash unexpectedly commits to synthetic baseFeePerGas: "
+            f"with={matches_with}, without={matches_without}"
+        )
+
+
+def assert_basefee_rpc_compatibility(
+    w3,
+    eip1559: int,
+    london: int,
+    timeout_sec: float = 120,
+    poll_interval_sec: float = 0.5,
+) -> dict[str, dict]:
+    """Assert omission, synthetic RPC compatibility, then real London base fee."""
+    if not 0 < eip1559 < london:
+        raise AssertionError(
+            f"Expected staggered activation timestamps, got EIP-1559={eip1559}, London={london}"
+        )
+
+    blocks = _find_era_blocks(w3, eip1559, london, timeout_sec, poll_interval_sec)
+
+    pre_number = blocks["pre-eip1559"]
+    pre_variants = _block_rpc_variants(w3, pre_number)
+    _assert_rpc_field(pre_variants, expected_presence=False)
+
+    compatibility_number = blocks["compatibility"]
+    compatibility_variants = _block_rpc_variants(w3, compatibility_number)
+    synthetic_base_fee = _assert_rpc_field(compatibility_variants, expected_presence=True)
+    assert synthetic_base_fee is not None
+    gas_price = _quantity(_rpc(w3, "eth_gasPrice", []))
+    if synthetic_base_fee != gas_price:
+        raise AssertionError(
+            f"synthetic baseFeePerGas={synthetic_base_fee} differs from "
+            f"stable chain gas price={gas_price}"
+        )
+    _assert_hash_uses_base_fee(
+        compatibility_variants["number-hashes"], synthetic_base_fee, expected=False
+    )
+
+    london_number = blocks["post-london"]
+    london_variants = _block_rpc_variants(w3, london_number)
+    london_base_fee = _assert_rpc_field(london_variants, expected_presence=True)
+    assert london_base_fee is not None
+    _assert_hash_uses_base_fee(london_variants["number-hashes"], london_base_fee, expected=True)
+
+    return {
+        "pre-eip1559": {"block": pre_number},
+        "compatibility": {
+            "block": compatibility_number,
+            "baseFeePerGas": synthetic_base_fee,
+        },
+        "post-london": {"block": london_number, "baseFeePerGas": london_base_fee},
+    }

--- a/test/api-tests/hardfork-compat/hardfork-compat.toml
+++ b/test/api-tests/hardfork-compat/hardfork-compat.toml
@@ -1,13 +1,14 @@
 # ==========================================================================
-# hardfork-compat suite -- Paris fork replay test parameters
+# hardfork-compat suite -- fork-boundary RPC and Paris replay test parameters
 # ==========================================================================
 # Merged on top of run.toml at runtime by the test runner.
 #
-# Purpose: confirm that the current Paris-capable skaled binary can replay a
-# chain that starts on the London-capable binary, upgrades before Paris
-# activation, and continues after Paris activation without stateRoot or block
-# hash divergence.  The final current-version sync node runs with
-# syncNode=true and archiveMode=true and compares every block.
+# Purpose: verify baseFeePerGas RPC compatibility across staggered EIP-1559 and
+# London activation, then confirm that the current Paris-capable skaled binary
+# can replay a chain that starts on the London-capable binary, upgrades before
+# Paris activation, and continues after activation without stateRoot or block
+# hash divergence. The final current-version sync node runs with syncNode=true
+# and archiveMode=true and compares every block.
 
 # --------------------------------------------------------------------------
 # Environment type override
@@ -37,6 +38,19 @@ current_binary = "build/skaled/skaled"
 # Ports: primary on 5334, archive sync node on 5344.
 primary_http_port = 5334
 sync_http_port    = 5344
+
+# A separate current-binary node exercises the EIP-1559-to-London RPC window
+# without changing the London->Paris replay chain below.
+[hardfork_compat.basefee_compat]
+http_port = 6234
+transition_timeout_sec = 120
+poll_interval_sec = 0.5
+
+[hardfork_compat.basefee_compat.patches]
+EIP1559TransactionsPatchTimestamp = "now+30s"
+londonForkPatchTimestamp = "now+60s"
+emptyBlockIntervalMs = 2000
+snapshotIntervalSec = 0
 
 # --------------------------------------------------------------------------
 # Baseline London-era settings injected into the primary config before the

--- a/test/api-tests/hardfork-compat/test_hardfork_compat.py
+++ b/test/api-tests/hardfork-compat/test_hardfork_compat.py
@@ -1,17 +1,18 @@
 """
-hardfork-compat: Paris fork replay compatibility across a London -> current upgrade.
+hardfork-compat: fork-boundary RPC and Paris replay compatibility.
 
 Test flow:
-  1. Start the primary node with the London-capable binary.
-  2. Produce a pre-upgrade London workload:
+  1. Exercise staggered EIP-1559/London block RPC output on a temporary current node.
+  2. Start the primary node with the London-capable binary.
+  3. Produce a pre-upgrade London workload:
        - native token transfers
        - basic ERC20 deploy/mint/transfer
        - a DIFFICULTY/PREVRANDAO opcode transaction
-  3. Restart the same primary node/datadir on the current binary and inject a
+  4. Restart the same primary node/datadir on the current binary and inject a
      future ParisForkPatch timestamp.
-  4. Produce the same essential workload before Paris activation.
-  5. Wait until the Paris timestamp is active and produce the workload again.
-  6. Launch a current-version sync node with archiveMode=true and verify that
+  5. Produce the same essential workload before Paris activation.
+  6. Wait until the Paris timestamp is active and produce the workload again.
+  7. Launch a current-version sync node with archiveMode=true and verify that
      replaying the whole chain has no per-block stateRoot or block-hash
      mismatches.
 """
@@ -24,6 +25,7 @@ import pytest
 from eth_account import Account
 from web3 import Web3
 
+from _basefee_compat import assert_basefee_rpc_compatibility
 from _test_utils import (
     compare_block_hashes,
     compare_state_roots,
@@ -244,6 +246,28 @@ def _read_schain_value(config_path: Path, key: str):
     return cfg["skaleConfig"]["sChain"].get(key)
 
 
+def _configure_single_node_ports(config_path: Path, http_port: int) -> None:
+    """Keep the compatibility node's consensus and RPC sockets isolated."""
+    with open(config_path) as f:
+        cfg = json.load(f)
+
+    ports = {
+        "basePort": http_port - 3,
+        "httpRpcPort": http_port,
+        "httpsRpcPort": http_port + 5,
+        "wsRpcPort": http_port - 1,
+        "wssRpcPort": http_port + 4,
+    }
+    node_info = cfg["skaleConfig"]["nodeInfo"]
+    node_info.update(ports)
+    node_info["infoHttpRpcPort"] = http_port + 6
+    for node in cfg["skaleConfig"]["sChain"]["nodes"]:
+        node.update(ports)
+
+    with open(config_path, "w") as f:
+        json.dump(cfg, f, indent=2)
+
+
 def _assert_receipts_before_timestamp(w3: Web3, receipts: list, timestamp: int, label: str) -> None:
     for receipt in receipts:
         block = w3.eth.get_block(receipt["blockNumber"])
@@ -356,6 +380,79 @@ def _run_paris_workload_phase(
 # ---------------------------------------------------------------------------
 # Tests (ordered by file position)
 # ---------------------------------------------------------------------------
+
+def test_current_binary_basefee_rpc_compatibility(
+    current_binary: Path, run_cfg: dict, hardfork_cfg: dict, private_key: str,
+):
+    """Check block RPC output before EIP-1559, before London, and after London."""
+    from conftest import _launch_node, _resolve, _resolve_ft, _stop_node, _wait_for_rpc
+    from run import (
+        configure_single_node_skaled,
+        ensure_genesis_balance,
+        inject_patches,
+        render_template_file,
+        set_ulimit,
+    )
+
+    if not current_binary.is_file():
+        pytest.fail(
+            f"Current skaled binary not found: {current_binary}\n"
+            "Set HARDFORK_COMPAT_CURRENT_BINARY or [hardfork_compat].current_binary."
+        )
+
+    basefee_cfg = hardfork_cfg.get("basefee_compat", {})
+    http_port = int(basefee_cfg.get("http_port", 6234))
+    cfg_out = _resolve(
+        "test/api-tests/hardfork-compat/configs/config-basefee.generated.json"
+    )
+    datadir = _resolve("test/api-tests/hardfork-compat/datadir-basefee")
+    template = _resolve_ft("hardfork-compat/config-templates/config-template.json.j2")
+    template_context = run_cfg.get("skaled", {}).get("template", {}).get("context", {})
+
+    render_template_file(str(template), str(cfg_out), template_context)
+    ensure_genesis_balance(str(cfg_out), private_key)
+    configure_single_node_skaled(str(cfg_out))
+    _configure_single_node_ports(cfg_out, http_port)
+    inject_patches(str(cfg_out), basefee_cfg.get("patches", {}))
+
+    eip1559 = _read_schain_value(cfg_out, "EIP1559TransactionsPatchTimestamp")
+    london = _read_schain_value(cfg_out, "londonForkPatchTimestamp")
+    assert isinstance(eip1559, int) and isinstance(london, int), (
+        "baseFeePerGas compatibility patch timestamps must resolve to integers"
+    )
+
+    set_ulimit()
+    log_dir = SUITE_DIR / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "skaled-basefee-compat.log"
+    proc, log_fd = _launch_node(
+        current_binary,
+        cfg_out,
+        http_port,
+        datadir,
+        log_path,
+        "BASEFEE(current)",
+    )
+    w3 = Web3(Web3.HTTPProvider(
+        f"http://127.0.0.1:{http_port}", request_kwargs={"timeout": 10}
+    ))
+
+    try:
+        rpc_timeout = hardfork_cfg.get("timeouts", {}).get("rpc_up", 360)
+        _wait_for_rpc(w3, rpc_timeout, "BASEFEE(current)")
+        details = assert_basefee_rpc_compatibility(
+            w3,
+            eip1559,
+            london,
+            timeout_sec=float(basefee_cfg.get("transition_timeout_sec", 120)),
+            poll_interval_sec=float(basefee_cfg.get("poll_interval_sec", 0.5)),
+        )
+        logger.info("baseFeePerGas RPC compatibility checks passed: %s", details)
+    except Exception as exc:
+        pytest.fail(f"{exc}\n--- {log_path} tail ---\n{log_path.read_text(errors='replace')[-8000:]}")
+    finally:
+        _stop_node(proc, log_fd, "BASEFEE(current)")
+
 
 def test_london_primary_rpc_up(w3_primary: Web3):
     """Verify the London primary node RPC is reachable."""

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -4527,6 +4527,10 @@ BOOST_AUTO_TEST_CASE( eip2930Transactions ) {
                        "latest" ) == "0x16345785d8a0000" );
 
 #ifndef FAIR
+    auto preEip1559Block =
+        fixture.rpcClient->eth_getBlockByNumber( receipt["blockNumber"].asString(), false );
+    BOOST_REQUIRE( !preEip1559Block.isMember( "baseFeePerGas" ) );
+
     // try sending type1 txn before patchTimestmap
     BOOST_REQUIRE_THROW(
         fixture.rpcClient->eth_sendRawTransaction(
@@ -4576,8 +4580,19 @@ BOOST_AUTO_TEST_CASE( eip2930Transactions ) {
     auto block = fixture.rpcClient->eth_getBlockByNumber( "4", false );
     BOOST_REQUIRE( block["transactions"].size() == 1 );
     BOOST_REQUIRE( block["transactions"][0].asString() == txHash );
+#ifndef FAIR
+    const auto syntheticBaseFeePerGas = toJS( fixture.client->gasBidPrice( 3 ) );
+    BOOST_REQUIRE( block.isMember( "baseFeePerGas" ) );
+    BOOST_REQUIRE_EQUAL( block["baseFeePerGas"].asString(), syntheticBaseFeePerGas );
+    auto blockByHash = fixture.rpcClient->eth_getBlockByHash( block["hash"].asString(), false );
+    BOOST_REQUIRE( blockByHash.isMember( "baseFeePerGas" ) );
+    BOOST_REQUIRE_EQUAL( blockByHash["baseFeePerGas"].asString(), syntheticBaseFeePerGas );
+#endif
 
     block = fixture.rpcClient->eth_getBlockByNumber( "4", true );
+#ifndef FAIR
+    BOOST_REQUIRE_EQUAL( block["baseFeePerGas"].asString(), syntheticBaseFeePerGas );
+#endif
     BOOST_REQUIRE( block["transactions"].size() == 1 );
     BOOST_REQUIRE( block["transactions"][0]["hash"].asString() == txHash );
     BOOST_REQUIRE( block["transactions"][0]["type"] == "0x1" );
@@ -4796,6 +4811,8 @@ BOOST_AUTO_TEST_CASE( eip1559Transactions ) {
 
     block = fixture.rpcClient->eth_getBlockByNumber( "4", true );
     BOOST_REQUIRE( !block["baseFeePerGas"].asString().empty() );
+    BOOST_REQUIRE_EQUAL(
+        block["baseFeePerGas"].asString(), toJS( fixture.client->blockInfo( 4 ).baseFeePerGas() ) );
     BOOST_REQUIRE( block["transactions"].size() == 1 );
     BOOST_REQUIRE( block["transactions"][0]["hash"].asString() == txHash );
     BOOST_REQUIRE( block["transactions"][0]["type"] == "0x2" );


### PR DESCRIPTION

   ## Description

   Small fix for baseFeePerGas handling for different blocks depending on timestamp. 

   - Before `EIP1559TransactionsPatch`: omit the field.
   - Between EIP-1559 and London activation: return the synthetic parent-block gas bid price.
   - After `LondonForkPatch`: return the real block-header value.
   - Continue omitting the field for genesis.

   The change is limited to JSON-RPC output and does not modify header serialization, RLP, block hashes, or consensus behavior.

   ## Tests

   - Passed unit tests
   - Updated api-tests

   ## Performance Impact
Changes only related to json rpc request pipeline with no performance degrade expected. Consensus, block production, catchup and evm logic are untouched. 
