### PR TITLE
#2530 set broadcastEnabled true as default for all node types

### DIFF
--- a/skaled/main.cpp
+++ b/skaled/main.cpp
@@ -1973,12 +1973,13 @@ int main( int argc, char** argv ) {
             DefaultConsensusFactory cons_fact( *g_client );
             setenv( "DATA_DIR", getDataDir().c_str(), 0 );
 
+            const bool broadcastEnabled = true;
             std::shared_ptr< SkaleHost > skaleHost =
                 std::make_shared< SkaleHost >( *g_client, &cons_fact, instanceMonitor,
 #ifndef FAIR
                     skutils::json_config_file_accessor::g_strImaMainNetURL,
 #endif
-                    !chainParams->isSyncNode() );
+                    broadcastEnabled );
             dev::eth::g_skaleHost = skaleHost;
 
             // XXX nested lambdas and strlen hacks..


### PR DESCRIPTION
## Description

- As part of London fork's changes, broadcast behavior of sync nodes was changed, changing the node behavior compared to 5.2.0 (https://github.com/skalenetwork/skaled/commit/a8bc9249e09007aa556340fe8dcf100eacf6e1d2)
- The commit above added some tx broadcast logic over a bool broadcast field that was previously unused.
- To preserve the same behavior as in `5.2.0`, this field was set to true for all nodes. Meaning all node types, upon receiving a tx will broadcast it to other nodes.

## Tests

- Tested locally running 1 core + 1 sync node, sending 1 tx to sync node:
  - before: tx never got included in any block
  - after: tx got broadcasted to core node & mined

Fixes #2530 