### PR TITLE
Bug/2327 fix get latest snapshot beta

### DIFF
--- a/docs/features/snapshots.md
+++ b/docs/features/snapshots.md
@@ -2,13 +2,14 @@
 
 # Snapshots
 
--   [Introduction](#introduction)
--   [Design](#design)    
--   [JSON-RPC Snapshot Methods](#json-rpc-snapshot-methods)
-    -   [skale_getSnapshot](#skale_getsnapshot)
-    -   [skale_downloadSnapshotFragment](#skale_downloadsnapshotfragment)
-    -   [skale_getSnapshotSignature](#skale_getsnapshotsignature)
-    -   [skale_getLatestSnapshotBlockNumber](#skale_getlatestsnapshotblocknumber)
+- [Snapshots](#snapshots)
+  - [Introduction](#introduction)
+  - [Design](#design)
+  - [JSON-RPC Snapshot Methods](#json-rpc-snapshot-methods)
+    - [skale\_getSnapshot](#skale_getsnapshot)
+    - [skale\_downloadSnapshotFragment](#skale_downloadsnapshotfragment)
+    - [skale\_getSnapshotSignature](#skale_getsnapshotsignature)
+    - [skale\_getLatestSnapshotBlockNumber](#skale_getlatestsnapshotblocknumber)
 
 ## Introduction
 

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -872,9 +872,9 @@ void Client::rejigSealing() {
 
                 // TODO Deduplicate code
                 dev::h256 stateRootToSet;
-                if ( m_snapshotAgent->getLatestSnapshotBlockNumer() > 0 ) {
+                if ( m_snapshotAgent->getOneBeforeLatestSnapshotBlockNumer() > 0 ) {
                     dev::h256 stateRootHash = this->m_snapshotAgent->getSnapshotHash(
-                        m_snapshotAgent->getLatestSnapshotBlockNumer() );
+                        m_snapshotAgent->getOneBeforeLatestSnapshotBlockNumer() );
                     stateRootToSet = stateRootHash;
                 }
                 // propagate current
@@ -930,9 +930,9 @@ void Client::sealUnconditionally( bool submitToBlockChain ) {
         // latest hash is really updated after NEXT snapshot already started hash computation
         // TODO Deduplicate code
         dev::h256 stateRootToSet;
-        if ( m_snapshotAgent->getLatestSnapshotBlockNumer() > 0 ) {
+        if ( m_snapshotAgent->getOneBeforeLatestSnapshotBlockNumer() > 0 ) {
             dev::h256 stateRootHash = this->m_snapshotAgent->getSnapshotHash(
-                m_snapshotAgent->getLatestSnapshotBlockNumer() );
+                m_snapshotAgent->getOneBeforeLatestSnapshotBlockNumer() );
             stateRootToSet = stateRootHash;
         }
         // propagate current

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -346,9 +346,7 @@ public:
         return m_snapshotAgent->getLatestSnapshotBlockNumer();
     }
 
-    dev::h256 getLatestSnapshotHash() const {
-        return m_snapshotAgent->getLatestSnapshotHash();
-    }
+    dev::h256 getLatestSnapshotHash() const { return m_snapshotAgent->getLatestSnapshotHash(); }
 
     uint64_t getSnapshotCalculationTime() const {
         return m_snapshotAgent->getSnapshotCalculationTime();

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -338,8 +338,16 @@ public:
         return m_snapshotAgent->getBlockTimestampFromSnapshot( _blockNumber );
     }
 
+    int64_t getOneBeforeLatestSnapshotBlockNumer() const {
+        return m_snapshotAgent->getOneBeforeLatestSnapshotBlockNumer();
+    }
+
     int64_t getLatestSnapshotBlockNumer() const {
         return m_snapshotAgent->getLatestSnapshotBlockNumer();
+    }
+
+    dev::h256 getLatestSnapshotHash() const {
+        return m_snapshotAgent->getLatestSnapshotHash();
     }
 
     uint64_t getSnapshotCalculationTime() const {

--- a/libethereum/SnapshotAgent.cpp
+++ b/libethereum/SnapshotAgent.cpp
@@ -32,41 +32,36 @@ void SnapshotAgent::init( unsigned _currentBlockNumber, int64_t _timestampOfBloc
     if ( latest_snapshots.first ) {
         assert( latest_snapshots.first != 1 );  // 1 can never be snapshotted
 
+        this->one_before_last_snapshoted_block_with_hash = latest_snapshots.first;
         this->last_snapshoted_block_with_hash = latest_snapshots.first;
-
-        // ignore second as it was "in hash computation"
-        // check that both are imported!!
-        // h256 h2 = this->hashFromNumber( latest_snapshots.second );
-        // assert( h2 != h256() );
-        // last_snapshot_creation_time = blockInfo( h2 ).timestamp();
 
         last_snapshot_creation_time =
             this->m_snapshotManager->getBlockTimestamp( latest_snapshots.second );
 
         if ( !m_snapshotManager->checkSnapshotFolderAndSnapshotHash( latest_snapshots.second ) )
             startHashComputingThread();
+        else
+            this->last_snapshoted_block_with_hash = latest_snapshots.second;
 
         // one snapshot
     } else if ( latest_snapshots.second ) {
         assert( latest_snapshots.second != 1 );  // 1 can never be snapshotted
         assert( _timestampOfBlock1 > 0 );        // we created snapshot somehow
 
-        // whether it is local or downloaded - we shall ignore it's hash but use it's time
-        // see also how last_snapshotted_block_with_hash is updated in importTransactionsAsBlock
-        // h256 h2 = this->hashFromNumber( latest_snapshots.second );
-        // uint64_t time_of_second = blockInfo( h2 ).timestamp();
-
+        this->one_before_last_snapshoted_block_with_hash = -1;
         this->last_snapshoted_block_with_hash = -1;
-        // last_snapshot_creation_time = time_of_second;
 
         last_snapshot_creation_time =
             this->m_snapshotManager->getBlockTimestamp( latest_snapshots.second );
 
         if ( !m_snapshotManager->checkSnapshotFolderAndSnapshotHash( latest_snapshots.second ) )
             startHashComputingThread();
+        else
+            this->last_snapshoted_block_with_hash = latest_snapshots.second;
 
         // no snapshots yet
     } else {
+        this->one_before_last_snapshoted_block_with_hash = -1;
         this->last_snapshoted_block_with_hash = -1;
         // init last block creation time with only robust time source - timestamp of 1st block!
         last_snapshot_creation_time = _timestampOfBlock1;
@@ -74,6 +69,7 @@ void SnapshotAgent::init( unsigned _currentBlockNumber, int64_t _timestampOfBloc
 
     BOOST_LOG( m_loggerInfo ) << "Latest snapshots init: " << latest_snapshots.first << " "
                               << latest_snapshots.second << " -> "
+                              << this->one_before_last_snapshoted_block_with_hash << " / "
                               << this->last_snapshoted_block_with_hash;
 
     BOOST_LOG( m_loggerInfo ) << "Init last snapshot creation time: "
@@ -96,7 +92,7 @@ void SnapshotAgent::finishHashComputingAndUpdateHashesIfNeeded( int64_t _timesta
         if ( latest_snapshots.second ) {
             assert(
                 m_snapshotManager->checkSnapshotFolderAndSnapshotHash( latest_snapshots.second ) );
-            this->last_snapshoted_block_with_hash = latest_snapshots.second;
+            this->one_before_last_snapshoted_block_with_hash = latest_snapshots.second;
             m_snapshotManager->leaveNLastSnapshots( 2 );
         }
     }
@@ -144,7 +140,7 @@ void SnapshotAgent::doSnapshotIfNeeded( unsigned _currentBlockNumber, int64_t _t
 }
 
 boost::filesystem::path SnapshotAgent::createSnapshotFile( unsigned _blockNumber ) {
-    if ( _blockNumber > this->getLatestSnapshotBlockNumer() && _blockNumber != 0 )
+    if ( _blockNumber > this->getOneBeforeLatestSnapshotBlockNumer() && _blockNumber != 0 )
         throw std::invalid_argument( "Too new snapshot requested" );
     boost::filesystem::path path = m_snapshotManager->makeOrGetDiff( _blockNumber );
     // TODO Make constant 2 configurable
@@ -178,6 +174,10 @@ dev::h256 SnapshotAgent::getSnapshotHash( unsigned _blockNumber ) const {
     // fall through other exceptions
 }
 
+dev::h256 SnapshotAgent::getLatestSnapshotHash() const {
+    return this->getSnapshotHash( this->last_snapshoted_block_with_hash );
+}
+
 uint64_t SnapshotAgent::getBlockTimestampFromSnapshot( unsigned _blockNumber ) const {
     return this->m_snapshotManager->getBlockTimestamp( _blockNumber );
 }
@@ -201,6 +201,7 @@ void SnapshotAgent::startHashComputingThread() {
             t2 = boost::chrono::high_resolution_clock::now();
             this->snapshot_hash_calculation_time_ms =
                 boost::chrono::duration_cast< boost::chrono::milliseconds >( t2 - t1 ).count();
+            this->last_snapshoted_block_with_hash = latest_snapshots.second;
             BOOST_LOG( m_loggerInfo )
                 << "Computed hash for snapshot " << latest_snapshots.second << ": "
                 << m_snapshotManager->getSnapshotHash( latest_snapshots.second );

--- a/libethereum/SnapshotAgent.h
+++ b/libethereum/SnapshotAgent.h
@@ -33,7 +33,9 @@ public:
     dev::h256 getSnapshotHash( unsigned _blockNumber ) const;
     dev::h256 getLatestSnapshotHash() const;
     uint64_t getBlockTimestampFromSnapshot( unsigned _blockNumber ) const;
-    int64_t getOneBeforeLatestSnapshotBlockNumer() const { return this->one_before_last_snapshoted_block_with_hash; }
+    int64_t getOneBeforeLatestSnapshotBlockNumer() const {
+        return this->one_before_last_snapshoted_block_with_hash;
+    }
     int64_t getLatestSnapshotBlockNumer() const { return this->last_snapshoted_block_with_hash; }
     uint64_t getSnapshotCalculationTime() const { return this->snapshot_calculation_time_ms; }
     uint64_t getSnapshotHashCalculationTime() const {

--- a/libethereum/SnapshotAgent.h
+++ b/libethereum/SnapshotAgent.h
@@ -31,7 +31,9 @@ public:
     void terminate();
 
     dev::h256 getSnapshotHash( unsigned _blockNumber ) const;
+    dev::h256 getLatestSnapshotHash() const;
     uint64_t getBlockTimestampFromSnapshot( unsigned _blockNumber ) const;
+    int64_t getOneBeforeLatestSnapshotBlockNumer() const { return this->one_before_last_snapshoted_block_with_hash; }
     int64_t getLatestSnapshotBlockNumer() const { return this->last_snapshoted_block_with_hash; }
     uint64_t getSnapshotCalculationTime() const { return this->snapshot_calculation_time_ms; }
     uint64_t getSnapshotHashCalculationTime() const {
@@ -41,8 +43,10 @@ public:
 private:
     // time of last physical snapshot
     int64_t last_snapshot_creation_time = 0;
-    // usually this is snapshot before last!
-    int64_t last_snapshoted_block_with_hash = -1;
+
+    // holds the block before last snapshoted block with hash
+    int64_t one_before_last_snapshoted_block_with_hash = -1;
+    std::atomic< int64_t > last_snapshoted_block_with_hash = -1;
 
     int64_t m_snapshotIntervalSec;
     std::shared_ptr< SnapshotManager > m_snapshotManager;

--- a/libethereum/SnapshotAgent.h
+++ b/libethereum/SnapshotAgent.h
@@ -6,6 +6,7 @@
 
 #include <boost/filesystem.hpp>
 
+#include <atomic>
 #include <memory>
 #include <thread>
 
@@ -47,7 +48,7 @@ private:
     int64_t last_snapshot_creation_time = 0;
 
     // holds the block before last snapshoted block with hash
-    int64_t one_before_last_snapshoted_block_with_hash = -1;
+    std::atomic< int64_t > one_before_last_snapshoted_block_with_hash = -1;
     std::atomic< int64_t > last_snapshoted_block_with_hash = -1;
 
     int64_t m_snapshotIntervalSec;

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -395,7 +395,8 @@ Json::Value Skale::skale_getSnapshotSignature( unsigned blockNumber ) {
          ( chainParams.getKeyShareName().empty() || chainParams.getSgxServerUrl().empty() ) )
         throw jsonrpc::JsonRpcException( "Snapshot signing is not enabled" );
 
-    if ( blockNumber != 0 && blockNumber != this->m_client.getOneBeforeLatestSnapshotBlockNumer() ) {
+    if ( blockNumber != 0 &&
+         blockNumber != this->m_client.getOneBeforeLatestSnapshotBlockNumer() ) {
         throw jsonrpc::JsonRpcException(
             "Invalid snapshot block number requested - it might be deleted." );
     }

--- a/libweb3jsonrpc/Skale.cpp
+++ b/libweb3jsonrpc/Skale.cpp
@@ -159,7 +159,7 @@ nlohmann::json Skale::impl_skale_getSnapshot( const nlohmann::json& joRequest, C
 
     // TODO check
     unsigned blockNumber = joRequest["blockNumber"].get< unsigned >();
-    if ( blockNumber != 0 && blockNumber != m_client.getLatestSnapshotBlockNumer() ) {
+    if ( blockNumber != 0 && blockNumber != m_client.getOneBeforeLatestSnapshotBlockNumer() ) {
         joResponse["error"] = "Invalid snapshot block number requested - it might be deleted.";
         return joResponse;
     }
@@ -353,26 +353,14 @@ std::string Skale::skale_getLatestBlockNumber() {
 }
 
 std::string Skale::skale_getLatestSnapshotBlockNumber() {
-    int64_t response = this->m_client.getLatestSnapshotBlockNumer();
+    int64_t response = this->m_client.getOneBeforeLatestSnapshotBlockNumer();
     return response > 0 ? std::to_string( response ) : "earliest";
 }
 
 std::string Skale::skale_getLatestSnapshotHash() {
-    int64_t latestSnapshotBlockNumber = this->m_client.getLatestSnapshotBlockNumer();
-    if ( latestSnapshotBlockNumber <= 0 ) {
-        throw jsonrpc::JsonRpcException( "Latest snapshot is not available" );
-    }
-
-    if ( static_cast< uint64_t >( latestSnapshotBlockNumber ) >
-         std::numeric_limits< unsigned >::max() ) {
-        throw jsonrpc::JsonRpcException( "Latest snapshot block number exceeds supported range" );
-    }
-
-    unsigned snapshotBlockNumber = static_cast< unsigned >( latestSnapshotBlockNumber );
-
-    dev::h256 snapshotHash = this->m_client.getSnapshotHash( snapshotBlockNumber );
+    dev::h256 snapshotHash = this->m_client.getLatestSnapshotHash();
     if ( !snapshotHash ) {
-        throw jsonrpc::JsonRpcException( "Latest snapshot hash is not available yet" );
+        throw jsonrpc::JsonRpcException( "There isn't any snapshot hash available yet" );
     }
 
     return snapshotHash.hex();
@@ -407,7 +395,7 @@ Json::Value Skale::skale_getSnapshotSignature( unsigned blockNumber ) {
          ( chainParams.getKeyShareName().empty() || chainParams.getSgxServerUrl().empty() ) )
         throw jsonrpc::JsonRpcException( "Snapshot signing is not enabled" );
 
-    if ( blockNumber != 0 && blockNumber != this->m_client.getLatestSnapshotBlockNumer() ) {
+    if ( blockNumber != 0 && blockNumber != this->m_client.getOneBeforeLatestSnapshotBlockNumer() ) {
         throw jsonrpc::JsonRpcException(
             "Invalid snapshot block number requested - it might be deleted." );
     }

--- a/test/unittests/libethereum/ClientTest.cpp
+++ b/test/unittests/libethereum/ClientTest.cpp
@@ -1493,7 +1493,7 @@ BOOST_AUTO_TEST_CASE( ClientSnapshotsTest, *boost::unit_test::disabled() ) {
     TestClientSnapshotsFixture fixture( c_skaleConfigString );
     ClientTest* testClient = asClientTest( fixture.ethereum() );
 
-    BOOST_REQUIRE( testClient->getLatestSnapshotBlockNumer() == -1 );
+    BOOST_REQUIRE( testClient->getOneBeforeLatestSnapshotBlockNumer() == -1 );
 
     BOOST_REQUIRE( testClient->getSnapshotHash( 0 ) != dev::h256() );
 
@@ -1501,7 +1501,7 @@ BOOST_AUTO_TEST_CASE( ClientSnapshotsTest, *boost::unit_test::disabled() ) {
     int64_t snapshotBlockNumber = -1;
     for ( int i = 0; i < 30; ++i ) {
         std::this_thread::sleep_for( 1000ms );
-        snapshotBlockNumber = testClient->getLatestSnapshotBlockNumer();
+        snapshotBlockNumber = testClient->getOneBeforeLatestSnapshotBlockNumer();
         if ( snapshotBlockNumber > 0 )
             break;
     }

--- a/test/unittests/libskale/HashSnapshot.cpp
+++ b/test/unittests/libskale/HashSnapshot.cpp
@@ -22,8 +22,10 @@
 #include <test/tools/libtesteth/TestOutputHelper.h>
 #include <boost/test/unit_test.hpp>
 
+#include <chrono>
 #include <iostream>
 #include <string>
+#include <thread>
 
 #include "../libweb3jsonrpc/WebThreeStubClient.h"
 
@@ -324,7 +326,10 @@ struct FixtureCommon {
 
 // TODO Do not copy&paste from JsonRpcFixture
 struct SnapshotHashingFixture : public TestOutputHelperFixture, public FixtureCommon {
-    SnapshotHashingFixture() {
+    // _snapshotIntervalSec <= 0 (the default) disables SnapshotAgent's automatic
+    // snapshot/hash-computation cycle, matching the behavior relied on by tests that drive
+    // SnapshotManager manually via `mgr`.
+    explicit SnapshotHashingFixture( int64_t _snapshotIntervalSec = -1 ) {
         check_sudo();
         cleanupBtrfsArtifacts();
 
@@ -366,6 +371,7 @@ struct SnapshotHashingFixture : public TestOutputHelperFixture, public FixtureCo
         chainParams->extraData = h256::random().asBytes();
 
         chainParams->sChain.emptyBlockIntervalMs = 1000;
+        chainParams->sChain.snapshotIntervalSec = _snapshotIntervalSec;
 
         //        web3.reset( new WebThreeDirect(
         //            "eth tests", tempDir.path(), "", chainParams, WithExisting::Kill, {"eth"},
@@ -415,8 +421,11 @@ struct SnapshotHashingFixture : public TestOutputHelperFixture, public FixtureCo
         auto monitor = make_shared< InstanceMonitor >( "test" );
 
         setenv( "DATA_DIR", BTRFS_DIR_PATH.c_str(), 1 );
+        // Client's internal SnapshotAgent needs a real SnapshotManager whenever
+        // snapshotIntervalSec > 0 (its automatic snapshot/hash cycle is enabled and will
+        // dereference it); reuse the same `mgr` the test uses for manual snapshot calls.
         client.reset( new eth::ClientTest( chainParams, ( int ) chainParams->getNetworkId(),
-            shared_ptr< GasPricer >(), NULL, monitor, boost::filesystem::path( BTRFS_DIR_PATH ),
+            shared_ptr< GasPricer >(), mgr, monitor, boost::filesystem::path( BTRFS_DIR_PATH ),
             WithExisting::Kill ) );
 
         // wait for 1st block to prevent race conditions in UnsafeRegion
@@ -505,7 +514,7 @@ struct SnapshotHashingFixture : public TestOutputHelperFixture, public FixtureCo
     unique_ptr< WebThreeStubClient > rpcClient;
     TestIpcClient* testIpcClient;
     std::string adminSession;
-    unique_ptr< SnapshotManager > mgr;
+    shared_ptr< SnapshotManager > mgr;
 };
 }  // namespace
 
@@ -606,7 +615,7 @@ BOOST_FIXTURE_TEST_CASE( SnapshotHashingTest, SnapshotHashingFixture,
     t["to"] = toJS( receiver.address() );
     t["value"] = jsToDecimal( toJS( 10000 * dev::eth::szabo ) );
 
-    BOOST_REQUIRE( client->getLatestSnapshotBlockNumer() == -1 );
+    BOOST_REQUIRE( client->getOneBeforeLatestSnapshotBlockNumer() == -1 );
 
     // Mine to generate a non-zero account balance
     const int blocksToMine = 1;
@@ -666,6 +675,47 @@ BOOST_FIXTURE_TEST_CASE( SnapshotHashingTest, SnapshotHashingFixture,
     uint64_t timestampFromBlockchain = client->blockInfo( hash ).timestamp();
 
     BOOST_REQUIRE_EQUAL( timestampFromBlockchain, mgr->getBlockTimestamp( 3 ) );
+}
+
+BOOST_AUTO_TEST_CASE( SnapshotOneBeforeTracksPreviousLatest,
+    *boost::unit_test::precondition( dev::test::run_not_express ) ) {
+    SnapshotHashingFixture fixture( 1 );  // snapshotIntervalSec = 1s
+
+    int64_t lastObservedLatest = -1;
+    int distinctLatestTransitions = 0;
+
+    for ( int i = 0; i < 300 && distinctLatestTransitions < 3; ++i ) {
+        std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
+
+        int64_t latest = fixture.client->getLatestSnapshotBlockNumer();
+        int64_t oneBefore = fixture.client->getOneBeforeLatestSnapshotBlockNumer();
+
+        BOOST_REQUIRE_MESSAGE( oneBefore <= latest,
+            "one-before-latest snapshot (" << oneBefore << ") got ahead of latest (" << latest
+                                            << ")" );
+
+        if ( latest != lastObservedLatest ) {
+            if ( lastObservedLatest >= 0 ) {
+                // Give the one-before pointer a chance to catch up to what "latest" used to be,
+                // in case this exact sample raced it.
+                bool convergedToPrevious = ( oneBefore == lastObservedLatest );
+                for ( int j = 0; j < 50 && !convergedToPrevious; ++j ) {
+                    std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
+                    convergedToPrevious = ( fixture.client->getOneBeforeLatestSnapshotBlockNumer() ==
+                                             lastObservedLatest );
+                }
+                BOOST_REQUIRE_MESSAGE( convergedToPrevious,
+                    "one-before-latest snapshot never converged to the previous latest snapshot ("
+                        << lastObservedLatest << ")" );
+            }
+            lastObservedLatest = latest;
+            ++distinctLatestTransitions;
+        }
+    }
+
+    BOOST_REQUIRE_MESSAGE( distinctLatestTransitions >= 3,
+        "could not observe enough distinct latest-snapshot transitions to validate the "
+        "one-before invariant" );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -19,6 +19,8 @@
 
 #pragma GCC diagnostic ignored "-Wdeprecated"
 
+#include <algorithm>
+#include <fstream>
 #include <limits>
 #include <sys/types.h>
 #include <unistd.h>
@@ -826,6 +828,67 @@ struct JsonRpcBtrfsFixture : public BtrfsSetupForRpc, public JsonRpcFixture {
           JsonRpcFixture( _config, true, true, false, false, false, -1, {}, btrfsMountPath ) {}
 };
 
+// Builds a genesis config with snapshotting enabled, tuned to produce snapshots quickly enough
+// for tests.
+std::string makeSnapshotTestConfig(
+    int64_t _snapshotIntervalSec = 1, int64_t _emptyBlockIntervalMs = 2000 ) {
+    Json::Value ret;
+    Json::Reader().parse( c_genesisConfigString, ret );
+    ret["skaleConfig"]["sChain"]["snapshotIntervalSec"] = _snapshotIntervalSec;
+    ret["skaleConfig"]["sChain"]["emptyBlockIntervalMs"] = _emptyBlockIntervalMs;
+
+    Json::FastWriter fastWriter;
+    return fastWriter.write( ret );
+}
+
+// Polls for a consensus-committed block that triggers a snapshot at block > 0.
+// Returns the observed block number, or -1 if none was observed within the timeout.
+int64_t waitForOneBeforeLatestSnapshot( JsonRpcFixture& _fixture, int _maxIterations = 30,
+    std::chrono::milliseconds _sleep = std::chrono::milliseconds( 200 ) ) {
+    int64_t snapshotBlockNumber = -1;
+    for ( int i = 0; i < _maxIterations; ++i ) {
+        std::this_thread::sleep_for( _sleep );
+        snapshotBlockNumber = _fixture.client->getOneBeforeLatestSnapshotBlockNumer();
+        if ( snapshotBlockNumber > 0 )
+            break;
+    }
+    return snapshotBlockNumber;
+}
+
+// Path to the hash file of a given snapshot inside _snapshotsDir.
+boost::filesystem::path snapshotHashFilePath(
+    const boost::filesystem::path& _snapshotsDir, unsigned _blockNumber ) {
+    return _snapshotsDir / std::to_string( _blockNumber ) / "snapshot_hash.txt";
+}
+
+// Snapshot numbers present on disk, newest first (snapshot 0 is excluded, as everywhere else).
+std::vector< unsigned > scanSnapshotsDesc( const boost::filesystem::path& _snapshotsDir ) {
+    std::vector< unsigned > numbers;
+    if ( boost::filesystem::exists( _snapshotsDir ) ) {
+        for ( const auto& entry : boost::filesystem::directory_iterator( _snapshotsDir ) ) {
+            if ( !boost::filesystem::is_directory( entry.path() ) )
+                continue;
+            const std::string dirName = entry.path().filename().string();
+            if ( dirName.empty() || dirName == "0" )
+                continue;
+            if ( !std::all_of( dirName.begin(), dirName.end(), ::isdigit ) )
+                continue;
+            numbers.push_back( std::stoul( dirName ) );
+        }
+    }
+    std::sort( numbers.rbegin(), numbers.rend() );
+    return numbers;
+}
+
+std::string readSnapshotHashFile( const boost::filesystem::path& _path ) {
+    std::ifstream file( _path.string() );
+    std::string hash;
+    std::getline( file, hash );
+    hash.erase( hash.find_last_not_of( " \n\r\t" ) + 1 );
+    std::transform( hash.begin(), hash.end(), hash.begin(), ::tolower );
+    return hash;
+}
+
 #ifndef FAIR
 struct RestrictedAddressFixture : public JsonRpcFixture {
     RestrictedAddressFixture(
@@ -994,25 +1057,11 @@ BOOST_AUTO_TEST_CASE( jsonrpc_stateAt ) {
 BOOST_AUTO_TEST_CASE( skale_getLatestSnapshotHash_success,
     *boost::unit_test::precondition( dev::test::option_all_tests ) *
         boost::unit_test::label( "btrfs" ) ) {
-    Json::Value ret;
-    Json::Reader().parse( c_genesisConfigString, ret );
-    ret["skaleConfig"]["sChain"]["snapshotIntervalSec"] = 1;
-    ret["skaleConfig"]["sChain"]["emptyBlockIntervalMs"] = 2000;
+    JsonRpcBtrfsFixture fixture( makeSnapshotTestConfig() );
 
-    Json::FastWriter fastWriter;
-    std::string config = fastWriter.write( ret );
-    JsonRpcBtrfsFixture fixture( config );
-
-    // Poll for a consensus-committed block that triggers a snapshot at block > 0.
     // emptyBlockIntervalMs=2000 produces blocks slowly enough to avoid the
     // blockPromise callback race during fixture construction.
-    int64_t snapshotBlockNumber = -1;
-    for ( int i = 0; i < 30; ++i ) {
-        std::this_thread::sleep_for( std::chrono::milliseconds( 200 ) );
-        snapshotBlockNumber = fixture.client->getLatestSnapshotBlockNumer();
-        if ( snapshotBlockNumber > 0 )
-            break;
-    }
+    int64_t snapshotBlockNumber = waitForOneBeforeLatestSnapshot( fixture );
     BOOST_REQUIRE_GT( snapshotBlockNumber, 0 );
 
     std::string hash = fixture.rpcClient->skale_getLatestSnapshotHash();
@@ -1024,37 +1073,23 @@ BOOST_AUTO_TEST_CASE( skale_getLatestSnapshotHash_success,
 BOOST_AUTO_TEST_CASE( skale_getLatestSnapshotHash_hashNotAvailableYet,
     *boost::unit_test::precondition( dev::test::option_all_tests ) *
         boost::unit_test::label( "btrfs" ) ) {
-    Json::Value ret;
-    Json::Reader().parse( c_genesisConfigString, ret );
-    ret["skaleConfig"]["sChain"]["snapshotIntervalSec"] = 1;
-    ret["skaleConfig"]["sChain"]["emptyBlockIntervalMs"] = 2000;
+    JsonRpcBtrfsFixture fixture( makeSnapshotTestConfig() );
 
-    Json::FastWriter fastWriter;
-    std::string config = fastWriter.write( ret );
-    JsonRpcBtrfsFixture fixture( config );
-
-    // Poll for a consensus-committed block that triggers a snapshot at block > 0.
     // emptyBlockIntervalMs=2000 produces blocks slowly enough to avoid the
     // blockPromise callback race during fixture construction.
-    int64_t snapshotBlockNumber = -1;
-    for ( int i = 0; i < 30; ++i ) {
-        std::this_thread::sleep_for( std::chrono::milliseconds( 200 ) );
-        snapshotBlockNumber = fixture.client->getLatestSnapshotBlockNumer();
-        if ( snapshotBlockNumber > 0 )
-            break;
-    }
+    int64_t snapshotBlockNumber = waitForOneBeforeLatestSnapshot( fixture );
     BOOST_REQUIRE_GT( snapshotBlockNumber, 0 );
 
     // remove only hash file to simulate snapshot present but hash unavailable
-    boost::filesystem::path snapshotHashPath =
-        boost::filesystem::path( fixture.btrfsMountPath ) / "snapshots" /
-        std::to_string( snapshotBlockNumber ) / "snapshot_hash.txt";
+    boost::filesystem::path snapshotHashPath = snapshotHashFilePath(
+        boost::filesystem::path( fixture.btrfsMountPath ) / "snapshots",
+        static_cast< unsigned >( snapshotBlockNumber ) );
     BOOST_REQUIRE( boost::filesystem::exists( snapshotHashPath ) );
     BOOST_REQUIRE( boost::filesystem::remove( snapshotHashPath ) );
 
     BOOST_CHECK_EXCEPTION( fixture.rpcClient->skale_getLatestSnapshotHash(),
         jsonrpc::JsonRpcException, []( const jsonrpc::JsonRpcException& ex ) {
-            return std::string( ex.what() ).find( "Latest snapshot hash is not available yet" ) !=
+            return std::string( ex.what() ).find( "There isn't any snapshot hash available yet" ) !=
                    std::string::npos;
         } );
 }
@@ -1075,9 +1110,66 @@ BOOST_AUTO_TEST_CASE( skale_getLatestSnapshotHash_unavailable ) {
 
     BOOST_CHECK_EXCEPTION( fixture.rpcClient->skale_getLatestSnapshotHash(),
         jsonrpc::JsonRpcException, []( const jsonrpc::JsonRpcException& ex ) {
-            return std::string( ex.what() ).find( "Latest snapshot is not available" ) !=
+            return std::string( ex.what() ).find( "There isn't any snapshot hash available yet" ) !=
                    std::string::npos;
         } );
+}
+
+BOOST_AUTO_TEST_CASE( skale_getLatestSnapshotHash_tracksPhysicalNewest,
+    *boost::unit_test::precondition( dev::test::option_all_tests ) *
+        boost::unit_test::label( "btrfs" ) ) {
+    JsonRpcBtrfsFixture fixture( makeSnapshotTestConfig() );
+
+    boost::filesystem::path snapshotsDir =
+        boost::filesystem::path( fixture.btrfsMountPath ) / "snapshots";
+
+    // Verify skale_getLatestSnapshotHash() always returns the hash of the physically newest
+    // snapshot on disk, once that snapshot's hash has finished computing. Sampled across at
+    // least two distinct "newest" snapshots, to prove it keeps tracking new snapshots as they
+    // land rather than merely matching once by coincidence (or lagging behind by one, as it
+    // used to before last_snapshoted_block_with_hash was introduced).
+    unsigned lastObservedNewest = 0;
+    int distinctObservations = 0;
+
+    for ( int i = 0; i < 200 && distinctObservations < 2; ++i ) {
+        std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
+
+        const std::vector< unsigned > diskBefore = scanSnapshotsDesc( snapshotsDir );
+        if ( diskBefore.empty() )
+            continue;
+
+        const unsigned newestDisk = diskBefore[0];
+        // Only interesting once the newest snapshot's hash computation has completed.
+        if ( !boost::filesystem::exists( snapshotHashFilePath( snapshotsDir, newestDisk ) ) )
+            continue;
+
+        const std::string newestDiskHash =
+            readSnapshotHashFile( snapshotHashFilePath( snapshotsDir, newestDisk ) );
+        if ( newestDiskHash.empty() )
+            continue;
+
+        std::string hashViaApi = fixture.rpcClient->skale_getLatestSnapshotHash();
+        std::transform( hashViaApi.begin(), hashViaApi.end(), hashViaApi.begin(), ::tolower );
+
+        const std::vector< unsigned > diskAfter = scanSnapshotsDesc( snapshotsDir );
+        if ( diskAfter.empty() || diskAfter[0] != newestDisk )
+            continue;  // a newer snapshot landed mid-sample - values may be inconsistent, retry
+
+        BOOST_CHECK_MESSAGE( hashViaApi == newestDiskHash,
+            "skale_getLatestSnapshotHash() returned " << hashViaApi
+                                                       << " but the physically newest snapshot ("
+                                                       << newestDisk << ") has hash "
+                                                       << newestDiskHash );
+
+        if ( newestDisk != lastObservedNewest ) {
+            lastObservedNewest = newestDisk;
+            ++distinctObservations;
+        }
+    }
+
+    BOOST_REQUIRE_MESSAGE( distinctObservations >= 2,
+        "could not observe skale_getLatestSnapshotHash() tracking at least two distinct "
+        "physically-newest snapshots" );
 }
 
 BOOST_AUTO_TEST_CASE(


### PR DESCRIPTION
### Summary

Fixes a naming and semantics mismatch in snapshot accessors that could expose a snapshot whose hash was still being computed.

### Problem

The existing snapshot accessor was effectively treated as returning the **latest snapshot**, while it actually returned the snapshot immediately preceding it (`one_before_last_snapshoted_block_with_hash`).

This distinction matters because the latest snapshot hash may still be computed asynchronously. The previous snapshot is the latest one guaranteed to have a fully computed hash.

### Changes

* Renamed the existing accessor to `Client::getOneBeforeLatestSnapshotBlockNumer()` to make its semantics explicit.
* Added `Client::getLatestSnapshotBlockNumer()` and corresponding `SnapshotAgent` support for retrieving the actual latest snapshot block.
* Made `last_snapshoted_block_with_hash` an `std::atomic<int64_t>` so it can be safely read while the snapshot hash computation thread updates it.
* Updated `skale_getLatestSnapshotHash()` and related snapshot RPC handling to use the appropriate latest/one-before-latest accessors, ensuring that only fully computed snapshot hashes are returned.
* Added tests covering both the RPC behavior and the snapshot bookkeeping invariants.

### Testing

Added coverage verifying that:

* `skale_getLatestSnapshotHash()` does not return the hash of a snapshot whose hash is still being computed.
* The one-before-latest snapshot block correctly tracks the snapshot immediately preceding the current latest snapshot.

This change only affects snapshot bookkeeping and related RPC behavior; it does not affect block execution, consensus, or state-root computation.

Fixes #2327 